### PR TITLE
chore: duckdb refs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -75,7 +75,7 @@ body:
       label: "Backend"
       description: Which backend were you using when the bug occurred?
       options:
-        - "SQLite"
+        - "DuckDB"
         - "BigQuery"
         - "Other"
   - type: input

--- a/.gitignore
+++ b/.gitignore
@@ -57,10 +57,14 @@ junit.xml
 *.tmp
 *.swp
 
-# SQLite databases (if you don't want to commit local test/demo dbs)
+# Local database files
 *.db
 *.db-journal*
 mimic*.db
+*.duckdb
+*.duckdb.wal
+*.duckdb.tmp
+mimic*.duckdb
 
 # Configuration files
 config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY src ./src
 RUN pip install --no-cache-dir build && \
     python -m build --wheel
 
-# Base runtime: install m4 and baked SQLite DB
+# Base runtime: install m4 and baked DuckDB DB
 FROM python:3.11-slim AS base
 
 ENV PYTHONUNBUFFERED=1 \
@@ -25,7 +25,7 @@ RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
 # Download and initialize demo DB using m4 init
 RUN m4 init mimic-iv-demo
 
-# Lite: SQLite only
+# Lite: local DuckDB only
 FROM base AS lite
 CMD ["python", "-m", "m4.mcp_server"]
 


### PR DESCRIPTION
## Summary
- Update M4 references from SQLite → DuckDB (issue template + Dockerfile comments)
- Ignore local DuckDB database files in `.gitignore`

## Test plan
- [ ] `pre-commit run --all-files`