### PR TITLE
Add tool call telemetry for MCP server and Python API

### DIFF
--- a/src/m4/__init__.py
+++ b/src/m4/__init__.py
@@ -35,6 +35,7 @@ from m4.api import (
     search_notes,
     set_dataset,
 )
+from m4.core.telemetry import set_agent_id
 
 __all__ = [
     "DatasetError",
@@ -50,5 +51,6 @@ __all__ = [
     "list_datasets",
     "list_patient_notes",
     "search_notes",
+    "set_agent_id",
     "set_dataset",
 ]

--- a/src/m4/__init__.py
+++ b/src/m4/__init__.py
@@ -30,6 +30,8 @@ from m4.api import (
     get_note,
     get_schema,
     get_table_info,
+    # Telemetry
+    get_telemetry_path,
     list_datasets,
     list_patient_notes,
     search_notes,
@@ -48,6 +50,7 @@ __all__ = [
     "get_note",
     "get_schema",
     "get_table_info",
+    "get_telemetry_path",
     "list_datasets",
     "list_patient_notes",
     "search_notes",

--- a/src/m4/api.py
+++ b/src/m4/api.py
@@ -26,6 +26,7 @@ that work on both DuckDB and BigQuery backends. Use set_dataset()
 to switch between datasets.
 """
 
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -65,6 +66,7 @@ __all__ = [
     "get_note",
     "get_schema",
     "get_table_info",
+    "get_telemetry_path",
     "list_datasets",
     "list_patient_notes",
     "search_notes",
@@ -350,3 +352,25 @@ def list_patient_notes(
             limit=limit,
         ),
     )
+
+
+# =============================================================================
+# Telemetry
+# =============================================================================
+
+
+def get_telemetry_path() -> Path:
+    """Return the path to the telemetry JSONL file.
+
+    This file contains one JSON record per line, with each record
+    representing a tool invocation (see ToolCallRecord for schema).
+    External systems can read this file to build provenance trails.
+
+    Returns:
+        Path to the tool_calls.jsonl file (may not exist if no
+        calls have been made yet, or if M4_TELEMETRY=off).
+    """
+    from m4.config import get_telemetry_dir
+    from m4.core.telemetry import TELEMETRY_FILENAME
+
+    return get_telemetry_dir() / TELEMETRY_FILENAME

--- a/src/m4/api.py
+++ b/src/m4/api.py
@@ -34,6 +34,7 @@ from m4.config import get_active_dataset as _get_active_dataset
 from m4.config import set_active_dataset as _set_active_dataset
 from m4.core.datasets import DatasetRegistry
 from m4.core.exceptions import DatasetError, M4Error, ModalityError, QueryError
+from m4.core.telemetry import invoke_tracked, set_interface
 from m4.core.tools import ToolRegistry, ToolSelector, init_tools
 from m4.core.tools.notes import (
     GetNoteInput,
@@ -48,6 +49,7 @@ from m4.core.tools.tabular import (
 
 # Initialize tools on module import
 init_tools()
+set_interface("python_api")
 
 # Tool selector for compatibility checking
 _tool_selector = ToolSelector()
@@ -152,7 +154,7 @@ def get_schema() -> dict[str, Any]:
     """
     dataset = DatasetRegistry.get_active()
     tool = ToolRegistry.get("get_database_schema")
-    return tool.invoke(dataset, GetDatabaseSchemaInput())
+    return invoke_tracked(tool, dataset, GetDatabaseSchemaInput())
 
 
 def get_table_info(table_name: str, show_sample: bool = True) -> dict[str, Any]:
@@ -179,8 +181,8 @@ def get_table_info(table_name: str, show_sample: bool = True) -> dict[str, Any]:
     """
     dataset = DatasetRegistry.get_active()
     tool = ToolRegistry.get("get_table_info")
-    return tool.invoke(
-        dataset, GetTableInfoInput(table_name=table_name, show_sample=show_sample)
+    return invoke_tracked(
+        tool, dataset, GetTableInfoInput(table_name=table_name, show_sample=show_sample)
     )
 
 
@@ -206,7 +208,7 @@ def execute_query(sql: str) -> pd.DataFrame:
     """
     dataset = DatasetRegistry.get_active()
     tool = ToolRegistry.get("execute_query")
-    return tool.invoke(dataset, ExecuteQueryInput(sql_query=sql))
+    return invoke_tracked(tool, dataset, ExecuteQueryInput(sql_query=sql))
 
 
 # =============================================================================
@@ -261,7 +263,8 @@ def search_notes(
 
     dataset = DatasetRegistry.get_active()
     tool = ToolRegistry.get("search_notes")
-    return tool.invoke(
+    return invoke_tracked(
+        tool,
         dataset,
         SearchNotesInput(
             query=query,
@@ -300,7 +303,8 @@ def get_note(note_id: str, max_length: int | None = None) -> dict[str, Any]:
 
     dataset = DatasetRegistry.get_active()
     tool = ToolRegistry.get("get_note")
-    return tool.invoke(
+    return invoke_tracked(
+        tool,
         dataset,
         GetNoteInput(note_id=note_id, max_length=max_length),
     )
@@ -337,7 +341,8 @@ def list_patient_notes(
 
     dataset = DatasetRegistry.get_active()
     tool = ToolRegistry.get("list_patient_notes")
-    return tool.invoke(
+    return invoke_tracked(
+        tool,
         dataset,
         ListPatientNotesInput(
             subject_id=subject_id,

--- a/src/m4/config.py
+++ b/src/m4/config.py
@@ -329,6 +329,13 @@ def set_bigquery_project_id(project_id: str | None) -> None:
     save_runtime_config(cfg)
 
 
+def get_telemetry_dir() -> Path:
+    """Return the telemetry directory, creating it if needed."""
+    path = _PROJECT_DATA_DIR / "telemetry"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
 def get_duckdb_path_for(choice: str) -> Path | None:
     return get_default_database_path(choice)
 

--- a/src/m4/core/telemetry.py
+++ b/src/m4/core/telemetry.py
@@ -24,6 +24,8 @@ from m4.core.tools.base import Tool, ToolInput
 
 logger = logging.getLogger("m4.telemetry")
 
+TELEMETRY_FILENAME = "tool_calls.jsonl"
+
 # ---------------------------------------------------------------------------
 # Context variables — set by MCP server / Python API / external agents
 # ---------------------------------------------------------------------------
@@ -42,6 +44,19 @@ def set_agent_id(agent_id: str) -> None:
     _agent_id_var.set(agent_id)
 
 
+def _get_terminal_session() -> str | None:
+    """Return the POSIX session ID of the current process.
+
+    All processes spawned from the same terminal share this ID, making it
+    a natural correlation key for grouping tool calls by research session.
+    Returns None on platforms where os.getsid is unavailable (Windows).
+    """
+    try:
+        return str(os.getsid(0))
+    except (AttributeError, OSError):
+        return None
+
+
 # ---------------------------------------------------------------------------
 # ToolCallRecord
 # ---------------------------------------------------------------------------
@@ -49,9 +64,44 @@ def set_agent_id(agent_id: str) -> None:
 
 @dataclass
 class ToolCallRecord:
+    """A single tool invocation record, written as one JSON line to telemetry.
+
+    This schema is consumed by external systems (notably DOJO for provenance
+    tracking). Fields should be added but not removed or renamed without a
+    version bump.
+
+    Schema version: 2
+    (Version 1: original fields through params_summary.
+     Version 2: added terminal_session, row_count.)
+
+    Fields:
+        tool_name: Tool identifier (e.g., 'execute_query', 'search_notes')
+        interface: How the tool was called ('mcp', 'python_api', 'unknown')
+        agent_id: Caller identifier, set via set_agent_id(). None if not set.
+        terminal_session: POSIX session ID (os.getsid(0)), automatically
+            captured. Groups tool calls by terminal session — all processes
+            spawned from the same terminal share this value. None on
+            platforms without os.getsid (Windows).
+        dataset_name: Active dataset at call time (e.g., 'mimic-iv')
+        timestamp: ISO 8601 UTC timestamp of call start
+        duration_ms: Wall-clock time in milliseconds
+        success: True if tool returned without exception
+        error_type: Exception class name on failure, None on success
+        error_message: Exception message on failure, None on success
+        params_summary: Dict of input parameters (from dataclasses.asdict).
+            For execute_query this includes 'sql_query'.
+        row_count: Number of rows for direct DataFrame results (execute_query).
+            None for all other result types.
+
+    Consumers should tolerate missing fields (pre-v2 records lack
+    terminal_session, row_count) and unknown fields (future versions
+    may add more).
+    """
+
     tool_name: str
     interface: str
     agent_id: str | None
+    terminal_session: str | None
     dataset_name: str | None
     timestamp: str  # ISO 8601
     duration_ms: float
@@ -59,6 +109,7 @@ class ToolCallRecord:
     error_type: str | None
     error_message: str | None
     params_summary: dict[str, Any]
+    row_count: int | None
 
 
 # ---------------------------------------------------------------------------
@@ -100,7 +151,7 @@ class TelemetryWriter:
 
         telemetry_dir = get_telemetry_dir()
         self._handler = RotatingFileHandler(
-            telemetry_dir / "tool_calls.jsonl",
+            telemetry_dir / TELEMETRY_FILENAME,
             maxBytes=10 * 1024 * 1024,  # 10 MB
             backupCount=3,
         )
@@ -145,6 +196,7 @@ def invoke_tracked(tool: Tool, dataset: DatasetDefinition, params: ToolInput) ->
     """
     interface = _interface_var.get()
     agent_id = _agent_id_var.get()
+    terminal_session = _get_terminal_session()
     dataset_name = getattr(dataset, "name", None)
 
     # Build params summary
@@ -157,9 +209,13 @@ def invoke_tracked(tool: Tool, dataset: DatasetDefinition, params: ToolInput) ->
     success = True
     error_type = None
     error_message = None
+    row_count = None
 
     try:
         result = tool.invoke(dataset, params)
+        import pandas as pd
+
+        row_count = len(result) if isinstance(result, pd.DataFrame) else None
         return result
     except Exception as exc:
         success = False
@@ -173,6 +229,7 @@ def invoke_tracked(tool: Tool, dataset: DatasetDefinition, params: ToolInput) ->
             tool_name=tool.name,
             interface=interface,
             agent_id=agent_id,
+            terminal_session=terminal_session,
             dataset_name=dataset_name,
             timestamp=datetime.now(timezone.utc).isoformat(),
             duration_ms=duration_ms,
@@ -180,6 +237,7 @@ def invoke_tracked(tool: Tool, dataset: DatasetDefinition, params: ToolInput) ->
             error_type=error_type,
             error_message=error_message,
             params_summary=params_summary,
+            row_count=row_count,
         )
 
         record_json = _to_json(dataclasses.asdict(record))

--- a/src/m4/core/telemetry.py
+++ b/src/m4/core/telemetry.py
@@ -1,0 +1,188 @@
+"""Tool call telemetry for M4.
+
+Tracks every tool invocation regardless of interface (MCP server or Python API).
+Caller context (interface type, agent ID) flows via contextvars — no signature
+changes to Tool protocol or tool implementations.
+
+Records are written as JSONL to m4_data/telemetry/tool_calls.jsonl and logged
+via the standard logging module. Disable file output with M4_TELEMETRY=off.
+"""
+
+import dataclasses
+import json
+import logging
+import os
+import time
+from contextvars import ContextVar
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from logging.handlers import RotatingFileHandler
+from typing import Any
+
+from m4.core.datasets import DatasetDefinition
+from m4.core.tools.base import Tool, ToolInput
+
+logger = logging.getLogger("m4.telemetry")
+
+# ---------------------------------------------------------------------------
+# Context variables — set by MCP server / Python API / external agents
+# ---------------------------------------------------------------------------
+
+_interface_var: ContextVar[str] = ContextVar("m4_interface", default="unknown")
+_agent_id_var: ContextVar[str | None] = ContextVar("m4_agent_id", default=None)
+
+
+def set_interface(name: str) -> None:
+    """Set the current interface context (e.g. 'mcp', 'python_api')."""
+    _interface_var.set(name)
+
+
+def set_agent_id(agent_id: str) -> None:
+    """Set the current agent ID for telemetry attribution."""
+    _agent_id_var.set(agent_id)
+
+
+# ---------------------------------------------------------------------------
+# ToolCallRecord
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ToolCallRecord:
+    tool_name: str
+    interface: str
+    agent_id: str | None
+    dataset_name: str | None
+    timestamp: str  # ISO 8601
+    duration_ms: float
+    success: bool
+    error_type: str | None
+    error_message: str | None
+    params_summary: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# JSON encoder that gracefully handles non-serializable values
+# ---------------------------------------------------------------------------
+
+
+class _SafeEncoder(json.JSONEncoder):
+    def default(self, o: Any) -> Any:
+        return str(o)
+
+
+def _to_json(obj: Any) -> str:
+    return json.dumps(obj, cls=_SafeEncoder)
+
+
+# ---------------------------------------------------------------------------
+# TelemetryWriter — manages the JSONL file handler
+# ---------------------------------------------------------------------------
+
+
+class TelemetryWriter:
+    """Manages the rotating JSONL file handler for telemetry records.
+
+    Lazily initialised on first write. Respects M4_TELEMETRY=off.
+    """
+
+    def __init__(self) -> None:
+        self._handler: RotatingFileHandler | None = None
+        self._initialized = False
+
+    def _init_handler(self) -> None:
+        self._initialized = True
+
+        if os.environ.get("M4_TELEMETRY", "").lower() == "off":
+            return
+
+        from m4.config import get_telemetry_dir
+
+        telemetry_dir = get_telemetry_dir()
+        self._handler = RotatingFileHandler(
+            telemetry_dir / "tool_calls.jsonl",
+            maxBytes=10 * 1024 * 1024,  # 10 MB
+            backupCount=3,
+        )
+        self._handler.setFormatter(logging.Formatter("%(message)s"))
+
+    def emit(self, record_json: str) -> None:
+        if not self._initialized:
+            self._init_handler()
+        if self._handler is None:
+            return
+        log_record = logging.LogRecord(
+            name="m4.telemetry",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=record_json,
+            args=None,
+            exc_info=None,
+        )
+        self._handler.emit(log_record)
+
+    def reset(self) -> None:
+        """Reset state (for testing)."""
+        self._handler = None
+        self._initialized = False
+
+
+_writer = TelemetryWriter()
+
+
+# ---------------------------------------------------------------------------
+# invoke_tracked — the main wrapper
+# ---------------------------------------------------------------------------
+
+
+def invoke_tracked(tool: Tool, dataset: DatasetDefinition, params: ToolInput) -> Any:
+    """Invoke a tool with telemetry tracking.
+
+    Wraps tool.invoke() to record timing, success/failure, and context.
+    Records are written to JSONL and logged at INFO level.
+    On failure, the original exception is re-raised.
+    """
+    interface = _interface_var.get()
+    agent_id = _agent_id_var.get()
+    dataset_name = getattr(dataset, "name", None)
+
+    # Build params summary
+    try:
+        params_summary = dataclasses.asdict(params)
+    except (TypeError, AttributeError):
+        params_summary = {}
+
+    start = time.monotonic()
+    success = True
+    error_type = None
+    error_message = None
+
+    try:
+        result = tool.invoke(dataset, params)
+        return result
+    except Exception as exc:
+        success = False
+        error_type = type(exc).__name__
+        error_message = str(exc)
+        raise
+    finally:
+        duration_ms = round((time.monotonic() - start) * 1000, 2)
+
+        record = ToolCallRecord(
+            tool_name=tool.name,
+            interface=interface,
+            agent_id=agent_id,
+            dataset_name=dataset_name,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            duration_ms=duration_ms,
+            success=success,
+            error_type=error_type,
+            error_message=error_message,
+            params_summary=params_summary,
+        )
+
+        record_json = _to_json(dataclasses.asdict(record))
+
+        logger.info(record_json)
+        _writer.emit(record_json)

--- a/src/m4/mcp_server.py
+++ b/src/m4/mcp_server.py
@@ -35,6 +35,7 @@ from m4.auth import init_oauth2, require_oauth2
 from m4.core.datasets import DatasetRegistry
 from m4.core.exceptions import M4Error
 from m4.core.serialization import serialize_for_mcp
+from m4.core.telemetry import invoke_tracked, set_interface
 from m4.core.tools import ToolRegistry, ToolSelector, init_tools
 from m4.core.tools.management import ListDatasetsInput, SetDatasetInput
 from m4.core.tools.notes import (
@@ -55,6 +56,7 @@ mcp = FastMCP("m4")
 init_oauth2()
 init_tools()
 init_apps()
+set_interface("mcp")
 
 # Tool selector for capability-based filtering
 _tool_selector = ToolSelector()
@@ -279,7 +281,7 @@ def list_datasets() -> str:
     try:
         tool = ToolRegistry.get("list_datasets")
         dataset = DatasetRegistry.get_active()
-        result = tool.invoke(dataset, ListDatasetsInput())
+        result = invoke_tracked(tool, dataset, ListDatasetsInput())
         return _serialize_datasets_result(result)
     except M4Error as e:
         return f"**Error:** {e}"
@@ -301,7 +303,9 @@ def set_dataset(dataset_name: str) -> str:
 
         tool = ToolRegistry.get("set_dataset")
         dataset = DatasetRegistry.get_active()
-        result = tool.invoke(dataset, SetDatasetInput(dataset_name=dataset_name))
+        result = invoke_tracked(
+            tool, dataset, SetDatasetInput(dataset_name=dataset_name)
+        )
         output = _serialize_set_dataset_result(result)
 
         # Append supported tools snapshot if dataset is valid
@@ -336,7 +340,7 @@ def get_database_schema() -> str:
             return compat_result.error_message
 
         tool = ToolRegistry.get("get_database_schema")
-        result = tool.invoke(dataset, GetDatabaseSchemaInput())
+        result = invoke_tracked(tool, dataset, GetDatabaseSchemaInput())
         return _serialize_schema_result(result)
     except M4Error as e:
         return f"**Error:** {e}"
@@ -365,8 +369,10 @@ def get_table_info(table_name: str, show_sample: bool = True) -> str:
             return compat_result.error_message
 
         tool = ToolRegistry.get("get_table_info")
-        result = tool.invoke(
-            dataset, GetTableInfoInput(table_name=table_name, show_sample=show_sample)
+        result = invoke_tracked(
+            tool,
+            dataset,
+            GetTableInfoInput(table_name=table_name, show_sample=show_sample),
         )
         return _serialize_table_info_result(result)
     except M4Error as e:
@@ -398,7 +404,7 @@ def execute_query(sql_query: str) -> str:
             return compat_result.error_message
 
         tool = ToolRegistry.get("execute_query")
-        result = tool.invoke(dataset, ExecuteQueryInput(sql_query=sql_query))
+        result = invoke_tracked(tool, dataset, ExecuteQueryInput(sql_query=sql_query))
         # Result is a DataFrame - serialize it
         return serialize_for_mcp(result)
     except M4Error as e:
@@ -442,7 +448,8 @@ def search_notes(
             return compat_result.error_message
 
         tool = ToolRegistry.get("search_notes")
-        result = tool.invoke(
+        result = invoke_tracked(
+            tool,
             dataset,
             SearchNotesInput(
                 query=query,
@@ -480,7 +487,8 @@ def get_note(note_id: str, max_length: int | None = None) -> str:
             return compat_result.error_message
 
         tool = ToolRegistry.get("get_note")
-        result = tool.invoke(
+        result = invoke_tracked(
+            tool,
             dataset,
             GetNoteInput(note_id=note_id, max_length=max_length),
         )
@@ -522,7 +530,8 @@ def list_patient_notes(
             return compat_result.error_message
 
         tool = ToolRegistry.get("list_patient_notes")
-        result = tool.invoke(
+        result = invoke_tracked(
+            tool,
             dataset,
             ListPatientNotesInput(
                 subject_id=subject_id,
@@ -570,7 +579,7 @@ def cohort_builder() -> str:
             return compat_result.error_message
 
         tool = ToolRegistry.get("cohort_builder")
-        result = tool.invoke(dataset, CohortBuilderInput())
+        result = invoke_tracked(tool, dataset, CohortBuilderInput())
         return serialize_for_mcp(result)
     except M4Error as e:
         return f"**Error:** {e}"
@@ -614,7 +623,8 @@ def query_cohort(
             return json.dumps({"error": compat_result.error_message})
 
         tool = ToolRegistry.get("query_cohort")
-        result = tool.invoke(
+        result = invoke_tracked(
+            tool,
             dataset,
             QueryCohortInput(
                 age_min=age_min,

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -1,0 +1,177 @@
+"""Tests for tool call telemetry."""
+
+import json
+import os
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
+
+from m4.core.datasets import DatasetDefinition, Modality
+from m4.core.exceptions import M4Error
+from m4.core.telemetry import (
+    _agent_id_var,
+    _interface_var,
+    _writer,
+    invoke_tracked,
+    set_agent_id,
+    set_interface,
+)
+from m4.core.tools.base import ToolInput
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MockInput(ToolInput):
+    sql_query: str = "SELECT 1"
+    limit: int = 10
+
+
+class MockTool:
+    name = "mock_tool"
+    description = "A mock tool for testing"
+    input_model = MockInput
+    required_modalities = frozenset({Modality.TABULAR})
+    supported_datasets = None
+
+    def __init__(self, return_value="ok", side_effect=None):
+        self._return_value = return_value
+        self._side_effect = side_effect
+
+    def invoke(self, dataset, params):
+        if self._side_effect:
+            raise self._side_effect
+        return self._return_value
+
+    def is_compatible(self, dataset):
+        return True
+
+
+@pytest.fixture
+def mock_dataset():
+    return DatasetDefinition(
+        name="test-dataset",
+        description="Test dataset",
+        modalities=frozenset({Modality.TABULAR}),
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_telemetry_state():
+    """Reset telemetry writer and context vars between tests."""
+    _writer.reset()
+    token_iface = _interface_var.set("unknown")
+    token_agent = _agent_id_var.set(None)
+    yield
+    _writer.reset()
+    _interface_var.reset(token_iface)
+    _agent_id_var.reset(token_agent)
+
+
+def _capture_record(mock_dataset, tool=None, params=None):
+    """Helper: invoke a tool and return the parsed telemetry record."""
+    tool = tool or MockTool(return_value="ok")
+    params = params or MockInput()
+    with patch("m4.core.telemetry.logger") as mock_logger:
+        invoke_tracked(tool, mock_dataset, params)
+        return json.loads(mock_logger.info.call_args[0][0])
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeTracked:
+    def test_returns_tool_result(self, mock_dataset):
+        tool = MockTool(return_value={"data": [1, 2, 3]})
+        result = invoke_tracked(tool, mock_dataset, MockInput())
+        assert result == {"data": [1, 2, 3]}
+
+    def test_success_record(self, mock_dataset):
+        record = _capture_record(mock_dataset)
+
+        assert record["success"] is True
+        assert record["tool_name"] == "mock_tool"
+        assert record["dataset_name"] == "test-dataset"
+        assert record["error_type"] is None
+        assert record["error_message"] is None
+        assert record["duration_ms"] >= 0
+
+    def test_failure_record_reraises(self, mock_dataset):
+        tool = MockTool(side_effect=M4Error("something broke"))
+
+        with patch("m4.core.telemetry.logger") as mock_logger:
+            with pytest.raises(M4Error, match="something broke"):
+                invoke_tracked(tool, mock_dataset, MockInput())
+
+            record = json.loads(mock_logger.info.call_args[0][0])
+
+        assert record["success"] is False
+        assert record["error_type"] == "M4Error"
+        assert record["error_message"] == "something broke"
+
+    def test_context_vars_in_record(self, mock_dataset):
+        set_interface("mcp")
+        set_agent_id("agent-42")
+
+        record = _capture_record(mock_dataset)
+
+        assert record["interface"] == "mcp"
+        assert record["agent_id"] == "agent-42"
+
+    def test_params_captured(self, mock_dataset):
+        params = MockInput(sql_query="SELECT * FROM patients", limit=5)
+        record = _capture_record(mock_dataset, params=params)
+
+        assert record["params_summary"]["sql_query"] == "SELECT * FROM patients"
+        assert record["params_summary"]["limit"] == 5
+
+
+class TestJSONLFile:
+    def test_jsonl_written(self, mock_dataset, tmp_path):
+        """JSONL file is written with valid JSON per line."""
+        with patch("m4.config.get_telemetry_dir", return_value=tmp_path):
+            tool = MockTool(return_value="ok")
+            invoke_tracked(tool, mock_dataset, MockInput())
+            invoke_tracked(tool, mock_dataset, MockInput(sql_query="SELECT 2"))
+
+        jsonl_path = tmp_path / "tool_calls.jsonl"
+        assert jsonl_path.exists()
+
+        lines = jsonl_path.read_text().strip().split("\n")
+        assert len(lines) == 2
+
+        for line in lines:
+            record = json.loads(line)
+            assert record["tool_name"] == "mock_tool"
+            assert record["success"] is True
+
+    def test_telemetry_off_suppresses_file(self, mock_dataset, tmp_path):
+        """M4_TELEMETRY=off suppresses file output."""
+        with patch.dict(os.environ, {"M4_TELEMETRY": "off"}):
+            with patch("m4.config.get_telemetry_dir", return_value=tmp_path):
+                tool = MockTool(return_value="ok")
+                invoke_tracked(tool, mock_dataset, MockInput())
+
+        jsonl_path = tmp_path / "tool_calls.jsonl"
+        assert not jsonl_path.exists()
+
+
+class TestContextVars:
+    def test_default_interface(self, mock_dataset):
+        record = _capture_record(mock_dataset)
+
+        assert record["interface"] == "unknown"
+        assert record["agent_id"] is None
+
+    def test_set_interface(self):
+        set_interface("python_api")
+        assert _interface_var.get() == "python_api"
+
+    def test_set_agent_id(self):
+        set_agent_id("my-agent")
+        assert _agent_id_var.get() == "my-agent"

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -5,12 +5,15 @@ import os
 from dataclasses import dataclass
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 
 from m4.core.datasets import DatasetDefinition, Modality
 from m4.core.exceptions import M4Error
 from m4.core.telemetry import (
+    TELEMETRY_FILENAME,
     _agent_id_var,
+    _get_terminal_session,
     _interface_var,
     _writer,
     invoke_tracked,
@@ -175,3 +178,76 @@ class TestContextVars:
     def test_set_agent_id(self):
         set_agent_id("my-agent")
         assert _agent_id_var.get() == "my-agent"
+
+
+class TestTerminalSession:
+    def test_terminal_session_present(self, mock_dataset):
+        record = _capture_record(mock_dataset)
+        session = record["terminal_session"]
+        assert session is not None
+        assert session.isdigit()
+
+    def test_terminal_session_consistent(self, mock_dataset):
+        r1 = _capture_record(mock_dataset)
+        r2 = _capture_record(mock_dataset)
+        assert r1["terminal_session"] == r2["terminal_session"]
+
+    def test_terminal_session_none_without_getsid(self, mock_dataset):
+        with patch("m4.core.telemetry.os.getsid", side_effect=AttributeError):
+            record = _capture_record(mock_dataset)
+        assert record["terminal_session"] is None
+
+    def test_get_terminal_session_returns_string(self):
+        result = _get_terminal_session()
+        assert result is None or isinstance(result, str)
+
+
+class TestRowCount:
+    def test_row_count_for_dataframe(self, mock_dataset):
+        df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        tool = MockTool(return_value=df)
+        record = _capture_record(mock_dataset, tool=tool)
+        assert record["row_count"] == 3
+
+    def test_row_count_none_for_dict(self, mock_dataset):
+        tool = MockTool(return_value={"schema": "info"})
+        record = _capture_record(mock_dataset, tool=tool)
+        assert record["row_count"] is None
+
+    def test_row_count_none_for_string(self, mock_dataset):
+        tool = MockTool(return_value="ok")
+        record = _capture_record(mock_dataset, tool=tool)
+        assert record["row_count"] is None
+
+    def test_row_count_none_on_error(self, mock_dataset):
+        tool = MockTool(side_effect=M4Error("fail"))
+        with patch("m4.core.telemetry.logger") as mock_logger:
+            with pytest.raises(M4Error):
+                invoke_tracked(tool, mock_dataset, MockInput())
+            record = json.loads(mock_logger.info.call_args[0][0])
+        assert record["row_count"] is None
+
+    def test_row_count_zero_for_empty_dataframe(self, mock_dataset):
+        df = pd.DataFrame({"a": []})
+        tool = MockTool(return_value=df)
+        record = _capture_record(mock_dataset, tool=tool)
+        assert record["row_count"] == 0
+
+
+class TestTelemetryFilename:
+    def test_constant_value(self):
+        assert TELEMETRY_FILENAME == "tool_calls.jsonl"
+
+    def test_jsonl_uses_constant(self, mock_dataset, tmp_path):
+        with patch("m4.config.get_telemetry_dir", return_value=tmp_path):
+            invoke_tracked(MockTool(), mock_dataset, MockInput())
+        assert (tmp_path / TELEMETRY_FILENAME).exists()
+
+
+class TestGetTelemetryPath:
+    def test_returns_correct_path(self, tmp_path):
+        with patch("m4.config.get_telemetry_dir", return_value=tmp_path):
+            from m4.api import get_telemetry_path
+
+            path = get_telemetry_path()
+        assert path == tmp_path / "tool_calls.jsonl"


### PR DESCRIPTION
## Summary
- Adds a telemetry module (`core/telemetry.py`) that tracks every tool invocation with timing, context, and provenance fields
- Records are written as JSONL to `m4_data/telemetry/tool_calls.jsonl` with rotation (10 MB, 3 backups)
- Both MCP server and Python API tool calls are tracked via `invoke_tracked()` wrapper
- Caller context (interface type, agent ID, terminal session) flows via `contextvars` — no changes to the Tool protocol
- Exposes `get_telemetry_path()` and `set_agent_id()` in the public API for external consumers (e.g. DOJO)
- Telemetry can be disabled with `M4_TELEMETRY=off`

## Test plan
- [x] Unit tests for success/failure recording, context vars, JSONL output, row counts, and telemetry-off mode (`tests/core/test_telemetry.py`)
- [x] Verify JSONL output with a live dataset via MCP and Python API
- [x] Confirm `M4_TELEMETRY=off` suppresses file creation in production