### PR TITLE
Add clinician provenance records for reviewed M4Bench tasks

### DIFF
--- a/benchmark/tasks/meld/mimic-meld-24h-raw/PROVENANCE.yaml
+++ b/benchmark/tasks/meld/mimic-meld-24h-raw/PROVENANCE.yaml
@@ -11,13 +11,13 @@ sources:
 created:
   by: m4bench task authoring
   role: benchmark-task-construction
-  date: 2026-05-03
+  date: unknown
 
 reviews:
   - by: Ryohei Kobayashi-Yamamoto, MD
     date: 2026-05-03
     scope: clinical-accuracy, task-instruction-consistency
-    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+    notes: Reviewed instruction.md and bundled skill files, including MELD score and decoy KDIGO skill, for clinical accuracy, task alignment, and benchmark suitability. No major clinical concerns identified.
 
 references:
   - "Kamath PS, Wiesner RH, Malinchoc M, Kremers W, Therneau TM, Kosberg CL, D'Amico G, Dickson ER, Kim WR. A model to predict survival in patients with end-stage liver disease. Hepatology. 2001 Feb;33(2):464-70. doi: 10.1053/jhep.2001.22172. PMID: 11172350."
@@ -26,4 +26,4 @@ references:
 changelog:
   - version: "1.0"
     date: 2026-05-03
-    summary: Added provenance record for clinician review of M4Bench task materials.
+    summary: Added draft provenance record for M4Bench task review; original task creation date not verified.

--- a/benchmark/tasks/meld/mimic-meld-24h-raw/PROVENANCE.yaml
+++ b/benchmark/tasks/meld/mimic-meld-24h-raw/PROVENANCE.yaml
@@ -1,0 +1,29 @@
+sources:
+  - description: M4Bench MELD raw-table task instruction and bundled task skills
+    files:
+      - task.toml
+      - instruction.md
+      - skills/meld-score/SKILL.md
+      - skills-nosql/meld-score/SKILL.md
+      - skills-rawsql/mimic-meld-24h-raw/SKILL.md
+      - skills-decoy/kdigo-aki-staging/SKILL.md
+
+created:
+  by: m4bench task authoring
+  role: benchmark-task-construction
+  date: 2026-05-03
+
+reviews:
+  - by: Ryohei Kobayashi-Yamamoto, MD
+    date: 2026-05-03
+    scope: clinical-accuracy, task-instruction-consistency
+    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+
+references:
+  - "Kamath PS, Wiesner RH, Malinchoc M, Kremers W, Therneau TM, Kosberg CL, D'Amico G, Dickson ER, Kim WR. A model to predict survival in patients with end-stage liver disease. Hepatology. 2001 Feb;33(2):464-70. doi: 10.1053/jhep.2001.22172. PMID: 11172350."
+  - "Kim WR, Biggins SW, Kremers WK, Wiesner RH, Kamath PS, Benson JT, Edwards E, Therneau TM. Hyponatremia and mortality among patients on the liver-transplant waiting list. N Engl J Med. 2008 Sep 4;359(10):1018-26. doi: 10.1056/NEJMoa0801209. PMID: 18768945; PMCID: PMC4374557."
+
+changelog:
+  - version: "1.0"
+    date: 2026-05-03
+    summary: Added provenance record for clinician review of M4Bench task materials.

--- a/benchmark/tasks/meld/mimic-meld-24h/PROVENANCE.yaml
+++ b/benchmark/tasks/meld/mimic-meld-24h/PROVENANCE.yaml
@@ -1,0 +1,29 @@
+sources:
+  - description: M4Bench MELD task instruction and bundled task skills
+    files:
+      - task.toml
+      - instruction.md
+      - skills/meld-score/SKILL.md
+      - skills-nosql/meld-score/SKILL.md
+      - skills-rawsql/mimic-meld-24h/SKILL.md
+      - skills-decoy/kdigo-aki-staging/SKILL.md
+
+created:
+  by: m4bench task authoring
+  role: benchmark-task-construction
+  date: 2026-05-03
+
+reviews:
+  - by: Ryohei Kobayashi-Yamamoto, MD
+    date: 2026-05-03
+    scope: clinical-accuracy, task-instruction-consistency
+    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+
+references:
+  - "Kamath PS, Wiesner RH, Malinchoc M, Kremers W, Therneau TM, Kosberg CL, D'Amico G, Dickson ER, Kim WR. A model to predict survival in patients with end-stage liver disease. Hepatology. 2001 Feb;33(2):464-70. doi: 10.1053/jhep.2001.22172. PMID: 11172350."
+  - "Kim WR, Biggins SW, Kremers WK, Wiesner RH, Kamath PS, Benson JT, Edwards E, Therneau TM. Hyponatremia and mortality among patients on the liver-transplant waiting list. N Engl J Med. 2008 Sep 4;359(10):1018-26. doi: 10.1056/NEJMoa0801209. PMID: 18768945; PMCID: PMC4374557."
+
+changelog:
+  - version: "1.0"
+    date: 2026-05-03
+    summary: Added provenance record for clinician review of M4Bench task materials.

--- a/benchmark/tasks/meld/mimic-meld-24h/PROVENANCE.yaml
+++ b/benchmark/tasks/meld/mimic-meld-24h/PROVENANCE.yaml
@@ -11,13 +11,13 @@ sources:
 created:
   by: m4bench task authoring
   role: benchmark-task-construction
-  date: 2026-05-03
+  date: unknown
 
 reviews:
   - by: Ryohei Kobayashi-Yamamoto, MD
     date: 2026-05-03
     scope: clinical-accuracy, task-instruction-consistency
-    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+    notes: Reviewed instruction.md and bundled skill files, including MELD score and decoy KDIGO skill, for clinical accuracy, task alignment, and benchmark suitability. No major clinical concerns identified.
 
 references:
   - "Kamath PS, Wiesner RH, Malinchoc M, Kremers W, Therneau TM, Kosberg CL, D'Amico G, Dickson ER, Kim WR. A model to predict survival in patients with end-stage liver disease. Hepatology. 2001 Feb;33(2):464-70. doi: 10.1053/jhep.2001.22172. PMID: 11172350."
@@ -26,4 +26,4 @@ references:
 changelog:
   - version: "1.0"
     date: 2026-05-03
-    summary: Added provenance record for clinician review of M4Bench task materials.
+    summary: Added draft provenance record for M4Bench task review; original task creation date not verified.

--- a/benchmark/tasks/oasis/eicu-oasis/PROVENANCE.yaml
+++ b/benchmark/tasks/oasis/eicu-oasis/PROVENANCE.yaml
@@ -1,0 +1,27 @@
+sources:
+  - description: M4Bench eICU OASIS task instruction and bundled task skills
+    files:
+      - task.toml
+      - instruction.md
+      - skills/oasis-score/SKILL.md
+      - skills-nosql/oasis-score/SKILL.md
+      - skills-rawsql/eicu-oasis/SKILL.md
+      - skills-decoy/apsiii-score/SKILL.md
+
+created:
+  by: m4bench task authoring
+  role: benchmark-task-construction
+  date: 2026-05-03
+
+reviews:
+  - by: Ryohei Kobayashi-Yamamoto, MD
+    date: 2026-05-03
+    scope: clinical-accuracy, task-instruction-consistency
+    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+
+references: []
+
+changelog:
+  - version: "1.0"
+    date: 2026-05-03
+    summary: Added provenance record for clinician review of M4Bench task materials.

--- a/benchmark/tasks/oasis/eicu-oasis/PROVENANCE.yaml
+++ b/benchmark/tasks/oasis/eicu-oasis/PROVENANCE.yaml
@@ -11,17 +11,17 @@ sources:
 created:
   by: m4bench task authoring
   role: benchmark-task-construction
-  date: 2026-05-03
+  date: unknown
 
 reviews:
   - by: Ryohei Kobayashi-Yamamoto, MD
     date: 2026-05-03
     scope: clinical-accuracy, task-instruction-consistency
-    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+    notes: Reviewed instruction.md and bundled skill files, including OASIS score and decoy APS III skill, for clinical accuracy, task alignment, and benchmark suitability. No major clinical concerns identified.
 
 references: []
 
 changelog:
   - version: "1.0"
     date: 2026-05-03
-    summary: Added provenance record for clinician review of M4Bench task materials.
+    summary: Added draft provenance record for M4Bench task review; original task creation date not verified.

--- a/benchmark/tasks/oasis/mimic-oasis-24h-raw/PROVENANCE.yaml
+++ b/benchmark/tasks/oasis/mimic-oasis-24h-raw/PROVENANCE.yaml
@@ -11,17 +11,17 @@ sources:
 created:
   by: m4bench task authoring
   role: benchmark-task-construction
-  date: 2026-05-03
+  date: unknown
 
 reviews:
   - by: Ryohei Kobayashi-Yamamoto, MD
     date: 2026-05-03
     scope: clinical-accuracy, task-instruction-consistency
-    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+    notes: Reviewed instruction.md and bundled skill files, including OASIS score and decoy APS III skill, for clinical accuracy, task alignment, and benchmark suitability. No major clinical concerns identified.
 
 references: []
 
 changelog:
   - version: "1.0"
     date: 2026-05-03
-    summary: Added provenance record for clinician review of M4Bench task materials.
+    summary: Added draft provenance record for M4Bench task review; original task creation date not verified.

--- a/benchmark/tasks/oasis/mimic-oasis-24h-raw/PROVENANCE.yaml
+++ b/benchmark/tasks/oasis/mimic-oasis-24h-raw/PROVENANCE.yaml
@@ -1,0 +1,27 @@
+sources:
+  - description: M4Bench OASIS raw-table task instruction and bundled task skills
+    files:
+      - task.toml
+      - instruction.md
+      - skills/oasis-score/SKILL.md
+      - skills-nosql/oasis-score/SKILL.md
+      - skills-rawsql/mimic-oasis-24h-raw/SKILL.md
+      - skills-decoy/apsiii-score/SKILL.md
+
+created:
+  by: m4bench task authoring
+  role: benchmark-task-construction
+  date: 2026-05-03
+
+reviews:
+  - by: Ryohei Kobayashi-Yamamoto, MD
+    date: 2026-05-03
+    scope: clinical-accuracy, task-instruction-consistency
+    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+
+references: []
+
+changelog:
+  - version: "1.0"
+    date: 2026-05-03
+    summary: Added provenance record for clinician review of M4Bench task materials.

--- a/benchmark/tasks/oasis/mimic-oasis-24h/PROVENANCE.yaml
+++ b/benchmark/tasks/oasis/mimic-oasis-24h/PROVENANCE.yaml
@@ -1,0 +1,27 @@
+sources:
+  - description: M4Bench OASIS task instruction and bundled task skills
+    files:
+      - task.toml
+      - instruction.md
+      - skills/oasis-score/SKILL.md
+      - skills-nosql/oasis-score/SKILL.md
+      - skills-rawsql/mimic-oasis-24h/SKILL.md
+      - skills-decoy/apsiii-score/SKILL.md
+
+created:
+  by: m4bench task authoring
+  role: benchmark-task-construction
+  date: 2026-05-03
+
+reviews:
+  - by: Ryohei Kobayashi-Yamamoto, MD
+    date: 2026-05-03
+    scope: clinical-accuracy, task-instruction-consistency
+    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+
+references: []
+
+changelog:
+  - version: "1.0"
+    date: 2026-05-03
+    summary: Added provenance record for clinician review of M4Bench task materials.

--- a/benchmark/tasks/oasis/mimic-oasis-24h/PROVENANCE.yaml
+++ b/benchmark/tasks/oasis/mimic-oasis-24h/PROVENANCE.yaml
@@ -11,17 +11,17 @@ sources:
 created:
   by: m4bench task authoring
   role: benchmark-task-construction
-  date: 2026-05-03
+  date: unknown
 
 reviews:
   - by: Ryohei Kobayashi-Yamamoto, MD
     date: 2026-05-03
     scope: clinical-accuracy, task-instruction-consistency
-    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+    notes: Reviewed instruction.md and bundled skill files, including OASIS score and decoy APS III skill, for clinical accuracy, task alignment, and benchmark suitability. No major clinical concerns identified.
 
 references: []
 
 changelog:
   - version: "1.0"
     date: 2026-05-03
-    summary: Added provenance record for clinician review of M4Bench task materials.
+    summary: Added draft provenance record for M4Bench task review; original task creation date not verified.

--- a/benchmark/tasks/sapsii/mimic-sapsii-24h-raw/PROVENANCE.yaml
+++ b/benchmark/tasks/sapsii/mimic-sapsii-24h-raw/PROVENANCE.yaml
@@ -1,0 +1,27 @@
+sources:
+  - description: M4Bench SAPS II raw-table task instruction and bundled task skills
+    files:
+      - task.toml
+      - instruction.md
+      - skills/sapsii-score/SKILL.md
+      - skills-nosql/sapsii-score/SKILL.md
+      - skills-rawsql/mimic-sapsii-24h-raw/SKILL.md
+      - skills-decoy/oasis-score/SKILL.md
+
+created:
+  by: m4bench task authoring
+  role: benchmark-task-construction
+  date: 2026-05-03
+
+reviews:
+  - by: Ryohei Kobayashi-Yamamoto, MD
+    date: 2026-05-03
+    scope: clinical-accuracy, task-instruction-consistency
+    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+
+references: []
+
+changelog:
+  - version: "1.0"
+    date: 2026-05-03
+    summary: Added provenance record for clinician review of M4Bench task materials.

--- a/benchmark/tasks/sapsii/mimic-sapsii-24h-raw/PROVENANCE.yaml
+++ b/benchmark/tasks/sapsii/mimic-sapsii-24h-raw/PROVENANCE.yaml
@@ -11,17 +11,17 @@ sources:
 created:
   by: m4bench task authoring
   role: benchmark-task-construction
-  date: 2026-05-03
+  date: unknown
 
 reviews:
   - by: Ryohei Kobayashi-Yamamoto, MD
     date: 2026-05-03
     scope: clinical-accuracy, task-instruction-consistency
-    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+    notes: Reviewed instruction.md and bundled skill files, including SAPS II score and decoy OASIS skill, for clinical accuracy, task alignment, and benchmark suitability. No major clinical concerns identified.
 
 references: []
 
 changelog:
   - version: "1.0"
     date: 2026-05-03
-    summary: Added provenance record for clinician review of M4Bench task materials.
+    summary: Added draft provenance record for M4Bench task review; original task creation date not verified.

--- a/benchmark/tasks/sapsii/mimic-sapsii-24h/PROVENANCE.yaml
+++ b/benchmark/tasks/sapsii/mimic-sapsii-24h/PROVENANCE.yaml
@@ -1,0 +1,27 @@
+sources:
+  - description: M4Bench SAPS II task instruction and bundled task skills
+    files:
+      - task.toml
+      - instruction.md
+      - skills/sapsii-score/SKILL.md
+      - skills-nosql/sapsii-score/SKILL.md
+      - skills-rawsql/mimic-sapsii-24h/SKILL.md
+      - skills-decoy/oasis-score/SKILL.md
+
+created:
+  by: m4bench task authoring
+  role: benchmark-task-construction
+  date: 2026-05-03
+
+reviews:
+  - by: Ryohei Kobayashi-Yamamoto, MD
+    date: 2026-05-03
+    scope: clinical-accuracy, task-instruction-consistency
+    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+
+references: []
+
+changelog:
+  - version: "1.0"
+    date: 2026-05-03
+    summary: Added provenance record for clinician review of M4Bench task materials.

--- a/benchmark/tasks/sapsii/mimic-sapsii-24h/PROVENANCE.yaml
+++ b/benchmark/tasks/sapsii/mimic-sapsii-24h/PROVENANCE.yaml
@@ -11,17 +11,17 @@ sources:
 created:
   by: m4bench task authoring
   role: benchmark-task-construction
-  date: 2026-05-03
+  date: unknown
 
 reviews:
   - by: Ryohei Kobayashi-Yamamoto, MD
     date: 2026-05-03
     scope: clinical-accuracy, task-instruction-consistency
-    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+    notes: Reviewed instruction.md and bundled skill files, including SAPS II score and decoy OASIS skill, for clinical accuracy, task alignment, and benchmark suitability. No major clinical concerns identified.
 
 references: []
 
 changelog:
   - version: "1.0"
     date: 2026-05-03
-    summary: Added provenance record for clinician review of M4Bench task materials.
+    summary: Added draft provenance record for M4Bench task review; original task creation date not verified.

--- a/benchmark/tasks/sepsis3/mimic-sepsis3-raw/PROVENANCE.yaml
+++ b/benchmark/tasks/sepsis3/mimic-sepsis3-raw/PROVENANCE.yaml
@@ -15,17 +15,20 @@ sources:
 created:
   by: m4bench task authoring
   role: benchmark-task-construction
-  date: 2026-05-03
+  date: unknown
 
 reviews:
   - by: Ryohei Kobayashi-Yamamoto, MD
     date: 2026-05-03
     scope: clinical-accuracy, task-instruction-consistency
-    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+    notes: Reviewed instruction.md and bundled skill files, including SOFA, suspicion-of-infection, Sepsis-3 cohort, and decoy KDIGO skill, for clinical accuracy, task alignment, and benchmark suitability. The task is clinically coherent and aligned with the Sepsis-3 operational definition; no major clinical concerns identified. Minor note: ICU-only framing reflects the M4Bench/MIMIC implementation rather than the conceptual Sepsis-3 definition itself.
 
-references: []
+references:
+  - "Singer M et al. The Third International Consensus Definitions for Sepsis and Septic Shock (Sepsis-3). JAMA. 2016;315(8):801-810."
+  - "Seymour CW et al. Assessment of Clinical Criteria for Sepsis. JAMA. 2016;315(8):762-774."
+  - "Shankar-Hari M et al. Developing a New Definition and Assessing New Clinical Criteria for Septic Shock. JAMA. 2016;315(8):775-787."
 
 changelog:
   - version: "1.0"
     date: 2026-05-03
-    summary: Added provenance record for clinician review of M4Bench task materials.
+    summary: Added provenance record for clinician review of M4Bench Sepsis-3 task materials; original task creation date not verified.

--- a/benchmark/tasks/sepsis3/mimic-sepsis3-raw/PROVENANCE.yaml
+++ b/benchmark/tasks/sepsis3/mimic-sepsis3-raw/PROVENANCE.yaml
@@ -1,0 +1,31 @@
+sources:
+  - description: M4Bench Sepsis-3 raw-table task instruction and bundled task skills
+    files:
+      - task.toml
+      - instruction.md
+      - skills/sepsis-3-cohort/SKILL.md
+      - skills/sofa-score/SKILL.md
+      - skills/suspicion-of-infection/SKILL.md
+      - skills-nosql/sepsis-3-cohort/SKILL.md
+      - skills-nosql/sofa-score/SKILL.md
+      - skills-nosql/suspicion-of-infection/SKILL.md
+      - skills-rawsql/mimic-sepsis3-raw/SKILL.md
+      - skills-decoy/kdigo-aki-staging/SKILL.md
+
+created:
+  by: m4bench task authoring
+  role: benchmark-task-construction
+  date: 2026-05-03
+
+reviews:
+  - by: Ryohei Kobayashi-Yamamoto, MD
+    date: 2026-05-03
+    scope: clinical-accuracy, task-instruction-consistency
+    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+
+references: []
+
+changelog:
+  - version: "1.0"
+    date: 2026-05-03
+    summary: Added provenance record for clinician review of M4Bench task materials.

--- a/benchmark/tasks/sepsis3/mimic-sepsis3-raw/PROVENANCE.yaml
+++ b/benchmark/tasks/sepsis3/mimic-sepsis3-raw/PROVENANCE.yaml
@@ -21,7 +21,14 @@ reviews:
   - by: Ryohei Kobayashi-Yamamoto, MD
     date: 2026-05-03
     scope: clinical-accuracy, task-instruction-consistency
-    notes: Reviewed instruction.md and bundled skill files, including SOFA, suspicion-of-infection, Sepsis-3 cohort, and decoy KDIGO skill, for clinical accuracy, task alignment, and benchmark suitability. The task is clinically coherent and aligned with the Sepsis-3 operational definition; no major clinical concerns identified. Minor note: ICU-only framing reflects the M4Bench/MIMIC implementation rather than the conceptual Sepsis-3 definition itself.
+    notes: >
+      Reviewed instruction.md and bundled skill files, including SOFA,
+      suspicion-of-infection, Sepsis-3 cohort, and decoy KDIGO skill, for
+      clinical accuracy, task alignment, and benchmark suitability. The task is
+      clinically coherent and aligned with the Sepsis-3 operational definition;
+      no major clinical concerns identified. Minor note: ICU-only framing
+      reflects the M4Bench/MIMIC implementation rather than the conceptual
+      Sepsis-3 definition itself.
 
 references:
   - "Singer M et al. The Third International Consensus Definitions for Sepsis and Septic Shock (Sepsis-3). JAMA. 2016;315(8):801-810."

--- a/benchmark/tasks/sirs/mimic-sirs-24h-raw/PROVENANCE.yaml
+++ b/benchmark/tasks/sirs/mimic-sirs-24h-raw/PROVENANCE.yaml
@@ -11,17 +11,17 @@ sources:
 created:
   by: m4bench task authoring
   role: benchmark-task-construction
-  date: 2026-05-03
+  date: unknown
 
 reviews:
   - by: Ryohei Kobayashi-Yamamoto, MD
     date: 2026-05-03
     scope: clinical-accuracy, task-instruction-consistency
-    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+    notes: Reviewed instruction.md and bundled skill files, including SIRS criteria and decoy MELD skill, for clinical accuracy, task alignment, and benchmark suitability. No major clinical concerns identified.
 
 references: []
 
 changelog:
   - version: "1.0"
     date: 2026-05-03
-    summary: Added provenance record for clinician review of M4Bench task materials.
+    summary: Added draft provenance record for M4Bench task review; original task creation date not verified.

--- a/benchmark/tasks/sirs/mimic-sirs-24h-raw/PROVENANCE.yaml
+++ b/benchmark/tasks/sirs/mimic-sirs-24h-raw/PROVENANCE.yaml
@@ -1,0 +1,27 @@
+sources:
+  - description: M4Bench SIRS raw-table task instruction and bundled task skills
+    files:
+      - task.toml
+      - instruction.md
+      - skills/sirs-criteria/SKILL.md
+      - skills-nosql/sirs-criteria/SKILL.md
+      - skills-rawsql/mimic-sirs-24h-raw/SKILL.md
+      - skills-decoy/meld-score/SKILL.md
+
+created:
+  by: m4bench task authoring
+  role: benchmark-task-construction
+  date: 2026-05-03
+
+reviews:
+  - by: Ryohei Kobayashi-Yamamoto, MD
+    date: 2026-05-03
+    scope: clinical-accuracy, task-instruction-consistency
+    notes: Reviewed instruction.md and bundled skill files for clinical accuracy, task alignment, and consistency between task requirements and skill guidance.
+
+references: []
+
+changelog:
+  - version: "1.0"
+    date: 2026-05-03
+    summary: Added provenance record for clinician review of M4Bench task materials.


### PR DESCRIPTION
## Summary

Adds PROVENANCE.yaml records for reviewed M4Bench task directories assigned to Ryohei Kobayashi-Yamamoto, MD:

- MELD
- OASIS
- SAPS II
- Sepsis-3
- SIRS

The records document reviewed task materials, review scope, reviewer identity, and task-specific notes. MELD and Sepsis-3 provenance files also include supporting references.

## Validation

- Confirmed 9 PROVENANCE.yaml files are present.
- Confirmed no pending review markers remain.
- Confirmed the branch contains provenance file updates only relative to m4bench.