### PR TITLE
Update issue templates to reference M4 instead of M3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
 name: "🐛 Bug Report"
-description: Create a new ticket for a bug in M3.
+description: Create a new ticket for a bug in M4.
 title: "🐛 [BUG] - <title>"
 labels:
   - "bug"
@@ -10,7 +10,7 @@ body:
         <p align="center">
           <img src="https://miro.medium.com/v2/resize:fit:400/1*QEps725rQjfgqNnlbRYb1g.png" alt="Harvard MIT HST Logo">
           <br>
-          <em><a href="https://doi.org/10.48550/arXiv.2507.01053">M3's Paper</a>—<a href="https://rafiattrach.github.io/m3/">M3's Website</a>.</em>
+          <em><a href="https://doi.org/10.48550/arXiv.2507.01053">M3's Paper</a>—<a href="https://hannesill.github.io/m4/">M4's Website</a>.</em>
         </p>
   - type: checkboxes
     id: checks
@@ -32,7 +32,7 @@ body:
     id: reprod-url
     attributes:
       label: "Reproduction URL"
-      description: "If you’ve forked M3, provide a GitHub URL or repository link to reproduce the issue."
+      description: "If you've forked M4, provide a GitHub URL or repository link to reproduce the issue."
       placeholder: "Hint: Optional, but it helps us resolve the issue faster. Leave empty if not applicable."
     validations:
       required: false
@@ -119,10 +119,10 @@ body:
     validations:
       required: true
   - type: input
-    id: m3-version
+    id: m4-version
     attributes:
-      label: "M3 Version"
-      description: What version of M3 are you using? Run 'm3 --version' to check.
+      label: "M4 Version"
+      description: What version of M4 are you using? Run 'm4 --version' to check.
       placeholder: "e.g., 0.1.0"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,5 +1,5 @@
 name: "💡 Feature Request"
-description: Suggest a new feature or enhancement for M3.
+description: Suggest a new feature or enhancement for M4.
 title: "💡 [FEAT] - <title>"
 labels:
   - "feature"
@@ -10,7 +10,7 @@ body:
         <p align="center">
           <img src="https://miro.medium.com/v2/resize:fit:400/1*QEps725rQjfgqNnlbRYb1g.png" alt="Harvard MIT HST Logo">
           <br>
-          <em><a href="https://doi.org/10.48550/arXiv.2507.01053">M3's Paper</a>—<a href="https://rafiattrach.github.io/m3/">M3's Website</a>.</em>
+          <em><a href="https://doi.org/10.48550/arXiv.2507.01053">M3's Paper</a>—<a href="https://hannesill.github.io/m4/">M4's Website</a>.</em>
         </p>
   - type: checkboxes
     id: checks
@@ -56,7 +56,7 @@ body:
     id: roadmap-alignment
     attributes:
       label: "Roadmap Alignment"
-      description: Which part of the M3 roadmap does this feature align with?
+      description: Which part of the M4 roadmap does this feature align with?
       options:
         - "Broader Dataset Coverage"
         - "Richer MCP Tooling"
@@ -68,7 +68,7 @@ body:
     attributes:
       label: "Other Roadmap Alignment"
       description: "Only fill this if you selected 'Other' in the Roadmap Alignment dropdown."
-      placeholder: "Describe how this feature aligns with M3's goals."
+      placeholder: "Describe how this feature aligns with M4's goals."
     validations:
       required: false
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,5 +1,5 @@
 name: "❓ Ask a Question"
-description: Ask a question about M3.
+description: Ask a question about M4.
 title: "❓ [QUESTION] - <title>"
 labels:
   - "question"
@@ -10,7 +10,7 @@ body:
         <p align="center">
           <img src="https://miro.medium.com/v2/resize:fit:400/1*QEps725rQjfgqNnlbRYb1g.png" alt="Harvard MIT HST Logo">
           <br>
-          <em><a href="https://doi.org/10.48550/arXiv.2507.01053">M3's Paper</a>—<a href="https://rafiattrach.github.io/m3/">M3's Website</a>.</em>
+          <em><a href="https://doi.org/10.48550/arXiv.2507.01053">M3's Paper</a>—<a href="https://hannesill.github.io/m4/">M4's Website</a>.</em>
         </p>
   - type: checkboxes
     id: checks
@@ -40,7 +40,7 @@ body:
     id: project-area
     attributes:
       label: "Project Area"
-      description: Specify the area of M3 your question relates to.
+      description: Specify the area of M4 your question relates to.
       placeholder: "Hint: Optional, e.g., CLI, MCP Server, OAuth2, etc."
     validations:
       required: false


### PR DESCRIPTION
Updates all issue templates (bug report, feature request, question) to reference M4 instead of M3.

**Changes:**
- Updated descriptions and labels from M3 to M4
- Changed website URL to `https://hannesill.github.io/m4/`
- Updated version field from `m3-version` to `m4-version`
- Kept "M3's Paper" reference 