### PR TITLE
Expand OASIS skill cutoff specification

### DIFF
--- a/benchmark/tasks/oasis/eicu-oasis/skills-nosql/oasis-score/SKILL.md
+++ b/benchmark/tasks/oasis/eicu-oasis/skills-nosql/oasis-score/SKILL.md
@@ -128,8 +128,8 @@ first 24 h.
 
 | Status | Score |
 |---|---|
-| Elective admission AND surgical service | 0 |
-| All other admissions | 6 |
+| eICU/APACHE elective-surgery signal present and not admitted from ED | 0 |
+| Non-elective, ED-source, missing elective-surgery signal, or otherwise non-elective | 6 |
 
 The OASIS total is the sum of the 10 component scores. Report the component
 scores alongside the total so implementation differences are auditable.
@@ -162,10 +162,10 @@ distinction.
 2. **Mechanical Ventilation**: Any invasive ventilation during the first
    24 hours scores 9 points; otherwise 0.
 
-3. **Elective Surgery**: Requires BOTH an elective admission type AND a
-   surgical service assignment (identified from the first service
-   transfer). Scoring direction matters: elective surgical admissions
-   score **0** points; all other stays score **6** points.
+3. **Elective Surgery**: Follows the eICU/APACHE fields used by the
+   M4Bench/eICU labels. Stays with an elective-surgery signal and no ED-source
+   admission score **0** points; ED-source, non-elective, missing, or otherwise
+   non-elective stays score **6** points.
 
 4. **Missing Data Handling**: Per task instruction, treat missing data
    as normal (score 0). When a component cannot be computed because the

--- a/benchmark/tasks/oasis/eicu-oasis/skills-nosql/oasis-score/SKILL.md
+++ b/benchmark/tasks/oasis/eicu-oasis/skills-nosql/oasis-score/SKILL.md
@@ -23,10 +23,12 @@ In M4Bench, target concept tables listed in the task configuration are removed o
 
 ## Score Components (First 24 Hours)
 
-OASIS sums 10 component scores. The cutoffs below are the authoritative
-specification (Johnson AEW et al., *Crit Care Med* 2013, Table 2). For
-continuous variables, evaluate using the worst-direction observation in
-the first 24 h (see "Direction-aware Scoring" below).
+OASIS sums 10 component scores. The cutoffs below are aligned with the
+M4Bench/eICU labels, which follow the eICU implementation adapted from Johnson
+AEW et al. (*Crit Care Med* 2013, Table 2). For min/max-bound continuous
+variables, use the eICU evaluation order shown below because first-match
+ordering affects component labels when both low and high extremes occur in the
+first 24 h.
 
 ### Pre-ICU Length of Stay
 
@@ -57,57 +59,63 @@ the first 24 h (see "Direction-aware Scoring" below).
 | 14 | 3 |
 | 15 | 0 |
 
-### Heart Rate (min⁻¹)
+### Heart Rate (min^-1)
 
-| Bin | Score |
-|---|---|
-| min < 33 | 4 |
-| 33 – 88 | 0 |
-| max 89 – 106 | 1 |
-| max 107 – 125 | 3 |
-| max > 125 | 6 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | min < 33 | 4 |
+| 2 | max 33-88 | 0 |
+| 3 | max 89-106 | 1 |
+| 4 | max 107-125 | 3 |
+| 5 | max > 125 | 6 |
 
 ### Mean Arterial Pressure (mmHg)
 
-| Bin | Score |
-|---|---|
-| min < 20.65 | 4 |
-| min 20.65 – 50.99 | 3 |
-| min 51 – 61.32 | 2 |
-| 61.33 – 143.44 | 0 |
-| max > 143.44 | 3 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | invasive min < 20.65 | 4 |
+| 2 | invasive min 20.65-50.99 | 3 |
+| 3 | invasive min 51-61.32 | 2 |
+| 4 | invasive min 61.33-143.44 | 0 |
+| 5 | invasive max > 143.44 | 3 |
+| 6 | noninvasive min < 20.65 | 4 |
+| 7 | noninvasive min 20.65-50.99 | 3 |
+| 8 | noninvasive min 51-61.32 | 2 |
+| 9 | noninvasive min 61.33-143.44 | 0 |
+| 10 | noninvasive max > 143.44 | 3 |
 
-### Respiratory Rate (min⁻¹)
+### Respiratory Rate (min^-1)
 
-| Bin | Score |
-|---|---|
-| min < 6 | 10 |
-| min 6 – 12 | 1 |
-| 13 – 22 | 0 |
-| max 23 – 30 | 1 |
-| max 31 – 44 | 6 |
-| max > 44 | 9 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | min < 6 | 10 |
+| 2 | min 6-12 | 1 |
+| 3 | min 13-22 | 0 |
+| 4 | max 23-30 | 1 |
+| 5 | max 31-44 | 6 |
+| 6 | max > 44 | 9 |
 
-### Temperature (°C)
+### Temperature (deg C)
 
-| Bin | Score |
-|---|---|
-| min < 33.22 | 3 |
-| min or max 33.22 – 35.93 | 4 |
-| min 35.94 – 36.39 | 2 |
-| max 36.40 – 36.88 | 0 |
-| max 36.89 – 39.88 | 2 |
-| max > 39.88 | 6 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | min < 33.22 | 3 |
+| 2 | min 33.22-35.93 | 4 |
+| 3 | max 33.22-35.93 | 4 |
+| 4 | min 35.94-36.39 | 2 |
+| 5 | max 36.40-36.88 | 0 |
+| 6 | max 36.89-39.88 | 2 |
+| 7 | max > 39.88 | 6 |
 
 ### Urine Output (mL/day)
 
-| Range | Score |
-|---|---|
-| < 671 | 10 |
-| 671 – 1426.99 | 5 |
-| 1427 – 2543.99 | 1 |
-| 2544 – 6896 | 0 |
-| > 6896 | 8 |
+| Evaluation order | Range | Score |
+|---|---|---|
+| 1 | < 671 | 10 |
+| 2 | 671-1426.99 | 5 |
+| 3 | 1427-2543.99 | 1 |
+| 4 | 2544-6896 | 0 |
+| 5 | > 6896 | 8 |
 
 ### Mechanical Ventilation
 
@@ -126,16 +134,21 @@ the first 24 h (see "Direction-aware Scoring" below).
 The OASIS total is the sum of the 10 component scores. Report the component
 scores alongside the total so implementation differences are auditable.
 
-## Direction-aware Scoring (min vs max)
+## Direction-aware Scoring (eICU labels)
 
-For Heart Rate, MAP, Respiratory Rate, and Temperature, OASIS uses the
-worst-direction observation in the first 24 h:
+For the eICU OASIS task, follow the eICU-code evaluation order in the tables
+above. This ordering is intentionally dataset-specific and differs from the
+MIMIC OASIS task labels: if both a low and high extreme occur in the same
+first-24h window, the first matching row in the component table wins.
 
-- Test the **min** observation against the low-extreme bin first.
-- Test the **max** observation against the high-extreme bins next.
-- The first matching bin wins; do not sum or average across bins.
-- Temperature uniquely allows either min or max to satisfy the
-  33.22 – 35.93 °C bin (4 points); test both.
+Key conflict rules for eICU labels:
+
+- Heart rate checks the low extreme first, then high-heart-rate bins.
+- MAP checks invasive BP mean first; noninvasive BP mean is used only if no
+  invasive BP bin matches.
+- Respiratory rate checks low/normal bins before high respiratory-rate bins.
+- Temperature checks low-temperature bins before fever.
+- Urine output uses the eICU boundaries shown above.
 
 GCS uses the worst (minimum) value only. Pre-ICU LOS, Age, Urine Output,
 Mechanical Ventilation, and Elective Surgery are scalar — no min/max

--- a/benchmark/tasks/oasis/eicu-oasis/skills-nosql/oasis-score/SKILL.md
+++ b/benchmark/tasks/oasis/eicu-oasis/skills-nosql/oasis-score/SKILL.md
@@ -23,56 +23,175 @@ In M4Bench, target concept tables listed in the task configuration are removed o
 
 ## Score Components (First 24 Hours)
 
-| Variable | Range | Points |
-|----------|-------|--------|
-| Age | <24 to >=90 | 0-9 |
-| Pre-ICU LOS | <10 min to >=18708 min | 0-5 |
-| GCS | <=7 to >=15 | 0-10 |
-| Heart Rate | <33 to >125 | 0-6 |
-| Mean BP | <20.65 to >143.44 | 0-4 |
-| Respiratory Rate | <6 to >44 | 0-10 |
-| Temperature | <33.22 to >39.88 C | 0-6 |
-| Urine Output | <671 to >6897 mL/day | 0-10 |
-| Mechanical Ventilation | Yes/No | 0 or 9 |
-| Elective Surgery | Yes/No | 0 for elective surgical admissions, 6 otherwise |
+OASIS sums 10 component scores. The cutoffs below are the authoritative
+specification (Johnson AEW et al., *Crit Care Med* 2013, Table 2). For
+continuous variables, evaluate using the worst-direction observation in
+the first 24 h (see "Direction-aware Scoring" below).
+
+### Pre-ICU Length of Stay
+
+| Range (hours) | In minutes | Score |
+|---|---|---|
+| < 0.17 | < 10.2 | 5 |
+| 0.17 – 4.94 | 10.2 – 296.4 | 3 |
+| 4.95 – 24.00 | 297.0 – 1440.0 | 0 |
+| 24.01 – 311.80 | 1440.6 – 18708.0 | 2 |
+| > 311.80 | > 18708 | 1 |
+
+### Age (years)
+
+| Range | Score |
+|---|---|
+| < 24 | 0 |
+| 24 – 53 | 3 |
+| 54 – 77 | 6 |
+| 78 – 89 | 9 |
+| ≥ 90 | 7 |
+
+### Glasgow Coma Score (worst observation)
+
+| Range | Score |
+|---|---|
+| 3 – 7 | 10 |
+| 8 – 13 | 4 |
+| 14 | 3 |
+| 15 | 0 |
+
+### Heart Rate (min⁻¹)
+
+| Bin | Score |
+|---|---|
+| min < 33 | 4 |
+| 33 – 88 | 0 |
+| max 89 – 106 | 1 |
+| max 107 – 125 | 3 |
+| max > 125 | 6 |
+
+### Mean Arterial Pressure (mmHg)
+
+| Bin | Score |
+|---|---|
+| min < 20.65 | 4 |
+| min 20.65 – 50.99 | 3 |
+| min 51 – 61.32 | 2 |
+| 61.33 – 143.44 | 0 |
+| max > 143.44 | 3 |
+
+### Respiratory Rate (min⁻¹)
+
+| Bin | Score |
+|---|---|
+| min < 6 | 10 |
+| min 6 – 12 | 1 |
+| 13 – 22 | 0 |
+| max 23 – 30 | 1 |
+| max 31 – 44 | 6 |
+| max > 44 | 9 |
+
+### Temperature (°C)
+
+| Bin | Score |
+|---|---|
+| min < 33.22 | 3 |
+| min or max 33.22 – 35.93 | 4 |
+| min 35.94 – 36.39 | 2 |
+| max 36.40 – 36.88 | 0 |
+| max 36.89 – 39.88 | 2 |
+| max > 39.88 | 6 |
+
+### Urine Output (mL/day)
+
+| Range | Score |
+|---|---|
+| < 671 | 10 |
+| 671 – 1426.99 | 5 |
+| 1427 – 2543.99 | 1 |
+| 2544 – 6896 | 0 |
+| > 6896 | 8 |
+
+### Mechanical Ventilation
+
+| Status | Score |
+|---|---|
+| No | 0 |
+| Yes (any invasive ventilation in 24 h) | 9 |
+
+### Elective Surgery
+
+| Status | Score |
+|---|---|
+| Elective admission AND surgical service | 0 |
+| All other admissions | 6 |
 
 The OASIS total is the sum of the 10 component scores. Report the component
 scores alongside the total so implementation differences are auditable.
 
+## Direction-aware Scoring (min vs max)
+
+For Heart Rate, MAP, Respiratory Rate, and Temperature, OASIS uses the
+worst-direction observation in the first 24 h:
+
+- Test the **min** observation against the low-extreme bin first.
+- Test the **max** observation against the high-extreme bins next.
+- The first matching bin wins; do not sum or average across bins.
+- Temperature uniquely allows either min or max to satisfy the
+  33.22 – 35.93 °C bin (4 points); test both.
+
+GCS uses the worst (minimum) value only. Pre-ICU LOS, Age, Urine Output,
+Mechanical Ventilation, and Elective Surgery are scalar — no min/max
+distinction.
+
 ## Critical Implementation Notes
 
-1. **No Laboratory Values Required**: OASIS uses only vital signs, urine output, and administrative data - no labs needed.
+1. **No Laboratory Values Required**: OASIS uses only vital signs, urine
+   output, and administrative data — no labs needed.
 
-2. **Pre-ICU LOS Scoring**: Time from hospital admission to ICU admission in minutes. Scoring is non-linear:
-   - < 10.2 min: 5 points (immediate ICU)
-   - 10.2-297 min: 3 points
-   - 297-1440 min: 0 points (optimal)
-   - 1440-18708 min: 2 points
-   - > 18708 min: 1 point
+2. **Mechanical Ventilation**: Any invasive ventilation during the first
+   24 hours scores 9 points; otherwise 0.
 
-3. **Mechanical Ventilation**: Binary flag - any invasive ventilation during first 24 hours scores 9 points.
+3. **Elective Surgery**: Requires BOTH an elective admission type AND a
+   surgical service assignment (identified from the first service
+   transfer). Scoring direction matters: elective surgical admissions
+   score **0** points; all other stays score **6** points.
 
-4. **Elective Surgery**: Requires BOTH:
-   - Elective admission type AND
-   - Surgical service (identified from first service transfer)
-   - **Scoring direction matters**: elective surgical admissions score **0**
-     points; all other stays score **6** points
+4. **Missing Data Handling**: Per task instruction, treat missing data
+   as normal (score 0). When a component cannot be computed because the
+   underlying observation is absent, score that component as 0 before
+   summing. Output ALL ICU stays in the result, even those missing some
+   or all source measurements.
+   - Special case: the ventilation indicator is binary (yes/no) — absence
+     of any ventilation record is interpreted as "no ventilation",
+     contributing 0 points (not missing).
 
-5. **Ventilation Flag Cannot Be Missing**: Unlike other components, ventilation defaults to 0 (no ventilation) if no data found.
+## Mortality Probability
 
-6. **Mortality Probability**:
-   ```
-   oasis_prob = 1 / (1 + exp(-(-6.1746 + 0.1275 * oasis)))
-   ```
+OASIS predicts in-hospital mortality through a logistic model
+(Johnson et al. 2013):
 
-## Benchmark Implementation Notes
+```
+oasis_prob = 1 / (1 + exp(-(-6.1746 + 0.1275 * oasis)))
+```
 
-- In the **standard** MIMIC task, use available first-day vitals, GCS, urine
-  output, ventilation, admissions, and service-transfer information.
-- In the **raw** MIMIC task, derive the same components from base ICU/hospital
-  tables.
-- In the **eICU** task, use eICU-native tables and keep the same scoring logic;
-  do not assume MIMIC table names are present.
+This probability is informational only and is not required by the M4Bench
+output schema for this task.
+
+## Source Data Required
+
+OASIS requires the following clinical/administrative data per ICU stay:
+
+- ICU admission and discharge times; hospital admission time (for pre-ICU LOS)
+- Admission type (elective vs non-elective)
+- Service or specialty assignment at the time of ICU admission (to identify
+  surgical admissions)
+- Patient age at admission
+- First 24-hour vital signs: heart rate (min, max), mean arterial pressure
+  (min, max), respiratory rate (min, max), temperature (min, max)
+- First 24-hour Glasgow Coma Score (worst observation)
+- First 24-hour urine output total
+- Invasive mechanical ventilation status during the first 24 hours
+- Note: when the database represents pre-ICU LOS as a signed offset from
+  ICU admission (e.g., negative minutes back to hospital admission), take
+  its absolute value before applying the scoring bins above.
 
 ## Advantages Over APACHE/SAPS
 
@@ -83,4 +202,4 @@ scores alongside the total so implementation differences are auditable.
 
 ## References
 
-- Johnson AEW, Kramer AA, Clifford GD. "A new severity of illness scale using a subset of Acute Physiology And Chronic Health Evaluation data elements shows comparable predictive accuracy." Critical Care Medicine. 2013;41(7):1711-1718.
+- Johnson AEW, Kramer AA, Clifford GD. "A new severity of illness scale using a subset of Acute Physiology And Chronic Health Evaluation data elements shows comparable predictive accuracy." *Critical Care Medicine*. 2013;41(7):1711-1718.

--- a/benchmark/tasks/oasis/eicu-oasis/skills/oasis-score/SKILL.md
+++ b/benchmark/tasks/oasis/eicu-oasis/skills/oasis-score/SKILL.md
@@ -128,8 +128,8 @@ first 24 h.
 
 | Status | Score |
 |---|---|
-| Elective admission AND surgical service | 0 |
-| All other admissions | 6 |
+| eICU/APACHE elective-surgery signal present and not admitted from ED | 0 |
+| Non-elective, ED-source, missing elective-surgery signal, or otherwise non-elective | 6 |
 
 The OASIS total is the sum of the 10 component scores. Report the component
 scores alongside the total so implementation differences are auditable.
@@ -162,10 +162,10 @@ distinction.
 2. **Mechanical Ventilation**: Any invasive ventilation during the first
    24 hours scores 9 points; otherwise 0.
 
-3. **Elective Surgery**: Requires BOTH an elective admission type AND a
-   surgical service assignment (identified from the first service
-   transfer). Scoring direction matters: elective surgical admissions
-   score **0** points; all other stays score **6** points.
+3. **Elective Surgery**: Follows the eICU/APACHE fields used by the
+   M4Bench/eICU labels. Stays with an elective-surgery signal and no ED-source
+   admission score **0** points; ED-source, non-elective, missing, or otherwise
+   non-elective stays score **6** points.
 
 4. **Missing Data Handling**: Per task instruction, treat missing data
    as normal (score 0). When a component cannot be computed because the

--- a/benchmark/tasks/oasis/eicu-oasis/skills/oasis-score/SKILL.md
+++ b/benchmark/tasks/oasis/eicu-oasis/skills/oasis-score/SKILL.md
@@ -23,10 +23,12 @@ In M4Bench, target concept tables listed in the task configuration are removed o
 
 ## Score Components (First 24 Hours)
 
-OASIS sums 10 component scores. The cutoffs below are the authoritative
-specification (Johnson AEW et al., *Crit Care Med* 2013, Table 2). For
-continuous variables, evaluate using the worst-direction observation in
-the first 24 h (see "Direction-aware Scoring" below).
+OASIS sums 10 component scores. The cutoffs below are aligned with the
+M4Bench/eICU labels, which follow the eICU implementation adapted from Johnson
+AEW et al. (*Crit Care Med* 2013, Table 2). For min/max-bound continuous
+variables, use the eICU evaluation order shown below because first-match
+ordering affects component labels when both low and high extremes occur in the
+first 24 h.
 
 ### Pre-ICU Length of Stay
 
@@ -57,57 +59,63 @@ the first 24 h (see "Direction-aware Scoring" below).
 | 14 | 3 |
 | 15 | 0 |
 
-### Heart Rate (min⁻¹)
+### Heart Rate (min^-1)
 
-| Bin | Score |
-|---|---|
-| min < 33 | 4 |
-| 33 – 88 | 0 |
-| max 89 – 106 | 1 |
-| max 107 – 125 | 3 |
-| max > 125 | 6 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | min < 33 | 4 |
+| 2 | max 33-88 | 0 |
+| 3 | max 89-106 | 1 |
+| 4 | max 107-125 | 3 |
+| 5 | max > 125 | 6 |
 
 ### Mean Arterial Pressure (mmHg)
 
-| Bin | Score |
-|---|---|
-| min < 20.65 | 4 |
-| min 20.65 – 50.99 | 3 |
-| min 51 – 61.32 | 2 |
-| 61.33 – 143.44 | 0 |
-| max > 143.44 | 3 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | invasive min < 20.65 | 4 |
+| 2 | invasive min 20.65-50.99 | 3 |
+| 3 | invasive min 51-61.32 | 2 |
+| 4 | invasive min 61.33-143.44 | 0 |
+| 5 | invasive max > 143.44 | 3 |
+| 6 | noninvasive min < 20.65 | 4 |
+| 7 | noninvasive min 20.65-50.99 | 3 |
+| 8 | noninvasive min 51-61.32 | 2 |
+| 9 | noninvasive min 61.33-143.44 | 0 |
+| 10 | noninvasive max > 143.44 | 3 |
 
-### Respiratory Rate (min⁻¹)
+### Respiratory Rate (min^-1)
 
-| Bin | Score |
-|---|---|
-| min < 6 | 10 |
-| min 6 – 12 | 1 |
-| 13 – 22 | 0 |
-| max 23 – 30 | 1 |
-| max 31 – 44 | 6 |
-| max > 44 | 9 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | min < 6 | 10 |
+| 2 | min 6-12 | 1 |
+| 3 | min 13-22 | 0 |
+| 4 | max 23-30 | 1 |
+| 5 | max 31-44 | 6 |
+| 6 | max > 44 | 9 |
 
-### Temperature (°C)
+### Temperature (deg C)
 
-| Bin | Score |
-|---|---|
-| min < 33.22 | 3 |
-| min or max 33.22 – 35.93 | 4 |
-| min 35.94 – 36.39 | 2 |
-| max 36.40 – 36.88 | 0 |
-| max 36.89 – 39.88 | 2 |
-| max > 39.88 | 6 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | min < 33.22 | 3 |
+| 2 | min 33.22-35.93 | 4 |
+| 3 | max 33.22-35.93 | 4 |
+| 4 | min 35.94-36.39 | 2 |
+| 5 | max 36.40-36.88 | 0 |
+| 6 | max 36.89-39.88 | 2 |
+| 7 | max > 39.88 | 6 |
 
 ### Urine Output (mL/day)
 
-| Range | Score |
-|---|---|
-| < 671 | 10 |
-| 671 – 1426.99 | 5 |
-| 1427 – 2543.99 | 1 |
-| 2544 – 6896 | 0 |
-| > 6896 | 8 |
+| Evaluation order | Range | Score |
+|---|---|---|
+| 1 | < 671 | 10 |
+| 2 | 671-1426.99 | 5 |
+| 3 | 1427-2543.99 | 1 |
+| 4 | 2544-6896 | 0 |
+| 5 | > 6896 | 8 |
 
 ### Mechanical Ventilation
 
@@ -126,16 +134,21 @@ the first 24 h (see "Direction-aware Scoring" below).
 The OASIS total is the sum of the 10 component scores. Report the component
 scores alongside the total so implementation differences are auditable.
 
-## Direction-aware Scoring (min vs max)
+## Direction-aware Scoring (eICU labels)
 
-For Heart Rate, MAP, Respiratory Rate, and Temperature, OASIS uses the
-worst-direction observation in the first 24 h:
+For the eICU OASIS task, follow the eICU-code evaluation order in the tables
+above. This ordering is intentionally dataset-specific and differs from the
+MIMIC OASIS task labels: if both a low and high extreme occur in the same
+first-24h window, the first matching row in the component table wins.
 
-- Test the **min** observation against the low-extreme bin first.
-- Test the **max** observation against the high-extreme bins next.
-- The first matching bin wins; do not sum or average across bins.
-- Temperature uniquely allows either min or max to satisfy the
-  33.22 – 35.93 °C bin (4 points); test both.
+Key conflict rules for eICU labels:
+
+- Heart rate checks the low extreme first, then high-heart-rate bins.
+- MAP checks invasive BP mean first; noninvasive BP mean is used only if no
+  invasive BP bin matches.
+- Respiratory rate checks low/normal bins before high respiratory-rate bins.
+- Temperature checks low-temperature bins before fever.
+- Urine output uses the eICU boundaries shown above.
 
 GCS uses the worst (minimum) value only. Pre-ICU LOS, Age, Urine Output,
 Mechanical Ventilation, and Elective Surgery are scalar — no min/max

--- a/benchmark/tasks/oasis/eicu-oasis/skills/oasis-score/SKILL.md
+++ b/benchmark/tasks/oasis/eicu-oasis/skills/oasis-score/SKILL.md
@@ -23,56 +23,175 @@ In M4Bench, target concept tables listed in the task configuration are removed o
 
 ## Score Components (First 24 Hours)
 
-| Variable | Range | Points |
-|----------|-------|--------|
-| Age | <24 to >=90 | 0-9 |
-| Pre-ICU LOS | <10 min to >=18708 min | 0-5 |
-| GCS | <=7 to >=15 | 0-10 |
-| Heart Rate | <33 to >125 | 0-6 |
-| Mean BP | <20.65 to >143.44 | 0-4 |
-| Respiratory Rate | <6 to >44 | 0-10 |
-| Temperature | <33.22 to >39.88 C | 0-6 |
-| Urine Output | <671 to >6897 mL/day | 0-10 |
-| Mechanical Ventilation | Yes/No | 0 or 9 |
-| Elective Surgery | Yes/No | 0 for elective surgical admissions, 6 otherwise |
+OASIS sums 10 component scores. The cutoffs below are the authoritative
+specification (Johnson AEW et al., *Crit Care Med* 2013, Table 2). For
+continuous variables, evaluate using the worst-direction observation in
+the first 24 h (see "Direction-aware Scoring" below).
+
+### Pre-ICU Length of Stay
+
+| Range (hours) | In minutes | Score |
+|---|---|---|
+| < 0.17 | < 10.2 | 5 |
+| 0.17 – 4.94 | 10.2 – 296.4 | 3 |
+| 4.95 – 24.00 | 297.0 – 1440.0 | 0 |
+| 24.01 – 311.80 | 1440.6 – 18708.0 | 2 |
+| > 311.80 | > 18708 | 1 |
+
+### Age (years)
+
+| Range | Score |
+|---|---|
+| < 24 | 0 |
+| 24 – 53 | 3 |
+| 54 – 77 | 6 |
+| 78 – 89 | 9 |
+| ≥ 90 | 7 |
+
+### Glasgow Coma Score (worst observation)
+
+| Range | Score |
+|---|---|
+| 3 – 7 | 10 |
+| 8 – 13 | 4 |
+| 14 | 3 |
+| 15 | 0 |
+
+### Heart Rate (min⁻¹)
+
+| Bin | Score |
+|---|---|
+| min < 33 | 4 |
+| 33 – 88 | 0 |
+| max 89 – 106 | 1 |
+| max 107 – 125 | 3 |
+| max > 125 | 6 |
+
+### Mean Arterial Pressure (mmHg)
+
+| Bin | Score |
+|---|---|
+| min < 20.65 | 4 |
+| min 20.65 – 50.99 | 3 |
+| min 51 – 61.32 | 2 |
+| 61.33 – 143.44 | 0 |
+| max > 143.44 | 3 |
+
+### Respiratory Rate (min⁻¹)
+
+| Bin | Score |
+|---|---|
+| min < 6 | 10 |
+| min 6 – 12 | 1 |
+| 13 – 22 | 0 |
+| max 23 – 30 | 1 |
+| max 31 – 44 | 6 |
+| max > 44 | 9 |
+
+### Temperature (°C)
+
+| Bin | Score |
+|---|---|
+| min < 33.22 | 3 |
+| min or max 33.22 – 35.93 | 4 |
+| min 35.94 – 36.39 | 2 |
+| max 36.40 – 36.88 | 0 |
+| max 36.89 – 39.88 | 2 |
+| max > 39.88 | 6 |
+
+### Urine Output (mL/day)
+
+| Range | Score |
+|---|---|
+| < 671 | 10 |
+| 671 – 1426.99 | 5 |
+| 1427 – 2543.99 | 1 |
+| 2544 – 6896 | 0 |
+| > 6896 | 8 |
+
+### Mechanical Ventilation
+
+| Status | Score |
+|---|---|
+| No | 0 |
+| Yes (any invasive ventilation in 24 h) | 9 |
+
+### Elective Surgery
+
+| Status | Score |
+|---|---|
+| Elective admission AND surgical service | 0 |
+| All other admissions | 6 |
 
 The OASIS total is the sum of the 10 component scores. Report the component
 scores alongside the total so implementation differences are auditable.
 
+## Direction-aware Scoring (min vs max)
+
+For Heart Rate, MAP, Respiratory Rate, and Temperature, OASIS uses the
+worst-direction observation in the first 24 h:
+
+- Test the **min** observation against the low-extreme bin first.
+- Test the **max** observation against the high-extreme bins next.
+- The first matching bin wins; do not sum or average across bins.
+- Temperature uniquely allows either min or max to satisfy the
+  33.22 – 35.93 °C bin (4 points); test both.
+
+GCS uses the worst (minimum) value only. Pre-ICU LOS, Age, Urine Output,
+Mechanical Ventilation, and Elective Surgery are scalar — no min/max
+distinction.
+
 ## Critical Implementation Notes
 
-1. **No Laboratory Values Required**: OASIS uses only vital signs, urine output, and administrative data - no labs needed.
+1. **No Laboratory Values Required**: OASIS uses only vital signs, urine
+   output, and administrative data — no labs needed.
 
-2. **Pre-ICU LOS Scoring**: Time from hospital admission to ICU admission in minutes. Scoring is non-linear:
-   - < 10.2 min: 5 points (immediate ICU)
-   - 10.2-297 min: 3 points
-   - 297-1440 min: 0 points (optimal)
-   - 1440-18708 min: 2 points
-   - > 18708 min: 1 point
+2. **Mechanical Ventilation**: Any invasive ventilation during the first
+   24 hours scores 9 points; otherwise 0.
 
-3. **Mechanical Ventilation**: Binary flag - any invasive ventilation during first 24 hours scores 9 points.
+3. **Elective Surgery**: Requires BOTH an elective admission type AND a
+   surgical service assignment (identified from the first service
+   transfer). Scoring direction matters: elective surgical admissions
+   score **0** points; all other stays score **6** points.
 
-4. **Elective Surgery**: Requires BOTH:
-   - Elective admission type AND
-   - Surgical service (identified from first service transfer)
-   - **Scoring direction matters**: elective surgical admissions score **0**
-     points; all other stays score **6** points
+4. **Missing Data Handling**: Per task instruction, treat missing data
+   as normal (score 0). When a component cannot be computed because the
+   underlying observation is absent, score that component as 0 before
+   summing. Output ALL ICU stays in the result, even those missing some
+   or all source measurements.
+   - Special case: the ventilation indicator is binary (yes/no) — absence
+     of any ventilation record is interpreted as "no ventilation",
+     contributing 0 points (not missing).
 
-5. **Ventilation Flag Cannot Be Missing**: Unlike other components, ventilation defaults to 0 (no ventilation) if no data found.
+## Mortality Probability
 
-6. **Mortality Probability**:
-   ```
-   oasis_prob = 1 / (1 + exp(-(-6.1746 + 0.1275 * oasis)))
-   ```
+OASIS predicts in-hospital mortality through a logistic model
+(Johnson et al. 2013):
 
-## Benchmark Implementation Notes
+```
+oasis_prob = 1 / (1 + exp(-(-6.1746 + 0.1275 * oasis)))
+```
 
-- In the **standard** MIMIC task, use available first-day vitals, GCS, urine
-  output, ventilation, admissions, and service-transfer information.
-- In the **raw** MIMIC task, derive the same components from base ICU/hospital
-  tables.
-- In the **eICU** task, use eICU-native tables and keep the same scoring logic;
-  do not assume MIMIC table names are present.
+This probability is informational only and is not required by the M4Bench
+output schema for this task.
+
+## Source Data Required
+
+OASIS requires the following clinical/administrative data per ICU stay:
+
+- ICU admission and discharge times; hospital admission time (for pre-ICU LOS)
+- Admission type (elective vs non-elective)
+- Service or specialty assignment at the time of ICU admission (to identify
+  surgical admissions)
+- Patient age at admission
+- First 24-hour vital signs: heart rate (min, max), mean arterial pressure
+  (min, max), respiratory rate (min, max), temperature (min, max)
+- First 24-hour Glasgow Coma Score (worst observation)
+- First 24-hour urine output total
+- Invasive mechanical ventilation status during the first 24 hours
+- Note: when the database represents pre-ICU LOS as a signed offset from
+  ICU admission (e.g., negative minutes back to hospital admission), take
+  its absolute value before applying the scoring bins above.
 
 ## Advantages Over APACHE/SAPS
 
@@ -83,4 +202,4 @@ scores alongside the total so implementation differences are auditable.
 
 ## References
 
-- Johnson AEW, Kramer AA, Clifford GD. "A new severity of illness scale using a subset of Acute Physiology And Chronic Health Evaluation data elements shows comparable predictive accuracy." Critical Care Medicine. 2013;41(7):1711-1718.
+- Johnson AEW, Kramer AA, Clifford GD. "A new severity of illness scale using a subset of Acute Physiology And Chronic Health Evaluation data elements shows comparable predictive accuracy." *Critical Care Medicine*. 2013;41(7):1711-1718.

--- a/benchmark/tasks/oasis/mimic-oasis-24h-raw/skills-nosql/oasis-score/SKILL.md
+++ b/benchmark/tasks/oasis/mimic-oasis-24h-raw/skills-nosql/oasis-score/SKILL.md
@@ -23,47 +23,172 @@ In M4Bench, target concept tables listed in the task configuration are removed o
 
 ## Score Components (First 24 Hours)
 
-| Variable | Range | Points |
-|----------|-------|--------|
-| Age | <24 to >=90 | 0-9 |
-| Pre-ICU LOS | <10 min to >=18708 min | 0-5 |
-| GCS | <=7 to >=15 | 0-10 |
-| Heart Rate | <33 to >125 | 0-6 |
-| Mean BP | <20.65 to >143.44 | 0-4 |
-| Respiratory Rate | <6 to >44 | 0-10 |
-| Temperature | <33.22 to >39.88 C | 0-6 |
-| Urine Output | <671 to >6897 mL/day | 0-10 |
-| Mechanical Ventilation | Yes/No | 0 or 9 |
-| Elective Surgery | Yes/No | 0 or 6 |
+OASIS sums 10 component scores. The cutoffs below are the authoritative
+specification (Johnson AEW et al., *Crit Care Med* 2013, Table 2). For
+continuous variables, evaluate using the worst-direction observation in
+the first 24 h (see "Direction-aware Scoring" below).
+
+### Pre-ICU Length of Stay
+
+| Range (hours) | In minutes | Score |
+|---|---|---|
+| < 0.17 | < 10.2 | 5 |
+| 0.17 – 4.94 | 10.2 – 296.4 | 3 |
+| 4.95 – 24.00 | 297.0 – 1440.0 | 0 |
+| 24.01 – 311.80 | 1440.6 – 18708.0 | 2 |
+| > 311.80 | > 18708 | 1 |
+
+### Age (years)
+
+| Range | Score |
+|---|---|
+| < 24 | 0 |
+| 24 – 53 | 3 |
+| 54 – 77 | 6 |
+| 78 – 89 | 9 |
+| ≥ 90 | 7 |
+
+### Glasgow Coma Score (worst observation)
+
+| Range | Score |
+|---|---|
+| 3 – 7 | 10 |
+| 8 – 13 | 4 |
+| 14 | 3 |
+| 15 | 0 |
+
+### Heart Rate (min⁻¹)
+
+| Bin | Score |
+|---|---|
+| min < 33 | 4 |
+| 33 – 88 | 0 |
+| max 89 – 106 | 1 |
+| max 107 – 125 | 3 |
+| max > 125 | 6 |
+
+### Mean Arterial Pressure (mmHg)
+
+| Bin | Score |
+|---|---|
+| min < 20.65 | 4 |
+| min 20.65 – 50.99 | 3 |
+| min 51 – 61.32 | 2 |
+| 61.33 – 143.44 | 0 |
+| max > 143.44 | 3 |
+
+### Respiratory Rate (min⁻¹)
+
+| Bin | Score |
+|---|---|
+| min < 6 | 10 |
+| min 6 – 12 | 1 |
+| 13 – 22 | 0 |
+| max 23 – 30 | 1 |
+| max 31 – 44 | 6 |
+| max > 44 | 9 |
+
+### Temperature (°C)
+
+| Bin | Score |
+|---|---|
+| min < 33.22 | 3 |
+| min or max 33.22 – 35.93 | 4 |
+| min 35.94 – 36.39 | 2 |
+| max 36.40 – 36.88 | 0 |
+| max 36.89 – 39.88 | 2 |
+| max > 39.88 | 6 |
+
+### Urine Output (mL/day)
+
+| Range | Score |
+|---|---|
+| < 671 | 10 |
+| 671 – 1426.99 | 5 |
+| 1427 – 2543.99 | 1 |
+| 2544 – 6896 | 0 |
+| > 6896 | 8 |
+
+### Mechanical Ventilation
+
+| Status | Score |
+|---|---|
+| No | 0 |
+| Yes (any invasive ventilation in 24 h) | 9 |
+
+### Elective Surgery
+
+| Status | Score |
+|---|---|
+| Elective admission AND surgical service | 0 |
+| All other admissions | 6 |
 
 The OASIS total is the sum of the 10 component scores. Report the component
 scores alongside the total so implementation differences are auditable.
 
+## Direction-aware Scoring (min vs max)
+
+For Heart Rate, MAP, Respiratory Rate, and Temperature, OASIS uses the
+worst-direction observation in the first 24 h:
+
+- Test the **min** observation against the low-extreme bin first.
+- Test the **max** observation against the high-extreme bins next.
+- The first matching bin wins; do not sum or average across bins.
+- Temperature uniquely allows either min or max to satisfy the
+  33.22 – 35.93 °C bin (4 points); test both.
+
+GCS uses the worst (minimum) value only. Pre-ICU LOS, Age, Urine Output,
+Mechanical Ventilation, and Elective Surgery are scalar — no min/max
+distinction.
+
 ## Critical Implementation Notes
 
-1. **No Laboratory Values Required**: OASIS uses only vital signs, urine output, and administrative data - no labs needed.
+1. **No Laboratory Values Required**: OASIS uses only vital signs, urine
+   output, and administrative data — no labs needed.
 
-2. **Pre-ICU LOS Scoring**: Time from hospital admission to ICU admission in minutes. Scoring is non-linear:
-   - < 10.2 min: 5 points (immediate ICU)
-   - 10.2-297 min: 3 points
-   - 297-1440 min: 0 points (optimal)
-   - 1440-18708 min: 2 points
-   - > 18708 min: 1 point
+2. **Mechanical Ventilation**: Any invasive ventilation during the first
+   24 hours scores 9 points; otherwise 0.
 
-3. **Mechanical Ventilation**: Binary flag - any invasive ventilation during first 24 hours scores 9 points.
+3. **Elective Surgery**: Requires BOTH an elective admission type AND a
+   surgical service assignment (identified from the first service
+   transfer). Scoring direction matters: elective surgical admissions
+   score **0** points; all other stays score **6** points.
 
-4. **Elective Surgery**: Requires BOTH:
-   - Elective admission type AND
-   - Surgical service (identified from first service transfer)
-   - **Scoring direction matters**: elective surgical admissions score **0**
-     points; all other stays score **6** points
+4. **Missing Data Handling**: Per task instruction, treat missing data
+   as normal (score 0). When a component cannot be computed because the
+   underlying observation is absent, score that component as 0 before
+   summing. Output ALL ICU stays in the result, even those missing some
+   or all source measurements.
+   - Special case: the ventilation indicator is binary (yes/no) — absence
+     of any ventilation record is interpreted as "no ventilation",
+     contributing 0 points (not missing).
 
-5. **Ventilation Flag Cannot Be Missing**: Unlike other components, ventilation defaults to 0 (no ventilation) if no data found.
+## Mortality Probability
 
-6. **Mortality Probability**:
-   ```
-   oasis_prob = 1 / (1 + exp(-(-6.1746 + 0.1275 * oasis)))
-   ```
+OASIS predicts in-hospital mortality through a logistic model
+(Johnson et al. 2013):
+
+```
+oasis_prob = 1 / (1 + exp(-(-6.1746 + 0.1275 * oasis)))
+```
+
+This probability is informational only and is not required by the M4Bench
+output schema for this task.
+
+## Source Data Required
+
+OASIS requires the following clinical/administrative data per ICU stay:
+
+- ICU admission and discharge times; hospital admission time (for pre-ICU LOS)
+- Admission type (elective vs non-elective)
+- Service or specialty assignment at the time of ICU admission (to identify
+  surgical admissions)
+- Patient age at admission
+- First 24-hour vital signs: heart rate (min, max), mean arterial pressure
+  (min, max), respiratory rate (min, max), temperature (min, max)
+- First 24-hour Glasgow Coma Score (worst observation)
+- First 24-hour urine output total
+- Invasive mechanical ventilation status during the first 24 hours
 
 ## Advantages Over APACHE/SAPS
 
@@ -74,4 +199,4 @@ scores alongside the total so implementation differences are auditable.
 
 ## References
 
-- Johnson AEW, Kramer AA, Clifford GD. "A new severity of illness scale using a subset of Acute Physiology And Chronic Health Evaluation data elements shows comparable predictive accuracy." Critical Care Medicine. 2013;41(7):1711-1718.
+- Johnson AEW, Kramer AA, Clifford GD. "A new severity of illness scale using a subset of Acute Physiology And Chronic Health Evaluation data elements shows comparable predictive accuracy." *Critical Care Medicine*. 2013;41(7):1711-1718.

--- a/benchmark/tasks/oasis/mimic-oasis-24h-raw/skills-nosql/oasis-score/SKILL.md
+++ b/benchmark/tasks/oasis/mimic-oasis-24h-raw/skills-nosql/oasis-score/SKILL.md
@@ -23,10 +23,12 @@ In M4Bench, target concept tables listed in the task configuration are removed o
 
 ## Score Components (First 24 Hours)
 
-OASIS sums 10 component scores. The cutoffs below are the authoritative
-specification (Johnson AEW et al., *Crit Care Med* 2013, Table 2). For
-continuous variables, evaluate using the worst-direction observation in
-the first 24 h (see "Direction-aware Scoring" below).
+OASIS sums 10 component scores. The cutoffs below are aligned with the
+M4Bench/MIMIC labels, which follow the public MIMIC implementation adapted
+from Johnson AEW et al. (*Crit Care Med* 2013, Table 2). For min/max-bound
+continuous variables, use the MIMIC evaluation order shown below because
+first-match ordering affects component labels when both low and high extremes
+occur in the first 24 h.
 
 ### Pre-ICU Length of Stay
 
@@ -57,57 +59,57 @@ the first 24 h (see "Direction-aware Scoring" below).
 | 14 | 3 |
 | 15 | 0 |
 
-### Heart Rate (min⁻¹)
+### Heart Rate (min^-1)
 
-| Bin | Score |
-|---|---|
-| min < 33 | 4 |
-| 33 – 88 | 0 |
-| max 89 – 106 | 1 |
-| max 107 – 125 | 3 |
-| max > 125 | 6 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | max > 125 | 6 |
+| 2 | min < 33 | 4 |
+| 3 | max 107-125 | 3 |
+| 4 | max 89-106 | 1 |
+| 5 | otherwise | 0 |
 
 ### Mean Arterial Pressure (mmHg)
 
-| Bin | Score |
-|---|---|
-| min < 20.65 | 4 |
-| min 20.65 – 50.99 | 3 |
-| min 51 – 61.32 | 2 |
-| 61.33 – 143.44 | 0 |
-| max > 143.44 | 3 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | min < 20.65 | 4 |
+| 2 | min 20.65-50.99 | 3 |
+| 3 | max > 143.44 | 3 |
+| 4 | min 51-61.32 | 2 |
+| 5 | otherwise | 0 |
 
-### Respiratory Rate (min⁻¹)
+### Respiratory Rate (min^-1)
 
-| Bin | Score |
-|---|---|
-| min < 6 | 10 |
-| min 6 – 12 | 1 |
-| 13 – 22 | 0 |
-| max 23 – 30 | 1 |
-| max 31 – 44 | 6 |
-| max > 44 | 9 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | min < 6 | 10 |
+| 2 | max > 44 | 9 |
+| 3 | max 31-44 | 6 |
+| 4 | max 23-30 | 1 |
+| 5 | min < 13 | 1 |
+| 6 | otherwise | 0 |
 
-### Temperature (°C)
+### Temperature (deg C)
 
-| Bin | Score |
-|---|---|
-| min < 33.22 | 3 |
-| min or max 33.22 – 35.93 | 4 |
-| min 35.94 – 36.39 | 2 |
-| max 36.40 – 36.88 | 0 |
-| max 36.89 – 39.88 | 2 |
-| max > 39.88 | 6 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | max > 39.88 | 6 |
+| 2 | min or max 33.22-35.93 | 4 |
+| 3 | min < 33.22 | 3 |
+| 4 | min 35.94-36.39 | 2 |
+| 5 | max 36.89-39.88 | 2 |
+| 6 | otherwise | 0 |
 
 ### Urine Output (mL/day)
 
-| Range | Score |
-|---|---|
-| < 671 | 10 |
-| 671 – 1426.99 | 5 |
-| 1427 – 2543.99 | 1 |
-| 2544 – 6896 | 0 |
-| > 6896 | 8 |
+| Evaluation order | Range | Score |
+|---|---|---|
+| 1 | < 671.09 | 10 |
+| 2 | > 6896.80 | 8 |
+| 3 | 671.09-1426.99 | 5 |
+| 4 | 1427.00-2544.14 | 1 |
+| 5 | otherwise | 0 |
 
 ### Mechanical Ventilation
 
@@ -126,16 +128,24 @@ the first 24 h (see "Direction-aware Scoring" below).
 The OASIS total is the sum of the 10 component scores. Report the component
 scores alongside the total so implementation differences are auditable.
 
-## Direction-aware Scoring (min vs max)
+## Direction-aware Scoring (MIMIC labels)
 
-For Heart Rate, MAP, Respiratory Rate, and Temperature, OASIS uses the
-worst-direction observation in the first 24 h:
+For MIMIC OASIS tasks, follow the M4Bench/MIMIC SQL evaluation order in the
+tables above. This ordering is intentionally dataset-specific: if both a low
+and high extreme occur in the same first-24h window, the first matching row in
+the component table wins.
 
-- Test the **min** observation against the low-extreme bin first.
-- Test the **max** observation against the high-extreme bins next.
-- The first matching bin wins; do not sum or average across bins.
-- Temperature uniquely allows either min or max to satisfy the
-  33.22 – 35.93 °C bin (4 points); test both.
+Key conflict rules for MIMIC labels:
+
+- Heart rate prioritizes severe tachycardia (`max > 125`, 6 points) before
+  severe bradycardia (`min < 33`, 4 points).
+- MAP checks low MAP bins first, then high MAP (`max > 143.44`), then assigns
+  low-normal/normal scores.
+- Respiratory rate checks severe low RR first, then high RR bins, then mild low
+  RR.
+- Temperature prioritizes fever (`max > 39.88`, 6 points) before low-temperature
+  bins.
+- Urine output uses the exact MIMIC boundaries shown above.
 
 GCS uses the worst (minimum) value only. Pre-ICU LOS, Age, Urine Output,
 Mechanical Ventilation, and Elective Surgery are scalar — no min/max

--- a/benchmark/tasks/oasis/mimic-oasis-24h-raw/skills/oasis-score/SKILL.md
+++ b/benchmark/tasks/oasis/mimic-oasis-24h-raw/skills/oasis-score/SKILL.md
@@ -23,47 +23,172 @@ In M4Bench, target concept tables listed in the task configuration are removed o
 
 ## Score Components (First 24 Hours)
 
-| Variable | Range | Points |
-|----------|-------|--------|
-| Age | <24 to >=90 | 0-9 |
-| Pre-ICU LOS | <10 min to >=18708 min | 0-5 |
-| GCS | <=7 to >=15 | 0-10 |
-| Heart Rate | <33 to >125 | 0-6 |
-| Mean BP | <20.65 to >143.44 | 0-4 |
-| Respiratory Rate | <6 to >44 | 0-10 |
-| Temperature | <33.22 to >39.88 C | 0-6 |
-| Urine Output | <671 to >6897 mL/day | 0-10 |
-| Mechanical Ventilation | Yes/No | 0 or 9 |
-| Elective Surgery | Yes/No | 0 or 6 |
+OASIS sums 10 component scores. The cutoffs below are the authoritative
+specification (Johnson AEW et al., *Crit Care Med* 2013, Table 2). For
+continuous variables, evaluate using the worst-direction observation in
+the first 24 h (see "Direction-aware Scoring" below).
+
+### Pre-ICU Length of Stay
+
+| Range (hours) | In minutes | Score |
+|---|---|---|
+| < 0.17 | < 10.2 | 5 |
+| 0.17 – 4.94 | 10.2 – 296.4 | 3 |
+| 4.95 – 24.00 | 297.0 – 1440.0 | 0 |
+| 24.01 – 311.80 | 1440.6 – 18708.0 | 2 |
+| > 311.80 | > 18708 | 1 |
+
+### Age (years)
+
+| Range | Score |
+|---|---|
+| < 24 | 0 |
+| 24 – 53 | 3 |
+| 54 – 77 | 6 |
+| 78 – 89 | 9 |
+| ≥ 90 | 7 |
+
+### Glasgow Coma Score (worst observation)
+
+| Range | Score |
+|---|---|
+| 3 – 7 | 10 |
+| 8 – 13 | 4 |
+| 14 | 3 |
+| 15 | 0 |
+
+### Heart Rate (min⁻¹)
+
+| Bin | Score |
+|---|---|
+| min < 33 | 4 |
+| 33 – 88 | 0 |
+| max 89 – 106 | 1 |
+| max 107 – 125 | 3 |
+| max > 125 | 6 |
+
+### Mean Arterial Pressure (mmHg)
+
+| Bin | Score |
+|---|---|
+| min < 20.65 | 4 |
+| min 20.65 – 50.99 | 3 |
+| min 51 – 61.32 | 2 |
+| 61.33 – 143.44 | 0 |
+| max > 143.44 | 3 |
+
+### Respiratory Rate (min⁻¹)
+
+| Bin | Score |
+|---|---|
+| min < 6 | 10 |
+| min 6 – 12 | 1 |
+| 13 – 22 | 0 |
+| max 23 – 30 | 1 |
+| max 31 – 44 | 6 |
+| max > 44 | 9 |
+
+### Temperature (°C)
+
+| Bin | Score |
+|---|---|
+| min < 33.22 | 3 |
+| min or max 33.22 – 35.93 | 4 |
+| min 35.94 – 36.39 | 2 |
+| max 36.40 – 36.88 | 0 |
+| max 36.89 – 39.88 | 2 |
+| max > 39.88 | 6 |
+
+### Urine Output (mL/day)
+
+| Range | Score |
+|---|---|
+| < 671 | 10 |
+| 671 – 1426.99 | 5 |
+| 1427 – 2543.99 | 1 |
+| 2544 – 6896 | 0 |
+| > 6896 | 8 |
+
+### Mechanical Ventilation
+
+| Status | Score |
+|---|---|
+| No | 0 |
+| Yes (any invasive ventilation in 24 h) | 9 |
+
+### Elective Surgery
+
+| Status | Score |
+|---|---|
+| Elective admission AND surgical service | 0 |
+| All other admissions | 6 |
 
 The OASIS total is the sum of the 10 component scores. Report the component
 scores alongside the total so implementation differences are auditable.
 
+## Direction-aware Scoring (min vs max)
+
+For Heart Rate, MAP, Respiratory Rate, and Temperature, OASIS uses the
+worst-direction observation in the first 24 h:
+
+- Test the **min** observation against the low-extreme bin first.
+- Test the **max** observation against the high-extreme bins next.
+- The first matching bin wins; do not sum or average across bins.
+- Temperature uniquely allows either min or max to satisfy the
+  33.22 – 35.93 °C bin (4 points); test both.
+
+GCS uses the worst (minimum) value only. Pre-ICU LOS, Age, Urine Output,
+Mechanical Ventilation, and Elective Surgery are scalar — no min/max
+distinction.
+
 ## Critical Implementation Notes
 
-1. **No Laboratory Values Required**: OASIS uses only vital signs, urine output, and administrative data - no labs needed.
+1. **No Laboratory Values Required**: OASIS uses only vital signs, urine
+   output, and administrative data — no labs needed.
 
-2. **Pre-ICU LOS Scoring**: Time from hospital admission to ICU admission in minutes. Scoring is non-linear:
-   - < 10.2 min: 5 points (immediate ICU)
-   - 10.2-297 min: 3 points
-   - 297-1440 min: 0 points (optimal)
-   - 1440-18708 min: 2 points
-   - > 18708 min: 1 point
+2. **Mechanical Ventilation**: Any invasive ventilation during the first
+   24 hours scores 9 points; otherwise 0.
 
-3. **Mechanical Ventilation**: Binary flag - any invasive ventilation during first 24 hours scores 9 points.
+3. **Elective Surgery**: Requires BOTH an elective admission type AND a
+   surgical service assignment (identified from the first service
+   transfer). Scoring direction matters: elective surgical admissions
+   score **0** points; all other stays score **6** points.
 
-4. **Elective Surgery**: Requires BOTH:
-   - Elective admission type AND
-   - Surgical service (identified from first service transfer)
-   - **Scoring direction matters**: elective surgical admissions score **0**
-     points; all other stays score **6** points
+4. **Missing Data Handling**: Per task instruction, treat missing data
+   as normal (score 0). When a component cannot be computed because the
+   underlying observation is absent, score that component as 0 before
+   summing. Output ALL ICU stays in the result, even those missing some
+   or all source measurements.
+   - Special case: the ventilation indicator is binary (yes/no) — absence
+     of any ventilation record is interpreted as "no ventilation",
+     contributing 0 points (not missing).
 
-5. **Ventilation Flag Cannot Be Missing**: Unlike other components, ventilation defaults to 0 (no ventilation) if no data found.
+## Mortality Probability
 
-6. **Mortality Probability**:
-   ```
-   oasis_prob = 1 / (1 + exp(-(-6.1746 + 0.1275 * oasis)))
-   ```
+OASIS predicts in-hospital mortality through a logistic model
+(Johnson et al. 2013):
+
+```
+oasis_prob = 1 / (1 + exp(-(-6.1746 + 0.1275 * oasis)))
+```
+
+This probability is informational only and is not required by the M4Bench
+output schema for this task.
+
+## Source Data Required
+
+OASIS requires the following clinical/administrative data per ICU stay:
+
+- ICU admission and discharge times; hospital admission time (for pre-ICU LOS)
+- Admission type (elective vs non-elective)
+- Service or specialty assignment at the time of ICU admission (to identify
+  surgical admissions)
+- Patient age at admission
+- First 24-hour vital signs: heart rate (min, max), mean arterial pressure
+  (min, max), respiratory rate (min, max), temperature (min, max)
+- First 24-hour Glasgow Coma Score (worst observation)
+- First 24-hour urine output total
+- Invasive mechanical ventilation status during the first 24 hours
 
 ## Advantages Over APACHE/SAPS
 
@@ -74,4 +199,4 @@ scores alongside the total so implementation differences are auditable.
 
 ## References
 
-- Johnson AEW, Kramer AA, Clifford GD. "A new severity of illness scale using a subset of Acute Physiology And Chronic Health Evaluation data elements shows comparable predictive accuracy." Critical Care Medicine. 2013;41(7):1711-1718.
+- Johnson AEW, Kramer AA, Clifford GD. "A new severity of illness scale using a subset of Acute Physiology And Chronic Health Evaluation data elements shows comparable predictive accuracy." *Critical Care Medicine*. 2013;41(7):1711-1718.

--- a/benchmark/tasks/oasis/mimic-oasis-24h-raw/skills/oasis-score/SKILL.md
+++ b/benchmark/tasks/oasis/mimic-oasis-24h-raw/skills/oasis-score/SKILL.md
@@ -23,10 +23,12 @@ In M4Bench, target concept tables listed in the task configuration are removed o
 
 ## Score Components (First 24 Hours)
 
-OASIS sums 10 component scores. The cutoffs below are the authoritative
-specification (Johnson AEW et al., *Crit Care Med* 2013, Table 2). For
-continuous variables, evaluate using the worst-direction observation in
-the first 24 h (see "Direction-aware Scoring" below).
+OASIS sums 10 component scores. The cutoffs below are aligned with the
+M4Bench/MIMIC labels, which follow the public MIMIC implementation adapted
+from Johnson AEW et al. (*Crit Care Med* 2013, Table 2). For min/max-bound
+continuous variables, use the MIMIC evaluation order shown below because
+first-match ordering affects component labels when both low and high extremes
+occur in the first 24 h.
 
 ### Pre-ICU Length of Stay
 
@@ -57,57 +59,57 @@ the first 24 h (see "Direction-aware Scoring" below).
 | 14 | 3 |
 | 15 | 0 |
 
-### Heart Rate (min⁻¹)
+### Heart Rate (min^-1)
 
-| Bin | Score |
-|---|---|
-| min < 33 | 4 |
-| 33 – 88 | 0 |
-| max 89 – 106 | 1 |
-| max 107 – 125 | 3 |
-| max > 125 | 6 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | max > 125 | 6 |
+| 2 | min < 33 | 4 |
+| 3 | max 107-125 | 3 |
+| 4 | max 89-106 | 1 |
+| 5 | otherwise | 0 |
 
 ### Mean Arterial Pressure (mmHg)
 
-| Bin | Score |
-|---|---|
-| min < 20.65 | 4 |
-| min 20.65 – 50.99 | 3 |
-| min 51 – 61.32 | 2 |
-| 61.33 – 143.44 | 0 |
-| max > 143.44 | 3 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | min < 20.65 | 4 |
+| 2 | min 20.65-50.99 | 3 |
+| 3 | max > 143.44 | 3 |
+| 4 | min 51-61.32 | 2 |
+| 5 | otherwise | 0 |
 
-### Respiratory Rate (min⁻¹)
+### Respiratory Rate (min^-1)
 
-| Bin | Score |
-|---|---|
-| min < 6 | 10 |
-| min 6 – 12 | 1 |
-| 13 – 22 | 0 |
-| max 23 – 30 | 1 |
-| max 31 – 44 | 6 |
-| max > 44 | 9 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | min < 6 | 10 |
+| 2 | max > 44 | 9 |
+| 3 | max 31-44 | 6 |
+| 4 | max 23-30 | 1 |
+| 5 | min < 13 | 1 |
+| 6 | otherwise | 0 |
 
-### Temperature (°C)
+### Temperature (deg C)
 
-| Bin | Score |
-|---|---|
-| min < 33.22 | 3 |
-| min or max 33.22 – 35.93 | 4 |
-| min 35.94 – 36.39 | 2 |
-| max 36.40 – 36.88 | 0 |
-| max 36.89 – 39.88 | 2 |
-| max > 39.88 | 6 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | max > 39.88 | 6 |
+| 2 | min or max 33.22-35.93 | 4 |
+| 3 | min < 33.22 | 3 |
+| 4 | min 35.94-36.39 | 2 |
+| 5 | max 36.89-39.88 | 2 |
+| 6 | otherwise | 0 |
 
 ### Urine Output (mL/day)
 
-| Range | Score |
-|---|---|
-| < 671 | 10 |
-| 671 – 1426.99 | 5 |
-| 1427 – 2543.99 | 1 |
-| 2544 – 6896 | 0 |
-| > 6896 | 8 |
+| Evaluation order | Range | Score |
+|---|---|---|
+| 1 | < 671.09 | 10 |
+| 2 | > 6896.80 | 8 |
+| 3 | 671.09-1426.99 | 5 |
+| 4 | 1427.00-2544.14 | 1 |
+| 5 | otherwise | 0 |
 
 ### Mechanical Ventilation
 
@@ -126,16 +128,24 @@ the first 24 h (see "Direction-aware Scoring" below).
 The OASIS total is the sum of the 10 component scores. Report the component
 scores alongside the total so implementation differences are auditable.
 
-## Direction-aware Scoring (min vs max)
+## Direction-aware Scoring (MIMIC labels)
 
-For Heart Rate, MAP, Respiratory Rate, and Temperature, OASIS uses the
-worst-direction observation in the first 24 h:
+For MIMIC OASIS tasks, follow the M4Bench/MIMIC SQL evaluation order in the
+tables above. This ordering is intentionally dataset-specific: if both a low
+and high extreme occur in the same first-24h window, the first matching row in
+the component table wins.
 
-- Test the **min** observation against the low-extreme bin first.
-- Test the **max** observation against the high-extreme bins next.
-- The first matching bin wins; do not sum or average across bins.
-- Temperature uniquely allows either min or max to satisfy the
-  33.22 – 35.93 °C bin (4 points); test both.
+Key conflict rules for MIMIC labels:
+
+- Heart rate prioritizes severe tachycardia (`max > 125`, 6 points) before
+  severe bradycardia (`min < 33`, 4 points).
+- MAP checks low MAP bins first, then high MAP (`max > 143.44`), then assigns
+  low-normal/normal scores.
+- Respiratory rate checks severe low RR first, then high RR bins, then mild low
+  RR.
+- Temperature prioritizes fever (`max > 39.88`, 6 points) before low-temperature
+  bins.
+- Urine output uses the exact MIMIC boundaries shown above.
 
 GCS uses the worst (minimum) value only. Pre-ICU LOS, Age, Urine Output,
 Mechanical Ventilation, and Elective Surgery are scalar — no min/max

--- a/benchmark/tasks/oasis/mimic-oasis-24h/skills-nosql/oasis-score/SKILL.md
+++ b/benchmark/tasks/oasis/mimic-oasis-24h/skills-nosql/oasis-score/SKILL.md
@@ -23,47 +23,172 @@ In M4Bench, target concept tables listed in the task configuration are removed o
 
 ## Score Components (First 24 Hours)
 
-| Variable | Range | Points |
-|----------|-------|--------|
-| Age | <24 to >=90 | 0-9 |
-| Pre-ICU LOS | <10 min to >=18708 min | 0-5 |
-| GCS | <=7 to >=15 | 0-10 |
-| Heart Rate | <33 to >125 | 0-6 |
-| Mean BP | <20.65 to >143.44 | 0-4 |
-| Respiratory Rate | <6 to >44 | 0-10 |
-| Temperature | <33.22 to >39.88 C | 0-6 |
-| Urine Output | <671 to >6897 mL/day | 0-10 |
-| Mechanical Ventilation | Yes/No | 0 or 9 |
-| Elective Surgery | Yes/No | 0 for elective surgical admissions, 6 otherwise |
+OASIS sums 10 component scores. The cutoffs below are the authoritative
+specification (Johnson AEW et al., *Crit Care Med* 2013, Table 2). For
+continuous variables, evaluate using the worst-direction observation in
+the first 24 h (see "Direction-aware Scoring" below).
+
+### Pre-ICU Length of Stay
+
+| Range (hours) | In minutes | Score |
+|---|---|---|
+| < 0.17 | < 10.2 | 5 |
+| 0.17 – 4.94 | 10.2 – 296.4 | 3 |
+| 4.95 – 24.00 | 297.0 – 1440.0 | 0 |
+| 24.01 – 311.80 | 1440.6 – 18708.0 | 2 |
+| > 311.80 | > 18708 | 1 |
+
+### Age (years)
+
+| Range | Score |
+|---|---|
+| < 24 | 0 |
+| 24 – 53 | 3 |
+| 54 – 77 | 6 |
+| 78 – 89 | 9 |
+| ≥ 90 | 7 |
+
+### Glasgow Coma Score (worst observation)
+
+| Range | Score |
+|---|---|
+| 3 – 7 | 10 |
+| 8 – 13 | 4 |
+| 14 | 3 |
+| 15 | 0 |
+
+### Heart Rate (min⁻¹)
+
+| Bin | Score |
+|---|---|
+| min < 33 | 4 |
+| 33 – 88 | 0 |
+| max 89 – 106 | 1 |
+| max 107 – 125 | 3 |
+| max > 125 | 6 |
+
+### Mean Arterial Pressure (mmHg)
+
+| Bin | Score |
+|---|---|
+| min < 20.65 | 4 |
+| min 20.65 – 50.99 | 3 |
+| min 51 – 61.32 | 2 |
+| 61.33 – 143.44 | 0 |
+| max > 143.44 | 3 |
+
+### Respiratory Rate (min⁻¹)
+
+| Bin | Score |
+|---|---|
+| min < 6 | 10 |
+| min 6 – 12 | 1 |
+| 13 – 22 | 0 |
+| max 23 – 30 | 1 |
+| max 31 – 44 | 6 |
+| max > 44 | 9 |
+
+### Temperature (°C)
+
+| Bin | Score |
+|---|---|
+| min < 33.22 | 3 |
+| min or max 33.22 – 35.93 | 4 |
+| min 35.94 – 36.39 | 2 |
+| max 36.40 – 36.88 | 0 |
+| max 36.89 – 39.88 | 2 |
+| max > 39.88 | 6 |
+
+### Urine Output (mL/day)
+
+| Range | Score |
+|---|---|
+| < 671 | 10 |
+| 671 – 1426.99 | 5 |
+| 1427 – 2543.99 | 1 |
+| 2544 – 6896 | 0 |
+| > 6896 | 8 |
+
+### Mechanical Ventilation
+
+| Status | Score |
+|---|---|
+| No | 0 |
+| Yes (any invasive ventilation in 24 h) | 9 |
+
+### Elective Surgery
+
+| Status | Score |
+|---|---|
+| Elective admission AND surgical service | 0 |
+| All other admissions | 6 |
 
 The OASIS total is the sum of the 10 component scores. Report the component
 scores alongside the total so implementation differences are auditable.
 
+## Direction-aware Scoring (min vs max)
+
+For Heart Rate, MAP, Respiratory Rate, and Temperature, OASIS uses the
+worst-direction observation in the first 24 h:
+
+- Test the **min** observation against the low-extreme bin first.
+- Test the **max** observation against the high-extreme bins next.
+- The first matching bin wins; do not sum or average across bins.
+- Temperature uniquely allows either min or max to satisfy the
+  33.22 – 35.93 °C bin (4 points); test both.
+
+GCS uses the worst (minimum) value only. Pre-ICU LOS, Age, Urine Output,
+Mechanical Ventilation, and Elective Surgery are scalar — no min/max
+distinction.
+
 ## Critical Implementation Notes
 
-1. **No Laboratory Values Required**: OASIS uses only vital signs, urine output, and administrative data - no labs needed.
+1. **No Laboratory Values Required**: OASIS uses only vital signs, urine
+   output, and administrative data — no labs needed.
 
-2. **Pre-ICU LOS Scoring**: Time from hospital admission to ICU admission in minutes. Scoring is non-linear:
-   - < 10.2 min: 5 points (immediate ICU)
-   - 10.2-297 min: 3 points
-   - 297-1440 min: 0 points (optimal)
-   - 1440-18708 min: 2 points
-   - > 18708 min: 1 point
+2. **Mechanical Ventilation**: Any invasive ventilation during the first
+   24 hours scores 9 points; otherwise 0.
 
-3. **Mechanical Ventilation**: Binary flag - any invasive ventilation during first 24 hours scores 9 points.
+3. **Elective Surgery**: Requires BOTH an elective admission type AND a
+   surgical service assignment (identified from the first service
+   transfer). Scoring direction matters: elective surgical admissions
+   score **0** points; all other stays score **6** points.
 
-4. **Elective Surgery**: Requires BOTH:
-   - Elective admission type AND
-   - Surgical service (identified from first service transfer)
-   - **Scoring direction matters**: elective surgical admissions score **0**
-     points; all other stays score **6** points
+4. **Missing Data Handling**: Per task instruction, treat missing data
+   as normal (score 0). When a component cannot be computed because the
+   underlying observation is absent, score that component as 0 before
+   summing. Output ALL ICU stays in the result, even those missing some
+   or all source measurements.
+   - Special case: the ventilation indicator is binary (yes/no) — absence
+     of any ventilation record is interpreted as "no ventilation",
+     contributing 0 points (not missing).
 
-5. **Ventilation Flag Cannot Be Missing**: Unlike other components, ventilation defaults to 0 (no ventilation) if no data found.
+## Mortality Probability
 
-6. **Mortality Probability**:
-   ```
-   oasis_prob = 1 / (1 + exp(-(-6.1746 + 0.1275 * oasis)))
-   ```
+OASIS predicts in-hospital mortality through a logistic model
+(Johnson et al. 2013):
+
+```
+oasis_prob = 1 / (1 + exp(-(-6.1746 + 0.1275 * oasis)))
+```
+
+This probability is informational only and is not required by the M4Bench
+output schema for this task.
+
+## Source Data Required
+
+OASIS requires the following clinical/administrative data per ICU stay:
+
+- ICU admission and discharge times; hospital admission time (for pre-ICU LOS)
+- Admission type (elective vs non-elective)
+- Service or specialty assignment at the time of ICU admission (to identify
+  surgical admissions)
+- Patient age at admission
+- First 24-hour vital signs: heart rate (min, max), mean arterial pressure
+  (min, max), respiratory rate (min, max), temperature (min, max)
+- First 24-hour Glasgow Coma Score (worst observation)
+- First 24-hour urine output total
+- Invasive mechanical ventilation status during the first 24 hours
 
 ## Advantages Over APACHE/SAPS
 
@@ -74,4 +199,4 @@ scores alongside the total so implementation differences are auditable.
 
 ## References
 
-- Johnson AEW, Kramer AA, Clifford GD. "A new severity of illness scale using a subset of Acute Physiology And Chronic Health Evaluation data elements shows comparable predictive accuracy." Critical Care Medicine. 2013;41(7):1711-1718.
+- Johnson AEW, Kramer AA, Clifford GD. "A new severity of illness scale using a subset of Acute Physiology And Chronic Health Evaluation data elements shows comparable predictive accuracy." *Critical Care Medicine*. 2013;41(7):1711-1718.

--- a/benchmark/tasks/oasis/mimic-oasis-24h/skills-nosql/oasis-score/SKILL.md
+++ b/benchmark/tasks/oasis/mimic-oasis-24h/skills-nosql/oasis-score/SKILL.md
@@ -23,10 +23,12 @@ In M4Bench, target concept tables listed in the task configuration are removed o
 
 ## Score Components (First 24 Hours)
 
-OASIS sums 10 component scores. The cutoffs below are the authoritative
-specification (Johnson AEW et al., *Crit Care Med* 2013, Table 2). For
-continuous variables, evaluate using the worst-direction observation in
-the first 24 h (see "Direction-aware Scoring" below).
+OASIS sums 10 component scores. The cutoffs below are aligned with the
+M4Bench/MIMIC labels, which follow the public MIMIC implementation adapted
+from Johnson AEW et al. (*Crit Care Med* 2013, Table 2). For min/max-bound
+continuous variables, use the MIMIC evaluation order shown below because
+first-match ordering affects component labels when both low and high extremes
+occur in the first 24 h.
 
 ### Pre-ICU Length of Stay
 
@@ -57,57 +59,57 @@ the first 24 h (see "Direction-aware Scoring" below).
 | 14 | 3 |
 | 15 | 0 |
 
-### Heart Rate (min⁻¹)
+### Heart Rate (min^-1)
 
-| Bin | Score |
-|---|---|
-| min < 33 | 4 |
-| 33 – 88 | 0 |
-| max 89 – 106 | 1 |
-| max 107 – 125 | 3 |
-| max > 125 | 6 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | max > 125 | 6 |
+| 2 | min < 33 | 4 |
+| 3 | max 107-125 | 3 |
+| 4 | max 89-106 | 1 |
+| 5 | otherwise | 0 |
 
 ### Mean Arterial Pressure (mmHg)
 
-| Bin | Score |
-|---|---|
-| min < 20.65 | 4 |
-| min 20.65 – 50.99 | 3 |
-| min 51 – 61.32 | 2 |
-| 61.33 – 143.44 | 0 |
-| max > 143.44 | 3 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | min < 20.65 | 4 |
+| 2 | min 20.65-50.99 | 3 |
+| 3 | max > 143.44 | 3 |
+| 4 | min 51-61.32 | 2 |
+| 5 | otherwise | 0 |
 
-### Respiratory Rate (min⁻¹)
+### Respiratory Rate (min^-1)
 
-| Bin | Score |
-|---|---|
-| min < 6 | 10 |
-| min 6 – 12 | 1 |
-| 13 – 22 | 0 |
-| max 23 – 30 | 1 |
-| max 31 – 44 | 6 |
-| max > 44 | 9 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | min < 6 | 10 |
+| 2 | max > 44 | 9 |
+| 3 | max 31-44 | 6 |
+| 4 | max 23-30 | 1 |
+| 5 | min < 13 | 1 |
+| 6 | otherwise | 0 |
 
-### Temperature (°C)
+### Temperature (deg C)
 
-| Bin | Score |
-|---|---|
-| min < 33.22 | 3 |
-| min or max 33.22 – 35.93 | 4 |
-| min 35.94 – 36.39 | 2 |
-| max 36.40 – 36.88 | 0 |
-| max 36.89 – 39.88 | 2 |
-| max > 39.88 | 6 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | max > 39.88 | 6 |
+| 2 | min or max 33.22-35.93 | 4 |
+| 3 | min < 33.22 | 3 |
+| 4 | min 35.94-36.39 | 2 |
+| 5 | max 36.89-39.88 | 2 |
+| 6 | otherwise | 0 |
 
 ### Urine Output (mL/day)
 
-| Range | Score |
-|---|---|
-| < 671 | 10 |
-| 671 – 1426.99 | 5 |
-| 1427 – 2543.99 | 1 |
-| 2544 – 6896 | 0 |
-| > 6896 | 8 |
+| Evaluation order | Range | Score |
+|---|---|---|
+| 1 | < 671.09 | 10 |
+| 2 | > 6896.80 | 8 |
+| 3 | 671.09-1426.99 | 5 |
+| 4 | 1427.00-2544.14 | 1 |
+| 5 | otherwise | 0 |
 
 ### Mechanical Ventilation
 
@@ -126,16 +128,24 @@ the first 24 h (see "Direction-aware Scoring" below).
 The OASIS total is the sum of the 10 component scores. Report the component
 scores alongside the total so implementation differences are auditable.
 
-## Direction-aware Scoring (min vs max)
+## Direction-aware Scoring (MIMIC labels)
 
-For Heart Rate, MAP, Respiratory Rate, and Temperature, OASIS uses the
-worst-direction observation in the first 24 h:
+For MIMIC OASIS tasks, follow the M4Bench/MIMIC SQL evaluation order in the
+tables above. This ordering is intentionally dataset-specific: if both a low
+and high extreme occur in the same first-24h window, the first matching row in
+the component table wins.
 
-- Test the **min** observation against the low-extreme bin first.
-- Test the **max** observation against the high-extreme bins next.
-- The first matching bin wins; do not sum or average across bins.
-- Temperature uniquely allows either min or max to satisfy the
-  33.22 – 35.93 °C bin (4 points); test both.
+Key conflict rules for MIMIC labels:
+
+- Heart rate prioritizes severe tachycardia (`max > 125`, 6 points) before
+  severe bradycardia (`min < 33`, 4 points).
+- MAP checks low MAP bins first, then high MAP (`max > 143.44`), then assigns
+  low-normal/normal scores.
+- Respiratory rate checks severe low RR first, then high RR bins, then mild low
+  RR.
+- Temperature prioritizes fever (`max > 39.88`, 6 points) before low-temperature
+  bins.
+- Urine output uses the exact MIMIC boundaries shown above.
 
 GCS uses the worst (minimum) value only. Pre-ICU LOS, Age, Urine Output,
 Mechanical Ventilation, and Elective Surgery are scalar — no min/max

--- a/benchmark/tasks/oasis/mimic-oasis-24h/skills/oasis-score/SKILL.md
+++ b/benchmark/tasks/oasis/mimic-oasis-24h/skills/oasis-score/SKILL.md
@@ -23,47 +23,172 @@ In M4Bench, target concept tables listed in the task configuration are removed o
 
 ## Score Components (First 24 Hours)
 
-| Variable | Range | Points |
-|----------|-------|--------|
-| Age | <24 to >=90 | 0-9 |
-| Pre-ICU LOS | <10 min to >=18708 min | 0-5 |
-| GCS | <=7 to >=15 | 0-10 |
-| Heart Rate | <33 to >125 | 0-6 |
-| Mean BP | <20.65 to >143.44 | 0-4 |
-| Respiratory Rate | <6 to >44 | 0-10 |
-| Temperature | <33.22 to >39.88 C | 0-6 |
-| Urine Output | <671 to >6897 mL/day | 0-10 |
-| Mechanical Ventilation | Yes/No | 0 or 9 |
-| Elective Surgery | Yes/No | 0 for elective surgical admissions, 6 otherwise |
+OASIS sums 10 component scores. The cutoffs below are the authoritative
+specification (Johnson AEW et al., *Crit Care Med* 2013, Table 2). For
+continuous variables, evaluate using the worst-direction observation in
+the first 24 h (see "Direction-aware Scoring" below).
+
+### Pre-ICU Length of Stay
+
+| Range (hours) | In minutes | Score |
+|---|---|---|
+| < 0.17 | < 10.2 | 5 |
+| 0.17 – 4.94 | 10.2 – 296.4 | 3 |
+| 4.95 – 24.00 | 297.0 – 1440.0 | 0 |
+| 24.01 – 311.80 | 1440.6 – 18708.0 | 2 |
+| > 311.80 | > 18708 | 1 |
+
+### Age (years)
+
+| Range | Score |
+|---|---|
+| < 24 | 0 |
+| 24 – 53 | 3 |
+| 54 – 77 | 6 |
+| 78 – 89 | 9 |
+| ≥ 90 | 7 |
+
+### Glasgow Coma Score (worst observation)
+
+| Range | Score |
+|---|---|
+| 3 – 7 | 10 |
+| 8 – 13 | 4 |
+| 14 | 3 |
+| 15 | 0 |
+
+### Heart Rate (min⁻¹)
+
+| Bin | Score |
+|---|---|
+| min < 33 | 4 |
+| 33 – 88 | 0 |
+| max 89 – 106 | 1 |
+| max 107 – 125 | 3 |
+| max > 125 | 6 |
+
+### Mean Arterial Pressure (mmHg)
+
+| Bin | Score |
+|---|---|
+| min < 20.65 | 4 |
+| min 20.65 – 50.99 | 3 |
+| min 51 – 61.32 | 2 |
+| 61.33 – 143.44 | 0 |
+| max > 143.44 | 3 |
+
+### Respiratory Rate (min⁻¹)
+
+| Bin | Score |
+|---|---|
+| min < 6 | 10 |
+| min 6 – 12 | 1 |
+| 13 – 22 | 0 |
+| max 23 – 30 | 1 |
+| max 31 – 44 | 6 |
+| max > 44 | 9 |
+
+### Temperature (°C)
+
+| Bin | Score |
+|---|---|
+| min < 33.22 | 3 |
+| min or max 33.22 – 35.93 | 4 |
+| min 35.94 – 36.39 | 2 |
+| max 36.40 – 36.88 | 0 |
+| max 36.89 – 39.88 | 2 |
+| max > 39.88 | 6 |
+
+### Urine Output (mL/day)
+
+| Range | Score |
+|---|---|
+| < 671 | 10 |
+| 671 – 1426.99 | 5 |
+| 1427 – 2543.99 | 1 |
+| 2544 – 6896 | 0 |
+| > 6896 | 8 |
+
+### Mechanical Ventilation
+
+| Status | Score |
+|---|---|
+| No | 0 |
+| Yes (any invasive ventilation in 24 h) | 9 |
+
+### Elective Surgery
+
+| Status | Score |
+|---|---|
+| Elective admission AND surgical service | 0 |
+| All other admissions | 6 |
 
 The OASIS total is the sum of the 10 component scores. Report the component
 scores alongside the total so implementation differences are auditable.
 
+## Direction-aware Scoring (min vs max)
+
+For Heart Rate, MAP, Respiratory Rate, and Temperature, OASIS uses the
+worst-direction observation in the first 24 h:
+
+- Test the **min** observation against the low-extreme bin first.
+- Test the **max** observation against the high-extreme bins next.
+- The first matching bin wins; do not sum or average across bins.
+- Temperature uniquely allows either min or max to satisfy the
+  33.22 – 35.93 °C bin (4 points); test both.
+
+GCS uses the worst (minimum) value only. Pre-ICU LOS, Age, Urine Output,
+Mechanical Ventilation, and Elective Surgery are scalar — no min/max
+distinction.
+
 ## Critical Implementation Notes
 
-1. **No Laboratory Values Required**: OASIS uses only vital signs, urine output, and administrative data - no labs needed.
+1. **No Laboratory Values Required**: OASIS uses only vital signs, urine
+   output, and administrative data — no labs needed.
 
-2. **Pre-ICU LOS Scoring**: Time from hospital admission to ICU admission in minutes. Scoring is non-linear:
-   - < 10.2 min: 5 points (immediate ICU)
-   - 10.2-297 min: 3 points
-   - 297-1440 min: 0 points (optimal)
-   - 1440-18708 min: 2 points
-   - > 18708 min: 1 point
+2. **Mechanical Ventilation**: Any invasive ventilation during the first
+   24 hours scores 9 points; otherwise 0.
 
-3. **Mechanical Ventilation**: Binary flag - any invasive ventilation during first 24 hours scores 9 points.
+3. **Elective Surgery**: Requires BOTH an elective admission type AND a
+   surgical service assignment (identified from the first service
+   transfer). Scoring direction matters: elective surgical admissions
+   score **0** points; all other stays score **6** points.
 
-4. **Elective Surgery**: Requires BOTH:
-   - Elective admission type AND
-   - Surgical service (identified from first service transfer)
-   - **Scoring direction matters**: elective surgical admissions score **0**
-     points; all other stays score **6** points
+4. **Missing Data Handling**: Per task instruction, treat missing data
+   as normal (score 0). When a component cannot be computed because the
+   underlying observation is absent, score that component as 0 before
+   summing. Output ALL ICU stays in the result, even those missing some
+   or all source measurements.
+   - Special case: the ventilation indicator is binary (yes/no) — absence
+     of any ventilation record is interpreted as "no ventilation",
+     contributing 0 points (not missing).
 
-5. **Ventilation Flag Cannot Be Missing**: Unlike other components, ventilation defaults to 0 (no ventilation) if no data found.
+## Mortality Probability
 
-6. **Mortality Probability**:
-   ```
-   oasis_prob = 1 / (1 + exp(-(-6.1746 + 0.1275 * oasis)))
-   ```
+OASIS predicts in-hospital mortality through a logistic model
+(Johnson et al. 2013):
+
+```
+oasis_prob = 1 / (1 + exp(-(-6.1746 + 0.1275 * oasis)))
+```
+
+This probability is informational only and is not required by the M4Bench
+output schema for this task.
+
+## Source Data Required
+
+OASIS requires the following clinical/administrative data per ICU stay:
+
+- ICU admission and discharge times; hospital admission time (for pre-ICU LOS)
+- Admission type (elective vs non-elective)
+- Service or specialty assignment at the time of ICU admission (to identify
+  surgical admissions)
+- Patient age at admission
+- First 24-hour vital signs: heart rate (min, max), mean arterial pressure
+  (min, max), respiratory rate (min, max), temperature (min, max)
+- First 24-hour Glasgow Coma Score (worst observation)
+- First 24-hour urine output total
+- Invasive mechanical ventilation status during the first 24 hours
 
 ## Advantages Over APACHE/SAPS
 
@@ -74,4 +199,4 @@ scores alongside the total so implementation differences are auditable.
 
 ## References
 
-- Johnson AEW, Kramer AA, Clifford GD. "A new severity of illness scale using a subset of Acute Physiology And Chronic Health Evaluation data elements shows comparable predictive accuracy." Critical Care Medicine. 2013;41(7):1711-1718.
+- Johnson AEW, Kramer AA, Clifford GD. "A new severity of illness scale using a subset of Acute Physiology And Chronic Health Evaluation data elements shows comparable predictive accuracy." *Critical Care Medicine*. 2013;41(7):1711-1718.

--- a/benchmark/tasks/oasis/mimic-oasis-24h/skills/oasis-score/SKILL.md
+++ b/benchmark/tasks/oasis/mimic-oasis-24h/skills/oasis-score/SKILL.md
@@ -23,10 +23,12 @@ In M4Bench, target concept tables listed in the task configuration are removed o
 
 ## Score Components (First 24 Hours)
 
-OASIS sums 10 component scores. The cutoffs below are the authoritative
-specification (Johnson AEW et al., *Crit Care Med* 2013, Table 2). For
-continuous variables, evaluate using the worst-direction observation in
-the first 24 h (see "Direction-aware Scoring" below).
+OASIS sums 10 component scores. The cutoffs below are aligned with the
+M4Bench/MIMIC labels, which follow the public MIMIC implementation adapted
+from Johnson AEW et al. (*Crit Care Med* 2013, Table 2). For min/max-bound
+continuous variables, use the MIMIC evaluation order shown below because
+first-match ordering affects component labels when both low and high extremes
+occur in the first 24 h.
 
 ### Pre-ICU Length of Stay
 
@@ -57,57 +59,57 @@ the first 24 h (see "Direction-aware Scoring" below).
 | 14 | 3 |
 | 15 | 0 |
 
-### Heart Rate (min⁻¹)
+### Heart Rate (min^-1)
 
-| Bin | Score |
-|---|---|
-| min < 33 | 4 |
-| 33 – 88 | 0 |
-| max 89 – 106 | 1 |
-| max 107 – 125 | 3 |
-| max > 125 | 6 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | max > 125 | 6 |
+| 2 | min < 33 | 4 |
+| 3 | max 107-125 | 3 |
+| 4 | max 89-106 | 1 |
+| 5 | otherwise | 0 |
 
 ### Mean Arterial Pressure (mmHg)
 
-| Bin | Score |
-|---|---|
-| min < 20.65 | 4 |
-| min 20.65 – 50.99 | 3 |
-| min 51 – 61.32 | 2 |
-| 61.33 – 143.44 | 0 |
-| max > 143.44 | 3 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | min < 20.65 | 4 |
+| 2 | min 20.65-50.99 | 3 |
+| 3 | max > 143.44 | 3 |
+| 4 | min 51-61.32 | 2 |
+| 5 | otherwise | 0 |
 
-### Respiratory Rate (min⁻¹)
+### Respiratory Rate (min^-1)
 
-| Bin | Score |
-|---|---|
-| min < 6 | 10 |
-| min 6 – 12 | 1 |
-| 13 – 22 | 0 |
-| max 23 – 30 | 1 |
-| max 31 – 44 | 6 |
-| max > 44 | 9 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | min < 6 | 10 |
+| 2 | max > 44 | 9 |
+| 3 | max 31-44 | 6 |
+| 4 | max 23-30 | 1 |
+| 5 | min < 13 | 1 |
+| 6 | otherwise | 0 |
 
-### Temperature (°C)
+### Temperature (deg C)
 
-| Bin | Score |
-|---|---|
-| min < 33.22 | 3 |
-| min or max 33.22 – 35.93 | 4 |
-| min 35.94 – 36.39 | 2 |
-| max 36.40 – 36.88 | 0 |
-| max 36.89 – 39.88 | 2 |
-| max > 39.88 | 6 |
+| Evaluation order | Bin | Score |
+|---|---|---|
+| 1 | max > 39.88 | 6 |
+| 2 | min or max 33.22-35.93 | 4 |
+| 3 | min < 33.22 | 3 |
+| 4 | min 35.94-36.39 | 2 |
+| 5 | max 36.89-39.88 | 2 |
+| 6 | otherwise | 0 |
 
 ### Urine Output (mL/day)
 
-| Range | Score |
-|---|---|
-| < 671 | 10 |
-| 671 – 1426.99 | 5 |
-| 1427 – 2543.99 | 1 |
-| 2544 – 6896 | 0 |
-| > 6896 | 8 |
+| Evaluation order | Range | Score |
+|---|---|---|
+| 1 | < 671.09 | 10 |
+| 2 | > 6896.80 | 8 |
+| 3 | 671.09-1426.99 | 5 |
+| 4 | 1427.00-2544.14 | 1 |
+| 5 | otherwise | 0 |
 
 ### Mechanical Ventilation
 
@@ -126,16 +128,24 @@ the first 24 h (see "Direction-aware Scoring" below).
 The OASIS total is the sum of the 10 component scores. Report the component
 scores alongside the total so implementation differences are auditable.
 
-## Direction-aware Scoring (min vs max)
+## Direction-aware Scoring (MIMIC labels)
 
-For Heart Rate, MAP, Respiratory Rate, and Temperature, OASIS uses the
-worst-direction observation in the first 24 h:
+For MIMIC OASIS tasks, follow the M4Bench/MIMIC SQL evaluation order in the
+tables above. This ordering is intentionally dataset-specific: if both a low
+and high extreme occur in the same first-24h window, the first matching row in
+the component table wins.
 
-- Test the **min** observation against the low-extreme bin first.
-- Test the **max** observation against the high-extreme bins next.
-- The first matching bin wins; do not sum or average across bins.
-- Temperature uniquely allows either min or max to satisfy the
-  33.22 – 35.93 °C bin (4 points); test both.
+Key conflict rules for MIMIC labels:
+
+- Heart rate prioritizes severe tachycardia (`max > 125`, 6 points) before
+  severe bradycardia (`min < 33`, 4 points).
+- MAP checks low MAP bins first, then high MAP (`max > 143.44`), then assigns
+  low-normal/normal scores.
+- Respiratory rate checks severe low RR first, then high RR bins, then mild low
+  RR.
+- Temperature prioritizes fever (`max > 39.88`, 6 points) before low-temperature
+  bins.
+- Urine output uses the exact MIMIC boundaries shown above.
 
 GCS uses the worst (minimum) value only. Pre-ICU LOS, Age, Urine Output,
 Mechanical Ventilation, and Elective Surgery are scalar — no min/max


### PR DESCRIPTION
## Summary

- Replace the abbreviated range table in OASIS `SKILL.md` with per-component cutoff tables adapted from Johnson AEW et al. (*Crit Care Med* 2013, Table 2).
- Add label-faithful, dataset-specific min/max scoring guidance for OASIS components where first-match ordering affects labels.
- Applied consistently to `skills/` and `skills-nosql/` variants of `eicu-oasis`, `mimic-oasis-24h`, and `mimic-oasis-24h-raw`.
- MIMIC task skills document the M4Bench/MIMIC ordering and threshold precision used by `ground_truth/oasis-24h.sql`; eICU task skills document the current eICU-code/M4Bench ordering and eICU-specific operational details.
- No changes to ground truth, task.toml, or evaluation behavior.