### PR TITLE
Feat/tier3 pi ollama

### DIFF
--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -3,6 +3,7 @@ FROM node:20-slim
 ARG CLAUDE_CODE_VERSION=2.1.119
 ARG GEMINI_CLI_VERSION=0.39.1
 ARG CODEX_CLI_VERSION=0.124.0
+ARG PI_CODING_AGENT_VERSION=0.70.2
 
 ENV NPM_CONFIG_AUDIT=false \
     NPM_CONFIG_FUND=false \
@@ -18,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN npm install -g --loglevel=warn @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 RUN npm install -g --loglevel=warn @google/gemini-cli@${GEMINI_CLI_VERSION}
 RUN npm install -g --loglevel=warn @openai/codex@${CODEX_CLI_VERSION}
+RUN npm install -g --loglevel=warn @mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}
 
 # Non-root user for agent execution.
 # The orchestrator runs as root; the agent subprocess runs as benchagent.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -147,7 +147,8 @@ coverage, required columns, and per-criterion accuracy.
 
 ## Supported Agents
 
-Claude Code, Codex, Gemini CLI. See `AGENT_COMMANDS` in `run.py` for configuration.
+Claude Code, Codex, Gemini CLI, and Pi over Ollama (`pi-ollama`). See
+`AGENT_COMMANDS` in `run.py` for configuration.
 
 For Codex CLI, the harness uses `codex exec --dangerously-bypass-approvals-and-sandbox`
 because Docker already provides the outer sandbox, and it injects task
@@ -155,24 +156,92 @@ skills into `.codex/skills/` inside each run workdir. Authenticate first with
 `codex login` if you want to use ChatGPT subscription access instead of an API
 key.
 
+For `pi-ollama`, the harness invokes Pi in non-interactive mode with the
+Ollama provider and disables user-global discovery features (`--no-context-files`,
+`--no-themes`, `--no-prompt-templates`, `--no-extensions`) so runs are not
+affected by local themes, prompt templates, extensions, or context files. Task
+skills are injected into `.pi/skills/` inside each run workdir. The per-run HOME
+seeds only `.pi/agent/models.json`, which lets Pi find the local Ollama model
+configuration without copying unrelated auth files.
+
 `benchmark/matrix.py` uses agent-specific default model sets:
 - Claude: `opus`, `sonnet`
 - Codex: `gpt-5.5`, `gpt-5.4-mini`
 - Gemini: `gemini-3.1-pro-preview`, `gemini-3-flash-preview`
+- Pi/Ollama: `qwen3:4b`
 
 The default matrix profile is GPT-primary: run the powered campaign with
 `--agent codex`, then use `--profile provider-comparison` for sparse Claude or
-Gemini sentinel runs. Provider-comparison runs are supplementary and should not
-be described as powered benchmark-wide estimates.
+Gemini sentinel runs. `pi-ollama` is the Tier 3 OSS local-model baseline for
+zero-API-cost reproducibility. Provider-comparison runs are supplementary and
+should not be described as powered benchmark-wide estimates.
 
 Reasoning policy is pinned by default through `--reasoning-effort auto`: Codex
-and Claude Code run at `medium`, while Gemini CLI is recorded as
-`provider-default` because it does not expose the same named effort scale. Pass
-`--reasoning-effort default` to leave each CLI/provider default untouched, or an
-explicit supported level for Codex/Claude ablations.
+and Claude Code run at `medium`, while Gemini CLI and `pi-ollama` are recorded
+as `provider-default` because they do not expose the same named effort scale.
+Pass `--reasoning-effort default` to leave each CLI/provider default untouched,
+or an explicit supported level for Codex/Claude ablations.
 
 For Claude subscription campaigns, the matrix executes one `bench.sh` run per
 cell so the host can refresh OAuth-backed auth between Docker runs. Do not
 store expiring Claude OAuth tokens in `benchmark/.env`; that file should only
 hold stable Anthropic API keys. Subscription-backed Claude runs should come
 from `claude login` on macOS so `bench.sh` can pull a fresh keychain token.
+
+### Pi/Ollama local setup
+
+`pi-ollama` requires Pi, Ollama, and at least one local model. A minimal setup
+uses `qwen3:4b`:
+
+```bash
+node --version
+npm --version
+which pi
+which ollama
+
+npm install -g @mariozechner/pi-coding-agent
+brew install ollama
+ollama serve
+ollama pull qwen3:4b
+```
+
+Create or update `~/.pi/agent/models.json` with an Ollama provider:
+
+```json
+{
+  "providers": {
+    "ollama": {
+      "baseUrl": "http://localhost:11434/v1",
+      "api": "openai-completions",
+      "apiKey": "ollama",
+      "compat": {
+        "supportsUsageInStreaming": false,
+        "maxTokensField": "max_tokens"
+      },
+      "models": [
+        { "id": "qwen3:4b" }
+      ]
+    }
+  }
+}
+```
+
+Then confirm Pi can see the model:
+
+```bash
+pi --list-models ollama
+```
+
+Loopback access is allowed by the Docker network lock, so Ollama on
+`localhost:11434` remains reachable from isolated benchmark runs.
+
+Optional smoke test without MIMIC data:
+
+```bash
+SMOKE_DIR=$(mktemp -d -t m4_pi_smoke)
+cd "$SMOKE_DIR"
+printf "stay_id,score\n1,2\n2,3\n3,5\n4,7\n5,11\n" > input.csv
+
+pi --provider ollama --model qwen3:4b -p \
+  "Read input.csv. For each row, double the score column. Write the result to output.csv with the same columns and row count. Do not include extra columns. Do not print the CSV; write it to disk."
+```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -190,23 +190,26 @@ from `claude login` on macOS so `bench.sh` can pull a fresh keychain token.
 
 ### Pi/Ollama local setup
 
-`pi-ollama` requires Pi, Ollama, and at least one local model. A minimal setup
-uses `qwen3:4b`:
+`pi-ollama` requires Ollama and at least one local model. The Docker benchmark
+path installs Pi inside the benchmark image, so a host Pi install is needed only
+for the optional local smoke test. A minimal setup uses `qwen3:4b`:
 
 ```bash
-node --version
-npm --version
-which pi
 which ollama
 
-npm install -g @mariozechner/pi-coding-agent
 brew install ollama
 ollama serve
 ollama pull qwen3:4b
 ```
 
-Create or update `~/.pi/agent/models.json` with an Ollama provider. Use
-`localhost` for fully local smoke tests:
+For the optional local smoke test outside Docker, install Pi on the host and
+create or update `~/.pi/agent/models.json` with an Ollama provider that uses
+`localhost`:
+
+```bash
+npm install -g @mariozechner/pi-coding-agent
+mkdir -p ~/.pi/agent
+```
 
 ```json
 {
@@ -233,7 +236,7 @@ Then confirm Pi can see the model:
 pi --list-models ollama
 ```
 
-Optional smoke test without MIMIC data:
+Optional local smoke test without MIMIC data:
 
 ```bash
 SMOKE_DIR=$(mktemp -d -t m4_pi_smoke)
@@ -244,11 +247,15 @@ pi --provider ollama --model qwen3:4b -p \
   "Read input.csv. For each row, double the score column. Write the result to output.csv with the same columns and row count. Do not include extra columns. Do not print the CSV; write it to disk."
 ```
 
-For paper-quality Docker runs, `bench.sh` installs Pi in the benchmark image,
-mounts `~/.pi` read-only, and rewrites the per-run copy of
-`.pi/agent/models.json` to use `M4BENCH_OLLAMA_BASE_URL`. By default that URL is
+For paper-quality Docker runs, host `~/.pi` is optional. `bench.sh` installs Pi
+in the benchmark image, mounts `~/.pi` read-only only when it exists, and the
+harness creates or rewrites the per-run copy of `.pi/agent/models.json` from
+`M4BENCH_OLLAMA_BASE_URL`. By default that URL is
 `http://host.docker.internal:11434/v1`, which points from the container back to
-the host Ollama server. Override the host or port when needed:
+the host Ollama server. The required fresh-machine setup is therefore: Docker
+running, Ollama running on the host, and the selected model pulled.
+
+Override the host or port when needed:
 
 ```bash
 M4BENCH_OLLAMA_HOST=host.docker.internal \

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -205,7 +205,8 @@ ollama serve
 ollama pull qwen3:4b
 ```
 
-Create or update `~/.pi/agent/models.json` with an Ollama provider:
+Create or update `~/.pi/agent/models.json` with an Ollama provider. Use
+`localhost` for fully local smoke tests:
 
 ```json
 {
@@ -232,9 +233,6 @@ Then confirm Pi can see the model:
 pi --list-models ollama
 ```
 
-Loopback access is allowed by the Docker network lock, so Ollama on
-`localhost:11434` remains reachable from isolated benchmark runs.
-
 Optional smoke test without MIMIC data:
 
 ```bash
@@ -245,3 +243,20 @@ printf "stay_id,score\n1,2\n2,3\n3,5\n4,7\n5,11\n" > input.csv
 pi --provider ollama --model qwen3:4b -p \
   "Read input.csv. For each row, double the score column. Write the result to output.csv with the same columns and row count. Do not include extra columns. Do not print the CSV; write it to disk."
 ```
+
+For paper-quality Docker runs, `bench.sh` installs Pi in the benchmark image,
+mounts `~/.pi` read-only, and rewrites the per-run copy of
+`.pi/agent/models.json` to use `M4BENCH_OLLAMA_BASE_URL`. By default that URL is
+`http://host.docker.internal:11434/v1`, which points from the container back to
+the host Ollama server. Override the host or port when needed:
+
+```bash
+M4BENCH_OLLAMA_HOST=host.docker.internal \
+M4BENCH_OLLAMA_PORT=11434 \
+bash benchmark/bench.sh --task mimic-sirs-24h-raw --condition no-skill \
+  --agent pi-ollama --model qwen3:4b
+```
+
+When `--agent pi-ollama` is used, the Docker network lock allows the configured
+Ollama host and port for the `benchagent` user while continuing to reject other
+non-allowlisted outbound traffic.

--- a/benchmark/bench.sh
+++ b/benchmark/bench.sh
@@ -151,7 +151,7 @@ DATA_MOUNT_SOURCES=()
 
 add_data_mount_source() {
     local source="$1"
-    for existing in "${DATA_MOUNT_SOURCES[@]}"; do
+    for existing in "${DATA_MOUNT_SOURCES[@]+"${DATA_MOUNT_SOURCES[@]}"}"; do
         [[ "$existing" == "$source" ]] && return
     done
     DATA_MOUNT_SOURCES+=("$source")
@@ -218,7 +218,9 @@ fi
 echo "Locking sensitive directories (root-only)..."
 "$DOCKER_BIN" exec "$CONTAINER" bash -c \
     'for d in ground_truth tasks agent_db; do
-        [ -d "/benchmark/$d" ] && chmod 700 "/benchmark/$d"
+        if [ -d "/benchmark/$d" ]; then
+            chmod 700 "/benchmark/$d"
+        fi
     done'
 
 # 2. Lock network: iptables rules restrict the benchagent user to

--- a/benchmark/bench.sh
+++ b/benchmark/bench.sh
@@ -104,8 +104,18 @@ if [[ "$AGENT" == "claude" ]] && [[ "${ANTHROPIC_API_KEY:-}" == sk-ant-oat* ]] &
     exit 1
 fi
 
-# Build image if it doesn't exist, or when explicitly requested.
+NEEDS_BUILD=0
 if [[ "${M4BENCH_REBUILD:-0}" == "1" ]] || ! "$DOCKER_BIN" image inspect "$IMAGE" &>/dev/null; then
+    NEEDS_BUILD=1
+elif [[ "$AGENT" == "pi-ollama" ]] && ! "$DOCKER_BIN" run --rm "$IMAGE" \
+    sh -lc 'command -v pi >/dev/null 2>&1'; then
+    echo "Existing $IMAGE image does not include Pi; rebuilding..."
+    NEEDS_BUILD=1
+fi
+
+# Build image if it doesn't exist, when explicitly requested, or when the
+# selected agent requires tooling missing from an older local image.
+if [[ "$NEEDS_BUILD" == "1" ]]; then
     echo "Building $IMAGE..."
     "$DOCKER_BIN" build -t "$IMAGE" "$SCRIPT_DIR"
 fi
@@ -123,6 +133,19 @@ DOCKER_ARGS=(
     -v "$SCRIPT_DIR":/benchmark
     -e "M4BENCH_AUTH_ROOT=$AUTH_ROOT"
 )
+
+if [[ "$AGENT" == "pi-ollama" ]]; then
+    M4BENCH_OLLAMA_HOST="${M4BENCH_OLLAMA_HOST:-host.docker.internal}"
+    M4BENCH_OLLAMA_PORT="${M4BENCH_OLLAMA_PORT:-11434}"
+    M4BENCH_OLLAMA_BASE_URL="${M4BENCH_OLLAMA_BASE_URL:-http://${M4BENCH_OLLAMA_HOST}:${M4BENCH_OLLAMA_PORT}/v1}"
+    DOCKER_ARGS+=(
+        --add-host=host.docker.internal:host-gateway
+        -e "M4BENCH_ALLOW_OLLAMA=1"
+        -e "M4BENCH_OLLAMA_HOST=$M4BENCH_OLLAMA_HOST"
+        -e "M4BENCH_OLLAMA_PORT=$M4BENCH_OLLAMA_PORT"
+        -e "M4BENCH_OLLAMA_BASE_URL=$M4BENCH_OLLAMA_BASE_URL"
+    )
+fi
 
 DATA_MOUNT_SOURCES=()
 
@@ -174,6 +197,10 @@ fi
 
 if [[ -d "$HOME/.gemini" ]]; then
     DOCKER_ARGS+=(-v "$HOME/.gemini:$AUTH_ROOT/.gemini:ro")
+fi
+
+if [[ -d "$HOME/.pi" ]]; then
+    DOCKER_ARGS+=(-v "$HOME/.pi:$AUTH_ROOT/.pi:ro")
 fi
 
 "$DOCKER_BIN" run "${DOCKER_ARGS[@]}" "$IMAGE" >/dev/null

--- a/benchmark/matrix.py
+++ b/benchmark/matrix.py
@@ -152,6 +152,13 @@ def _model_plan_for_agent(agent: str) -> AgentModelPlan:
             contamination_models=("gemini-3-flash-preview",),
             noise_models=("gemini-3.1-pro-preview",),
         )
+    if agent == "pi-ollama":
+        return AgentModelPlan(
+            primary_models=("qwen3:4b",),
+            hurts_models=("qwen3:4b",),
+            contamination_models=("qwen3:4b",),
+            noise_models=("qwen3:4b",),
+        )
     raise ValueError(f"Unsupported agent: {agent}")
 
 
@@ -1012,7 +1019,7 @@ def main():
     parser.add_argument(
         "--agent",
         default="codex",
-        help="Agent CLI to use (claude, codex, gemini)",
+        help="Agent CLI to use (claude, codex, gemini, pi-ollama)",
     )
     parser.add_argument(
         "--reasoning-effort",

--- a/benchmark/network_lock.sh
+++ b/benchmark/network_lock.sh
@@ -45,6 +45,17 @@ for host in "${ALLOWED_HOSTS[@]}"; do
     done
 done
 
+if [[ "${M4BENCH_ALLOW_OLLAMA:-0}" == "1" ]]; then
+    OLLAMA_HOST="${M4BENCH_OLLAMA_HOST:-host.docker.internal}"
+    OLLAMA_PORT="${M4BENCH_OLLAMA_PORT:-11434}"
+    echo "Resolving Ollama host for local Pi baseline..."
+    for ip in $(getent ahostsv4 "$OLLAMA_HOST" 2>/dev/null | awk '{print $1}' | sort -u); do
+        iptables -A OUTPUT -m owner --uid-owner "$AGENT_UID" \
+            -d "$ip" -p tcp --dport "$OLLAMA_PORT" -j ACCEPT
+        echo "  $OLLAMA_HOST:$OLLAMA_PORT -> $ip"
+    done
+fi
+
 # Allow loopback (agent CLI may use local sockets)
 iptables -A OUTPUT -m owner --uid-owner "$AGENT_UID" -o lo -j ACCEPT
 

--- a/benchmark/preflight.py
+++ b/benchmark/preflight.py
@@ -376,17 +376,19 @@ def run_checks(
     check_dbs: bool = True,
     self_check_ground_truth: bool = False,
 ) -> list[CheckResult]:
+    # Keep check_dbs=False source-only so preflight can run in fresh checkouts
+    # before expensive generated benchmark artifacts exist locally.
     checks = [
         check_instruction_sparsity(),
         check_raw_mode_contract(),
         check_skill_snapshots(),
-        check_ground_truth(self_check=self_check_ground_truth),
-        check_contamination_ready(),
         check_results_root(results_root),
     ]
     if check_dbs:
         checks.insert(2, check_agent_databases())
         checks.insert(3, check_external_view_sources())
+        checks.insert(4, check_ground_truth(self_check=self_check_ground_truth))
+        checks.insert(5, check_contamination_ready())
     return checks
 
 
@@ -407,7 +409,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--skip-db-check",
         action="store_true",
-        help="Skip agent DB existence/drop-table checks",
+        help="Skip generated benchmark artifact checks (agent DBs, ground truth, contamination DBs)",
     )
     parser.add_argument(
         "--ground-truth-self-check",

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -125,7 +125,6 @@ AGENT_COMMANDS = {
     "pi-ollama": {
         "cmd": [
             "pi",
-            "-p",
             "--provider",
             "ollama",
             "--no-context-files",
@@ -134,6 +133,7 @@ AGENT_COMMANDS = {
             "--no-extensions",
             "--skill",
             ".pi/skills",
+            "-p",
         ],
         "skill_dir": ".pi/skills",
         "json_trace": False,
@@ -650,7 +650,42 @@ def prepare_run_home(agent_name: str, run_home: Path) -> list[str]:
                 indent=2,
             )
         )
+    elif agent_name == "pi-ollama":
+        _configure_pi_ollama_home(run_home)
     return copied
+
+
+def _configure_pi_ollama_home(run_home: Path) -> None:
+    """Point Pi's copied Ollama provider config at the benchmark endpoint."""
+    base_url = os.environ.get("M4BENCH_OLLAMA_BASE_URL")
+    if not base_url:
+        return
+
+    models_path = run_home / ".pi" / "agent" / "models.json"
+    models_path.parent.mkdir(parents=True, exist_ok=True)
+    if models_path.exists():
+        try:
+            data = json.loads(models_path.read_text())
+        except json.JSONDecodeError:
+            data = {}
+    else:
+        data = {}
+
+    providers = data.setdefault("providers", {})
+    ollama = providers.setdefault("ollama", {})
+    ollama.update(
+        {
+            "baseUrl": base_url,
+            "api": ollama.get("api", "openai-completions"),
+            "apiKey": ollama.get("apiKey", "ollama"),
+        }
+    )
+    ollama.setdefault(
+        "compat",
+        {"supportsUsageInStreaming": False, "maxTokensField": "max_tokens"},
+    )
+    ollama.setdefault("models", [{"id": "qwen3:4b"}])
+    models_path.write_text(json.dumps(data, indent=2) + "\n")
 
 
 def copy_results_back(workdir: Path, results_dir: Path) -> None:
@@ -812,7 +847,11 @@ def run_agent(
             else:
                 cmd.extend(["-m", model])
         elif agent_name == "pi-ollama":
-            cmd.extend(["--model", model])
+            if cmd and cmd[-1] == "-p":
+                cmd = cmd[:-1]
+                cmd.extend(["--model", model, "-p"])
+            else:
+                cmd.extend(["--model", model])
 
     resolved_reasoning_effort = _resolve_reasoning_effort(agent_name, reasoning_effort)
     cmd.extend(_reasoning_args_for_agent(agent_name, resolved_reasoning_effort))

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -122,6 +122,22 @@ AGENT_COMMANDS = {
         "skill_dir": ".gemini/skills",
         "json_trace": False,
     },
+    "pi-ollama": {
+        "cmd": [
+            "pi",
+            "-p",
+            "--provider",
+            "ollama",
+            "--no-context-files",
+            "--no-themes",
+            "--no-prompt-templates",
+            "--no-extensions",
+            "--skill",
+            ".pi/skills",
+        ],
+        "skill_dir": ".pi/skills",
+        "json_trace": False,
+    },
 }
 
 AGENT_HOME_SEEDS = {
@@ -134,6 +150,7 @@ AGENT_HOME_SEEDS = {
         ".gemini/settings.json",
         ".gemini/installation_id",
     ],
+    "pi-ollama": [".pi/agent/models.json"],
 }
 
 REASONING_EFFORT_CHOICES = (
@@ -794,6 +811,8 @@ def run_agent(
                 cmd.extend(["-m", model, "-p"])
             else:
                 cmd.extend(["-m", model])
+        elif agent_name == "pi-ollama":
+            cmd.extend(["--model", model])
 
     resolved_reasoning_effort = _resolve_reasoning_effort(agent_name, reasoning_effort)
     cmd.extend(_reasoning_args_for_agent(agent_name, resolved_reasoning_effort))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ known-first-party = ["m4"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+pythonpath = ["src"]
 addopts = "-m 'not requires_mimic_iv' --ignore=benchmark"
 markers = [
     "requires_mimic_iv: test requires local MIMIC-IV data (run with: uv run pytest -m requires_mimic_iv)",

--- a/tests/test_benchmark_harness.py
+++ b/tests/test_benchmark_harness.py
@@ -232,12 +232,45 @@ def test_gemini_command_uses_external_sandbox():
     assert "yolo" in gemini_cmd
 
 
+def test_pi_ollama_command_disables_context_discovery():
+    run = _load_module("benchmark_run_pi_ollama_cmd", "benchmark/run.py")
+
+    pi_cmd = run.AGENT_COMMANDS["pi-ollama"]["cmd"]
+
+    assert "--no-context-files" in pi_cmd
+    assert "--no-themes" in pi_cmd
+    assert "--no-prompt-templates" in pi_cmd
+    assert "--no-extensions" in pi_cmd
+    assert "--provider" in pi_cmd
+    assert "ollama" in pi_cmd
+    assert ".pi/skills" in pi_cmd
+
+
+def test_prepare_run_home_pi_ollama_seeds_only_models_json(monkeypatch, tmp_path):
+    run = _load_module("benchmark_run_pi_home", "benchmark/run.py")
+
+    auth_root = tmp_path / "auth"
+    (auth_root / ".pi" / "agent").mkdir(parents=True)
+    (auth_root / ".pi" / "agent" / "models.json").write_text("{}")
+    (auth_root / ".pi" / "agent" / "auth.json").write_text("{}")
+
+    monkeypatch.setenv("M4BENCH_AUTH_ROOT", str(auth_root))
+
+    pi_home = tmp_path / "pi-home"
+    copied = run.prepare_run_home("pi-ollama", pi_home)
+
+    assert copied == [".pi/agent/models.json"]
+    assert (pi_home / ".pi" / "agent" / "models.json").exists()
+    assert not (pi_home / ".pi" / "agent" / "auth.json").exists()
+
+
 def test_reasoning_auto_policy_resolves_by_agent():
     run = _load_module("benchmark_run_reasoning_policy", "benchmark/run.py")
 
     assert run._resolve_reasoning_effort("codex", "auto") == "medium"
     assert run._resolve_reasoning_effort("claude", "auto") == "medium"
     assert run._resolve_reasoning_effort("gemini", "auto") == "provider-default"
+    assert run._resolve_reasoning_effort("pi-ollama", "auto") == "provider-default"
 
 
 def test_reasoning_args_match_supported_agent_clis():
@@ -252,6 +285,7 @@ def test_reasoning_args_match_supported_agent_clis():
         "medium",
     ]
     assert run._reasoning_args_for_agent("gemini", "provider-default") == []
+    assert run._reasoning_args_for_agent("pi-ollama", "provider-default") == []
 
 
 def test_named_reasoning_rejects_unsupported_agent_scale():
@@ -263,6 +297,13 @@ def test_named_reasoning_rejects_unsupported_agent_scale():
         assert "does not support named reasoning effort" in str(exc)
     else:
         raise AssertionError("expected ValueError for Gemini named effort")
+
+    try:
+        run._resolve_reasoning_effort("pi-ollama", "high")
+    except ValueError as exc:
+        assert "does not support named reasoning effort" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for pi-ollama named effort")
 
 
 def test_network_lock_allows_subscription_backed_codex_hosts():

--- a/tests/test_benchmark_harness.py
+++ b/tests/test_benchmark_harness.py
@@ -297,9 +297,7 @@ def test_prepare_run_home_pi_ollama_seeds_only_models_json(monkeypatch, tmp_path
     assert not (pi_home / ".pi" / "agent" / "auth.json").exists()
 
 
-def test_prepare_run_home_pi_ollama_rewrites_docker_ollama_url(
-    monkeypatch, tmp_path
-):
+def test_prepare_run_home_pi_ollama_rewrites_docker_ollama_url(monkeypatch, tmp_path):
     run = _load_module("benchmark_run_pi_home_ollama_url", "benchmark/run.py")
 
     auth_root = tmp_path / "auth"
@@ -391,7 +389,7 @@ def test_network_lock_allows_configured_ollama_for_pi():
     assert "M4BENCH_ALLOW_OLLAMA" in script
     assert "M4BENCH_OLLAMA_HOST" in script
     assert "M4BENCH_OLLAMA_PORT" in script
-    assert "--dport \"$OLLAMA_PORT\"" in script
+    assert '--dport "$OLLAMA_PORT"' in script
 
 
 def test_benchmark_dockerfile_installs_pi_cli():
@@ -408,7 +406,7 @@ def test_bench_sh_mounts_pi_config_and_configures_ollama_endpoint():
     assert "command -v pi" in bench
     assert "M4BENCH_OLLAMA_BASE_URL" in bench
     assert "--add-host=host.docker.internal:host-gateway" in bench
-    assert '$HOME/.pi:$AUTH_ROOT/.pi:ro' in bench
+    assert "$HOME/.pi:$AUTH_ROOT/.pi:ro" in bench
 
 
 def test_task_discovery_uses_repo_relative_paths(monkeypatch):

--- a/tests/test_benchmark_harness.py
+++ b/tests/test_benchmark_harness.py
@@ -237,6 +237,8 @@ def test_pi_ollama_command_disables_context_discovery():
 
     pi_cmd = run.AGENT_COMMANDS["pi-ollama"]["cmd"]
 
+    assert pi_cmd[0] == "pi"
+    assert pi_cmd[-1] == "-p"
     assert "--no-context-files" in pi_cmd
     assert "--no-themes" in pi_cmd
     assert "--no-prompt-templates" in pi_cmd
@@ -244,6 +246,37 @@ def test_pi_ollama_command_disables_context_discovery():
     assert "--provider" in pi_cmd
     assert "ollama" in pi_cmd
     assert ".pi/skills" in pi_cmd
+
+
+def test_pi_ollama_model_flag_precedes_prompt_flag(monkeypatch, tmp_path):
+    run = _load_module("benchmark_run_pi_ollama_model_cmd", "benchmark/run.py")
+    seen: dict[str, list[str]] = {}
+
+    class FakeProcess:
+        returncode = 0
+        stdout = iter(["ok\n"])
+
+        def wait(self, timeout=None):
+            return 0
+
+    def fake_popen(cmd, **kwargs):
+        seen["cmd"] = cmd
+        return FakeProcess()
+
+    monkeypatch.setattr(run.subprocess, "Popen", fake_popen)
+
+    result = run.run_agent(
+        "double the scores",
+        "pi-ollama",
+        tmp_path,
+        model="qwen3:4b",
+    )
+
+    cmd = seen["cmd"]
+    assert result["returncode"] == 0
+    assert cmd[-2:] == ["-p", "double the scores"]
+    assert cmd[cmd.index("--model") + 1] == "qwen3:4b"
+    assert cmd.index("--model") < cmd.index("-p")
 
 
 def test_prepare_run_home_pi_ollama_seeds_only_models_json(monkeypatch, tmp_path):
@@ -262,6 +295,44 @@ def test_prepare_run_home_pi_ollama_seeds_only_models_json(monkeypatch, tmp_path
     assert copied == [".pi/agent/models.json"]
     assert (pi_home / ".pi" / "agent" / "models.json").exists()
     assert not (pi_home / ".pi" / "agent" / "auth.json").exists()
+
+
+def test_prepare_run_home_pi_ollama_rewrites_docker_ollama_url(
+    monkeypatch, tmp_path
+):
+    run = _load_module("benchmark_run_pi_home_ollama_url", "benchmark/run.py")
+
+    auth_root = tmp_path / "auth"
+    models_path = auth_root / ".pi" / "agent" / "models.json"
+    models_path.parent.mkdir(parents=True)
+    models_path.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "ollama": {
+                        "baseUrl": "http://localhost:11434/v1",
+                        "api": "openai-completions",
+                        "apiKey": "ollama",
+                        "models": [{"id": "qwen3:4b"}],
+                    }
+                }
+            }
+        )
+    )
+
+    monkeypatch.setenv("M4BENCH_AUTH_ROOT", str(auth_root))
+    monkeypatch.setenv(
+        "M4BENCH_OLLAMA_BASE_URL", "http://host.docker.internal:11434/v1"
+    )
+
+    pi_home = tmp_path / "pi-home"
+    run.prepare_run_home("pi-ollama", pi_home)
+
+    copied = json.loads((pi_home / ".pi" / "agent" / "models.json").read_text())
+    assert (
+        copied["providers"]["ollama"]["baseUrl"]
+        == "http://host.docker.internal:11434/v1"
+    )
 
 
 def test_reasoning_auto_policy_resolves_by_agent():
@@ -312,6 +383,32 @@ def test_network_lock_allows_subscription_backed_codex_hosts():
     assert "api.openai.com" in script
     assert "auth.openai.com" in script
     assert "chatgpt.com" in script
+
+
+def test_network_lock_allows_configured_ollama_for_pi():
+    script = (ROOT / "benchmark" / "network_lock.sh").read_text()
+
+    assert "M4BENCH_ALLOW_OLLAMA" in script
+    assert "M4BENCH_OLLAMA_HOST" in script
+    assert "M4BENCH_OLLAMA_PORT" in script
+    assert "--dport \"$OLLAMA_PORT\"" in script
+
+
+def test_benchmark_dockerfile_installs_pi_cli():
+    dockerfile = (ROOT / "benchmark" / "Dockerfile").read_text()
+
+    assert "PI_CODING_AGENT_VERSION=0.70.2" in dockerfile
+    assert "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}" in dockerfile
+
+
+def test_bench_sh_mounts_pi_config_and_configures_ollama_endpoint():
+    bench = (ROOT / "benchmark" / "bench.sh").read_text()
+
+    assert 'AGENT" == "pi-ollama"' in bench
+    assert "command -v pi" in bench
+    assert "M4BENCH_OLLAMA_BASE_URL" in bench
+    assert "--add-host=host.docker.internal:host-gateway" in bench
+    assert '$HOME/.pi:$AUTH_ROOT/.pi:ro' in bench
 
 
 def test_task_discovery_uses_repo_relative_paths(monkeypatch):

--- a/tests/test_benchmark_matrix.py
+++ b/tests/test_benchmark_matrix.py
@@ -111,6 +111,17 @@ def test_build_tiers_uses_agent_specific_gemini_models():
     assert "sonnet" not in models
 
 
+def test_build_tiers_uses_agent_specific_pi_ollama_models():
+    matrix = _load_module("benchmark_matrix_pi_ollama", "benchmark/matrix.py")
+    _reset_task_globals(matrix)
+    matrix._classify_tasks()
+
+    tiers = matrix.build_tiers(seeds=1, agent="pi-ollama")
+    models = {run["model"] for tier in tiers for run in tier.runs}
+
+    assert models == {"qwen3:4b"}
+
+
 def test_container_results_root_maps_under_benchmark_root():
     matrix = _load_module("benchmark_matrix_container_root", "benchmark/matrix.py")
     results_root = (ROOT / "benchmark" / "results" / "paper-smoke").resolve()

--- a/tests/test_benchmark_preflight.py
+++ b/tests/test_benchmark_preflight.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import duckdb
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -44,10 +46,31 @@ def test_preflight_skill_snapshots_have_no_target_leakage():
     assert result.ok, result.details
 
 
-def test_preflight_external_view_sources_are_present():
+def test_preflight_external_view_sources_are_present(monkeypatch, tmp_path):
     preflight = _load_module(
         "benchmark_preflight_external_views", "benchmark/preflight.py"
     )
+    agent_db_dir = tmp_path / "agent_db"
+    parquet_path = (
+        tmp_path / "m4_data" / "parquet" / "mimic-iv" / "hosp" / "admissions.parquet"
+    )
+    db_path = agent_db_dir / "mimic_test.duckdb"
+    agent_db_dir.mkdir()
+    parquet_path.parent.mkdir(parents=True)
+
+    con = duckdb.connect(str(db_path))
+    try:
+        con.execute(
+            f"COPY (SELECT 1 AS subject_id) TO '{parquet_path.as_posix()}' "
+            "(FORMAT PARQUET)"
+        )
+        con.execute(
+            "CREATE VIEW admissions AS SELECT * FROM "
+            f"read_parquet('{parquet_path.as_posix()}')"
+        )
+    finally:
+        con.close()
+    monkeypatch.setattr(preflight, "AGENT_DB_DIR", agent_db_dir)
 
     result = preflight.check_external_view_sources()
 


### PR DESCRIPTION
## Summary

Adds Pi over Ollama as a Tier 3 local OSS benchmark agent and tightens the Docker execution path for reproducible runs.

## Changes

- Adds `pi-ollama` support across the benchmark harness, Docker image, matrix defaults, and tests.
- Documents the Pi/Ollama setup for Docker-backed benchmark runs.
- Clarifies that host Pi config is optional for Docker runs because the harness creates the per-run Pi Ollama config.
- Fixes `bench.sh` handling for empty data mount arrays under `set -u`.
- Makes sensitive-directory locking tolerate missing optional benchmark directories.

## Verification

- `uv run python -m pytest tests/test_benchmark_harness.py tests/test_benchmark_matrix.py -q`
- `bash benchmark/bench.sh --list --agent pi-ollama`
- Manual Docker run confirmed Pi launches under isolated `benchagent` execution and records failed outputs cleanly when no `output.csv` is produced.