### PR TITLE
Add clinical-accuracy review for 5 benchmark task families

### DIFF
--- a/benchmark/tasks/apsiii/PROVENANCE.yaml
+++ b/benchmark/tasks/apsiii/PROVENANCE.yaml
@@ -1,0 +1,68 @@
+sources:
+  - "Adapted from MIT-LCP mimic-code apsiii.sql; deviations documented in ground-truth SQL header."
+
+created:
+  by: m4bench-task-authoring
+  role: authoring
+  date: 2026-03-28
+
+reviews:
+  - by: Ahram Han, MD
+    date: 2026-05-03
+    scope: clinical-accuracy
+    notes: |
+      Cross-checked against the APS-III scoring table in van Valburg 2024
+      (Suppl.); discrepancies traced back to Knaus 1991.
+
+      ## instruction.md
+      - time window and 16 component wchema matches orinigal paper.
+      - "Treat missing data as normal (score 0)" is a documented benchmark
+        simplification, internally consistent with ground-truth SQL.
+
+      ## skills/apsiii-score/SKILL.md
+      - Score components, normal reference values, and procedural notes
+        match published APS-III.
+      - Benchmark-safe subset of the production skill at
+        src/m4/skills/clinical/apsiii-score (precomputed-table examples
+        removed, "M4Bench Use" note added).
+      - Axillary-temperature correction not implemented (acknowledged in
+        SKILL.md note 6).
+
+      ## ground-truth SQL (also served verbatim as the skills-rawsql variant)
+      Deviations from mimic-code, already documented in SQL header that seems accceptable: 
+        - Final-SELECT COALESCE component scores to 0 (matches the
+          "missing as normal" instruction).
+        - Blood-gas charttime capped at first 24h via
+          LEAST(outtime, intime + 1 day), matching APS-III's Day-1 scope.
+        - "Worst from normal" tiebreaker fix for 6 variables (resp_rate,
+          hematocrit, wbc, sodium, albumin, glucose) corrects mimic-code
+          self-comparison bug.
+
+      Adaptation that seem acceptable: 
+        - ARF chronic-renal exclusion via ICD-9 585.4-585.6 / ICD-10
+          N18.4-N18.6 (CKD stage 4 through ESRD); stricter than Knaus's
+          "chronic dialysis" criterion but clinically defensible.
+
+      Discrepancies vs. Knaus 1991, likely inherited from mimic-code; for
+      project leadership to evaluate against the existing "correct
+      mimic-code" policy:
+        1. Respiratory rate in ventilated patients: SQL applies
+           `vent = 1 AND resp_rate < 14 -> 0` as a blanket override, but
+           per Knaus 1991 Fig. 1 the exception applies only to RR 6-12.
+           Vented patients with RR <=5 score 0 (literal Knaus: 17 -
+           apnea/oversedation) and RR=13 scores 0 (literal Knaus: 7).
+        2. PaO2 vs A-aDO2 selection: (vented + FiO2 <50%) and
+           (non-vented + FiO2 >=50%) fall into neither pathway,
+           producing NULL -> COALESCE'd to 0. Per Knaus, both groups
+           should use PaO2. Systematically under-scores oxygenation
+           in those subgroups.
+
+
+references:
+  - "Knaus WA, Wagner DP, Draper EA, et al. The APACHE III prognostic system: risk prediction of hospital mortality for critically ill hospitalized adults. Chest. 1991;100(6):1619-1636."
+  - "van Valburg MK, et al. Predicting 30-day mortality in intensive care unit patients with ischaemic stroke and intracerebral haemorrhage. Eur J Anaesthesiol. 2024;41(2):105-113."
+
+changelog:
+  - version: "1.0"
+    date: 2026-05-03
+    summary: Initial clinical-accuracy review of APS-III benchmark task.

--- a/benchmark/tasks/apsiii/PROVENANCE.yaml
+++ b/benchmark/tasks/apsiii/PROVENANCE.yaml
@@ -15,7 +15,7 @@ reviews:
       (Suppl.); discrepancies traced back to Knaus 1991.
 
       ## instruction.md
-      - time window and 16 component wchema matches orinigal paper.
+      - Time window and 16-component schema match the original paper.
       - "Treat missing data as normal (score 0)" is a documented benchmark
         simplification, internally consistent with ground-truth SQL.
 
@@ -29,7 +29,7 @@ reviews:
         SKILL.md note 6).
 
       ## ground-truth SQL (also served verbatim as the skills-rawsql variant)
-      Deviations from mimic-code, already documented in SQL header that seems accceptable: 
+      Deviations from mimic-code, already documented in SQL header as acceptable:
         - Final-SELECT COALESCE component scores to 0 (matches the
           "missing as normal" instruction).
         - Blood-gas charttime capped at first 24h via
@@ -38,7 +38,7 @@ reviews:
           hematocrit, wbc, sodium, albumin, glucose) corrects mimic-code
           self-comparison bug.
 
-      Adaptation that seem acceptable: 
+      Adaptation that seems acceptable:
         - ARF chronic-renal exclusion via ICD-9 585.4-585.6 / ICD-10
           N18.4-N18.6 (CKD stage 4 through ESRD); stricter than Knaus's
           "chronic dialysis" criterion but clinically defensible.
@@ -56,8 +56,6 @@ reviews:
            producing NULL -> COALESCE'd to 0. Per Knaus, both groups
            should use PaO2. Systematically under-scores oxygenation
            in those subgroups.
-
-
 references:
   - "Knaus WA, Wagner DP, Draper EA, et al. The APACHE III prognostic system: risk prediction of hospital mortality for critically ill hospitalized adults. Chest. 1991;100(6):1619-1636."
   - "van Valburg MK, et al. Predicting 30-day mortality in intensive care unit patients with ischaemic stroke and intracerebral haemorrhage. Eur J Anaesthesiol. 2024;41(2):105-113."

--- a/benchmark/tasks/charlson/mimic-charlson-raw/PROVENANCE.yaml
+++ b/benchmark/tasks/charlson/mimic-charlson-raw/PROVENANCE.yaml
@@ -36,7 +36,7 @@ reviews:
       correct per Quan/Charlson. Age-score cutoffs (<=50, 51-60, 61-70,
       71-80, >80 mapping to 0/1/2/3/4) match Charlson 1994.
 
-      No clinical-accuracy issues identified. 
+      No clinical-accuracy issues identified.
 
       Acceptable benchmark adaptation:
         - Drops `mimiciv_derived.charlson` and `mimiciv_derived.age` in

--- a/benchmark/tasks/charlson/mimic-charlson-raw/PROVENANCE.yaml
+++ b/benchmark/tasks/charlson/mimic-charlson-raw/PROVENANCE.yaml
@@ -1,0 +1,55 @@
+sources:
+  - "Adapted from MIT-LCP mimic-code charlson.sql; ICD mappings via Quan 2005."
+
+created:
+  by: m4bench-task-authoring
+  role: authoring
+  date: 2026-03-30
+
+reviews:
+  - by: Ahram Han, MD
+    date: 2026-05-03
+    scope: clinical-accuracy
+    notes: |
+      Cross-checked against Quan 2005 ICD-9-CM/ICD-10 coding algorithms
+      and the Charlson 1987 weighting / Charlson 1994 age-score scheme.
+
+      ## instruction.md
+      - Citations (Charlson 1987, Quan 2005) and output schema match the
+        Charlson Combined Comorbidity Index: 17 condition flags +
+        age_score + total CCI.
+      - "Admissions with no diagnosis codes -> all flags = 0, CCI =
+        age_score only" is internally consistent with the LEFT JOIN
+        behaviour in ground-truth SQL and matches the standard
+        administrative-data convention.
+
+      ## skills/comorbidity-score/SKILL.md
+      - Clinical content identical to the production skill at
+        src/m4/skills/clinical/comorbidity-score
+
+      ## ground-truth SQL (also served verbatim as skills-rawsql)
+      Spot-checked 11 of 17 condition ICD lists against Quan 2005 (MI,
+      CHF, PVD, cerebrovascular, dementia, chronic pulmonary, rheumatic,
+      PUD, mild liver, severe liver, AIDS) — all match. Hierarchy logic
+      applied at scoring level via GREATEST() (severe overrides mild,
+      with_cc overrides without_cc, metastatic overrides solid tumor) —
+      correct per Quan/Charlson. Age-score cutoffs (<=50, 51-60, 61-70,
+      71-80, >80 mapping to 0/1/2/3/4) match Charlson 1994.
+
+      No clinical-accuracy issues identified. 
+
+      Acceptable benchmark adaptation:
+        - Drops `mimiciv_derived.charlson` and `mimiciv_derived.age` in
+          raw mode; agent must derive age from
+          `patients.anchor_age + (admittime - anchor_year)` and compute
+          all 17 condition flags from `diagnoses_icd`.
+
+references:
+  - "Charlson ME, et al. A new method of classifying prognostic comorbidity in longitudinal studies: development and validation. J Chronic Dis. 1987;40(5):373-83."
+  - "Charlson M, et al. Validation of a combined comorbidity index. J Clin Epidemiol. 1994;47(11):1245-51."
+  - "Quan H, et al. Coding algorithms for defining comorbidities in ICD-9-CM and ICD-10 administrative data. Med Care. 2005;43(11):1130-9."
+
+changelog:
+  - version: "1.0"
+    date: 2026-05-03
+    summary: Initial clinical-accuracy review of Charlson benchmark task.

--- a/benchmark/tasks/creatinine-baseline/PROVENANCE.yaml
+++ b/benchmark/tasks/creatinine-baseline/PROVENANCE.yaml
@@ -1,0 +1,88 @@
+sources:
+  - "Adapted from MIT-LCP mimic-code creatinine_baseline.sql; MDRD-imputation method per ADQI 2004 / KDIGO 2012."
+
+created:
+  by: m4bench-task-authoring
+  role: authoring
+  date: 2026-03-30
+
+reviews:
+  - by: Ahram Han, MD
+    date: 2026-05-03
+    scope: clinical-accuracy
+    notes: |
+      Reviewed instruction.md, skills/baseline-creatinine/SKILL.md, and
+      ground-truth SQL against the AKI baseline-creatinine literature.
+
+      ## instruction.md
+      Two changes applied in this review (both task variants):
+      - **Citation corrected** from "Siew et al. (CJASN, 2012)" to
+        "KDIGO AKI Clinical Practice Guideline (2012)". Siew 2012
+        evaluated four methods using preadmission OUTPATIENT
+        creatinine — none of which is implemented here, since MIMIC
+        has no outpatient Cr. The implemented MDRD-imputation-at-
+        eGFR-75 approach matches KDIGO 2012's fallback rule, which
+        traces to the ADQI/RIFLE consensus (Bellomo et al. 2004).
+      - **Race-free MDRD directive added**: appended "Use the MDRD
+        equation without the race coefficient, consistent with
+        current race-free eGFR practice." This disambiguates a real
+        gap between the cited reference (KDIGO 2012 specifies MDRD
+        with race coefficient) and the ground-truth SQL (uses MDRD
+        without race coefficient). Without this clarification, agents
+        following the citation literally would systematically mismatch
+        ground truth on Black patients (~30% of MIMIC-IV). The
+        directive is also ethically aligned with 2021 NKF/ASN
+        race-free guidance.
+      - Output schema and "adults only (age >= 18)" appropriate.
+
+      ## skills/baseline-creatinine/SKILL.md
+      - Clinical content matches the sql logic of mimic-code repository.
+      - Hierarchical decision rule (use lowest if <=1.1, use lowest if
+        CKD, else MDRD imputation) is a mimic-code-specific hybrid;
+        only step 4 (MDRD imputation at eGFR=75) is canonically
+        supported by KDIGO 2012.
+      - MDRD formula correctly back-solves for Cr at assumed eGFR=75 as
+        supported by KDIGO 2012.
+      - ** However, the SQL implements MDRD-IV with the Black race coefficient
+        (1.21) dropped — i.e., it is not canonical MDRD-IV recommended by the 
+        by KDIGO 2012.** This is consistent with 2021 NKF/ASN race-free guidance for routine eGFR but matches no specific published equation: it differs from canonical MDRD-IV (which retains the race coefficient,
+        as used in ADQI 2004 / KDIGO 2012) and from CKD-EPI 2021 (the properly recalibrated race-free equation). Net: a hybrid that aligns with neither the original ADQI/KDIGO methodology nor the post-2021 race-free standard. Affects Black/African-American patients (~30% of MIMIC-IV). The proper modernization is forward to CKD-EPI 2021 race-free, not back to MDRD-with-race. The current dropped-race state is an imperfect-but-ethically-correct intermediate; recommend transition to CKD-EPI 2021 once KDIGO 2026 finalizes.
+
+      ## ground-truth SQL
+      Applies to both task variants (mimic-creatinine-baseline and
+      mimic-creatinine-baseline-raw); they share the same ground-truth
+      SQL and differ only in which derived tables are dropped.
+      - Same MDRD formula, hierarchy logic, and final CASE as the
+        production scripts/creatinine_baseline.sql; differences vs
+        production are formatting and comment header only.
+      - Acceptable benchmark adaptation: standard variant drops only
+        `mimiciv_derived.creatinine_baseline`. Raw variant additionally
+        drops 10 more derived tables (age, chemistry, kdigo_creatinine,
+        kdigo_stages, meld, oasis, sofa, apsiii, first_day_lab) —
+        agent must derive age from `patients.anchor_age + (admittime -
+        anchor_year)` and aggregate creatinine from
+        `mimiciv_hosp.labevents` directly.
+      - **Equation note**: SQL implements MDRD-IV with the Black race
+        coefficient dropped (see SKILL.md section above). Restoring
+        the race coefficient to "match KDIGO 2012 literal" would be
+        inappropriate — it would systematically delay AKI detection
+        for Black patients (~30% of MIMIC-IV) by inflating their
+        imputed baseline Cr at the 1.5x AKI threshold, the same
+        disparity pattern the 2021 NKF/ASN task force rejected.
+        Modernization should go forward to CKD-EPI 2021 race-free,
+        not back to MDRD-with-race.
+
+      No computational bugs in the SQL — items above are method-choice
+      and citation-accuracy notes, not errors.
+
+references:
+  - "KDIGO Clinical Practice Guideline for Acute Kidney Injury. Kidney International Supplements. 2012;2(1):1-138."
+  - "Bellomo R, Ronco C, Kellum JA, et al. (ADQI workgroup). Acute renal failure - definition, outcome measures, animal models, fluid therapy and information technology needs: Second International Consensus Conference of the ADQI Group. Crit Care. 2004;8(4):R204-R212."
+  - "Bagshaw SM, et al. A comparison of observed versus estimated baseline creatinine for determination of RIFLE class in patients with acute kidney injury. Nephrol Dial Transplant. 2009;24(9):2739-2744."
+  - "Siew ED, et al. Estimating baseline kidney function in hospitalized patients with impaired kidney function. Clin J Am Soc Nephrol. 2012;7(5):712-719. (Background; not the implemented method)"
+  - "KDIGO 2026 AKI Clinical Practice Guideline (public review draft, March 2026)."
+
+changelog:
+  - version: "1.0"
+    date: 2026-05-03
+    summary: Initial clinical-accuracy review. Two instruction.md changes applied (both task variants): (1) citation corrected from Siew 2012 to KDIGO 2012 AKI Guideline; (2) race-free MDRD directive added to disambiguate the citation-vs-ground-truth gap on the race coefficient. Race-coefficient ethics and forward-looking KDIGO 2026 draft discrepancies documented.

--- a/benchmark/tasks/creatinine-baseline/PROVENANCE.yaml
+++ b/benchmark/tasks/creatinine-baseline/PROVENANCE.yaml
@@ -36,17 +36,26 @@ reviews:
       - Output schema and "adults only (age >= 18)" appropriate.
 
       ## skills/baseline-creatinine/SKILL.md
-      - Clinical content matches the sql logic of mimic-code repository.
+      - Clinical content matches the SQL logic of the mimic-code repository.
       - Hierarchical decision rule (use lowest if <=1.1, use lowest if
         CKD, else MDRD imputation) is a mimic-code-specific hybrid;
         only step 4 (MDRD imputation at eGFR=75) is canonically
         supported by KDIGO 2012.
       - MDRD formula correctly back-solves for Cr at assumed eGFR=75 as
         supported by KDIGO 2012.
-      - ** However, the SQL implements MDRD-IV with the Black race coefficient
-        (1.21) dropped — i.e., it is not canonical MDRD-IV recommended by the 
-        by KDIGO 2012.** This is consistent with 2021 NKF/ASN race-free guidance for routine eGFR but matches no specific published equation: it differs from canonical MDRD-IV (which retains the race coefficient,
-        as used in ADQI 2004 / KDIGO 2012) and from CKD-EPI 2021 (the properly recalibrated race-free equation). Net: a hybrid that aligns with neither the original ADQI/KDIGO methodology nor the post-2021 race-free standard. Affects Black/African-American patients (~30% of MIMIC-IV). The proper modernization is forward to CKD-EPI 2021 race-free, not back to MDRD-with-race. The current dropped-race state is an imperfect-but-ethically-correct intermediate; recommend transition to CKD-EPI 2021 once KDIGO 2026 finalizes.
+      - **However, the SQL implements MDRD-IV with the Black race coefficient
+        (1.21) dropped — i.e., it is not canonical MDRD-IV recommended by
+        KDIGO 2012.** This is consistent with 2021 NKF/ASN race-free guidance
+        for routine eGFR but matches no specific published equation: it differs
+        from canonical MDRD-IV (which retains the race coefficient, as used in
+        ADQI 2004 / KDIGO 2012) and from CKD-EPI 2021 (the properly
+        recalibrated race-free equation). Net: a hybrid that aligns with
+        neither the original ADQI/KDIGO methodology nor the post-2021 race-free
+        standard. Affects Black/African-American patients (~30% of MIMIC-IV).
+        The proper modernization is forward to CKD-EPI 2021 race-free, not back
+        to MDRD-with-race. The current dropped-race state is an
+        imperfect-but-ethically-correct intermediate; recommend transition to
+        CKD-EPI 2021 once KDIGO 2026 finalizes.
 
       ## ground-truth SQL
       Applies to both task variants (mimic-creatinine-baseline and
@@ -85,4 +94,9 @@ references:
 changelog:
   - version: "1.0"
     date: 2026-05-03
-    summary: Initial clinical-accuracy review. Two instruction.md changes applied (both task variants): (1) citation corrected from Siew 2012 to KDIGO 2012 AKI Guideline; (2) race-free MDRD directive added to disambiguate the citation-vs-ground-truth gap on the race coefficient. Race-coefficient ethics and forward-looking KDIGO 2026 draft discrepancies documented.
+    summary: >-
+      Initial clinical-accuracy review. Two instruction.md changes applied
+      (both task variants): (1) citation corrected from Siew 2012 to KDIGO 2012
+      AKI Guideline; (2) race-free MDRD directive added to disambiguate the
+      citation-vs-ground-truth gap on the race coefficient. Race-coefficient
+      ethics and forward-looking KDIGO 2026 draft discrepancies documented.

--- a/benchmark/tasks/creatinine-baseline/mimic-creatinine-baseline-raw/instruction.md
+++ b/benchmark/tasks/creatinine-baseline/mimic-creatinine-baseline-raw/instruction.md
@@ -4,8 +4,9 @@ All derived shortcut tables have been removed from the task database.
 You must derive the requested concept from source clinical tables.
 
 Estimate the baseline (pre-illness) serum creatinine for each hospital
-admission, following the approach in Siew et al. (CJASN, 2012).
-Adults only (age >= 18).
+admission, following the KDIGO AKI Clinical Practice Guideline (2012).
+Use the MDRD equation without the race coefficient, consistent with
+current race-free eGFR practice. Adults only (age >= 18).
 
 Output a CSV file to `{output_path}` with these exact columns:
 hadm_id, gender, age, scr_min, ckd, mdrd_est, scr_baseline

--- a/benchmark/tasks/creatinine-baseline/mimic-creatinine-baseline/instruction.md
+++ b/benchmark/tasks/creatinine-baseline/mimic-creatinine-baseline/instruction.md
@@ -1,8 +1,9 @@
 # Task: Estimate Baseline Creatinine
 
 Estimate the baseline (pre-illness) serum creatinine for each hospital
-admission, following the approach in Siew et al. (CJASN, 2012).
-Adults only (age >= 18).
+admission, following the KDIGO AKI Clinical Practice Guideline (2012).
+Use the MDRD equation without the race coefficient, consistent with
+current race-free eGFR practice. Adults only (age >= 18).
 
 Output a CSV file to `{output_path}` with these exact columns:
 hadm_id, gender, age, scr_min, ckd, mdrd_est, scr_baseline

--- a/benchmark/tasks/gcs/PROVENANCE.yaml
+++ b/benchmark/tasks/gcs/PROVENANCE.yaml
@@ -1,0 +1,114 @@
+sources:
+  - "MIMIC variant: adapted from MIT-LCP mimic-code first_day_gcs.sql / gcs.sql; intubated-patient handling per SAPS-II convention (Le Gall 1993)."
+  - "eICU variant: adapted from MIT-LCP eicu-code pivoted-gcs.sql."
+
+created:
+  by: m4bench-task-authoring
+  role: authoring
+  date: 2026-03-28
+
+reviews:
+  - by: Ahram Han, MD
+    date: 2026-05-03
+    scope: clinical-accuracy
+    notes: |
+      Family-level review covering both task variants (mimic-gcs-24h-raw
+      and eicu-gcs). The two variants implement the same clinical concept
+      against different EHR schemas; they are not directly comparable
+      across databases (forced asymmetries from data-model differences)
+      and are intended as separate test buckets, not a paired
+      MIMIC-vs-eICU comparison.
+
+      ## Common to both variants
+      - **Citation**: Teasdale & Jennett 1974 (the GCS scale itself).
+      - **Window**: first 24 hours (-6h to +24h from ICU admission).
+      - **Output**: minimum total GCS and the component values at the
+        time of the minimum.
+      - **No-data fallback**: default to normal (gcs_min=15, motor=6,
+        verbal=5, eyes=4).
+
+      ## mimic-gcs-24h-raw
+      Reviewed against the GCS scale and SAPS-II handling rule.
+
+      Acceptable conventions (mimic-code-aligned):
+        - **SAPS-II "= 15 for intubated" rule**: when verbal is documented
+          as "No Response-ETT", total GCS is set to 15 (assumed
+          pre-intubation baseline). This is per Le Gall 1993 (SAPS-II),
+          not Teasdale 1974. Clinically debatable for brain-injured
+          populations where pre-intubation GCS may have been < 15, but
+          consistent across instruction.md / SKILL.md / ground-truth
+          SQL; defensible as a data-collection convention.
+        - **Verbal = 0 sentinel** for intubated patients: mimic-code
+          convention (most clinical practice uses "1-T" or similar).
+        - **6-hour carry-forward** for missing components: mimic-code
+          convention; reasonable for nurse-charting cadence.
+
+      **Instruction clarification applied in this review:**
+        Added a sentence specifying "Report `gcs_verbal = 0` in the
+        output for intubated patients (sentinel value indicating
+        'untestable'); do not substitute a numeric verbal score." This
+        disambiguates a real gap — agents in the decoy / no-skill
+        conditions could not infer the 0-sentinel convention from
+        clinical knowledge alone, and would have written verbal = 1, 5,
+        or NULL instead, mismatching ground truth. The clarification
+        targets benchmark fairness across conditions, not clinical
+        accuracy.
+
+      Internal alignment (instruction / SKILL / SQL): verified after
+      the clarification.
+
+      ## eicu-gcs
+      Reviewed against the GCS scale and eICU schema realities.
+
+      Acceptable conventions (eicu-code-aligned):
+        - **No intubation rule**: forced by eICU schema (no ETT sentinel
+          in nursecharting). Intubated patients are scored from whatever
+          verbal score is documented. Cross-database asymmetry vs MIMIC
+          is real but not "fixable" without schema augmentation.
+        - **"Assume normal" for missing components** (rather than
+          carry-forward): differs from MIMIC; defensible given eICU's
+          text-based nursecharting cadence. Can produce falsely-high
+          scores when components are charted at different times — a
+          known limitation.
+        - **Range validation 3-15**: defensible (text-based logging is
+          error-prone).
+        - **Charted total preferred over computed sum**: trusts the
+          bedside record over re-derivation; reasonable.
+
+      **Instruction clarifications applied in this review:**
+        Added one paragraph: "When a charted total GCS value is
+        available and within the valid range (3-15), use it as the
+        total; otherwise compute total from motor + verbal + eyes. If
+        multiple timepoints share the same minimum total GCS, select
+        the earliest chart offset." This closes three implementation
+        details (charted-total preference, range validation, tie-break)
+        that an agent in decoy / no-skill conditions could not reliably
+        infer from clinical knowledge. Targets benchmark fairness, not
+        clinical accuracy.
+
+      Internal alignment (instruction / SKILL / SQL): verified after
+      the clarifications.
+
+      ## Citation lineage
+      - Teasdale 1974 — GCS scale (cited in both variants).
+      - Le Gall 1993 (SAPS-II) — origin of the "= 15 for intubated"
+        rule in MIMIC variant; not currently cited in instruction.md
+        but cited in production skill discussion.
+      - Mimic-code / eicu-code conventions — implementation lineage.
+
+      ## Notes for benchmark coordination
+      Two instruction.md files were modified in this review pass.
+      Benchmark runs against pre-edit instruction.md are not directly
+      comparable to runs against post-edit instruction.md, particularly
+      in skills-decoy and no-skill conditions. Worth flagging to
+      project leadership before scheduling re-run.
+
+references:
+  - "Teasdale G, Jennett B. Assessment of coma and impaired consciousness: A practical scale. Lancet. 1974;2(7872):81-84."
+  - "Teasdale G, et al. The Glasgow Coma Scale at 40 years: standing the test of time. Lancet Neurology. 2014;13(8):844-854."
+  - "Le Gall JR, Lemeshow S, Saulnier F. A new Simplified Acute Physiology Score (SAPS II) based on a European/North American multicenter study. JAMA. 1993;270(24):2957-2963. (Source of the '= 15 for intubated' rule used in mimic-gcs-24h-raw)"
+
+changelog:
+  - version: "1.0"
+    date: 2026-05-03
+    summary: Initial clinical-accuracy review covering both task variants. Added instruction.md clarifications for benchmark fairness in skills-decoy and no-skill conditions (MIMIC: gcs_verbal=0 sentinel for intubated; eICU: charted-total preference, range validation 3-15, tie-break by earliest offset). No SQL changes; both variants verified internally consistent across instruction.md / SKILL.md / ground-truth SQL.

--- a/benchmark/tasks/gcs/PROVENANCE.yaml
+++ b/benchmark/tasks/gcs/PROVENANCE.yaml
@@ -111,4 +111,10 @@ references:
 changelog:
   - version: "1.0"
     date: 2026-05-03
-    summary: Initial clinical-accuracy review covering both task variants. Added instruction.md clarifications for benchmark fairness in skills-decoy and no-skill conditions (MIMIC: gcs_verbal=0 sentinel for intubated; eICU: charted-total preference, range validation 3-15, tie-break by earliest offset). No SQL changes; both variants verified internally consistent across instruction.md / SKILL.md / ground-truth SQL.
+    summary: >-
+      Initial clinical-accuracy review covering both task variants. Added
+      instruction.md clarifications for benchmark fairness in skills-decoy and
+      no-skill conditions (MIMIC: gcs_verbal=0 sentinel for intubated; eICU:
+      charted-total preference, range validation 3-15, tie-break by earliest
+      offset). No SQL changes; both variants verified internally consistent
+      across instruction.md / SKILL.md / ground-truth SQL.

--- a/benchmark/tasks/gcs/eicu-gcs/instruction.md
+++ b/benchmark/tasks/gcs/eicu-gcs/instruction.md
@@ -8,6 +8,11 @@ When a component is missing at a given timepoint, assume normal for
 that component. If no GCS data exists at all for a stay, default to
 normal (gcs_min=15, eyes=4, verbal=5, motor=6).
 
+When a charted total GCS value is available and within the valid range
+(3-15), use it as the total; otherwise compute total from
+motor + verbal + eyes. If multiple timepoints share the same minimum
+total GCS, use the row with the earliest chart offset.
+
 Report the minimum total GCS and the component values at the time of
 the minimum total score.
 

--- a/benchmark/tasks/gcs/mimic-gcs-24h-raw/instruction.md
+++ b/benchmark/tasks/gcs/mimic-gcs-24h-raw/instruction.md
@@ -9,7 +9,9 @@ to 24 hours after admission) (Teasdale & Jennett, Lancet, 1974).
 
 For intubated patients who cannot give a verbal response, the verbal
 component is untestable and the total GCS is assumed to be 15
-(unimpaired consciousness).
+(unimpaired consciousness). Report `gcs_verbal = 0` in the output for
+intubated patients (sentinel value indicating "untestable"); do not
+substitute a numeric verbal score.
 
 When a component is missing at a given time, use the most recent value
 within 6 hours. If no GCS data exists at all for a stay, default to

--- a/benchmark/tasks/kdigo/PROVENANCE.yaml
+++ b/benchmark/tasks/kdigo/PROVENANCE.yaml
@@ -1,0 +1,121 @@
+sources:
+  - "Adapted from MIT-LCP mimic-code kdigo_stages.sql / kdigo_creatinine.sql / kdigo_uo.sql; staging criteria per KDIGO 2012 AKI Clinical Practice Guideline."
+
+created:
+  by: m4bench-task-authoring
+  role: authoring
+  date: 2026-03-28
+
+reviews:
+  - by: Ahram Han, MD
+    date: 2026-05-04
+    scope: clinical-accuracy
+    notes: |
+      Family-level review covering both task variants
+      (mimic-kdigo-48h and mimic-kdigo-48h-raw). The two variants
+      share the same instruction.md content (raw variant adds the
+      standard 4-line raw-mode boilerplate) and the same
+      ground-truth SQL.
+
+      ## instruction.md
+      - Citation (KDIGO 2012 Clinical Practice Guideline) and 48h
+        window match the staging definition.
+      - "Treat missing data as no AKI (stage 0)" is internally
+        consistent with the SQL's COALESCE-to-0 at output.
+      - "Final AKI stage = max across creatinine, UO, CRRT" matches
+        the SQL's MAX-across-three-stage-columns logic.
+      - Output schema matches SQL.
+
+      ## skills/kdigo-aki-staging/SKILL.md
+      - KDIGO 2012 staging criteria correctly stated for both
+        creatinine-based and urine-output-based criteria, including
+        the Stage 3 "Cr >= 4.0 mg/dL with acute increase" qualifier
+        per the original KDIGO footnote.
+      - Implementation notes appropriately document the 48h vs 7-day
+        window distinction, UO weight estimation uncertainty, and
+        the 6h ICU-stay prerequisite for UO staging.
+      - SKILL.md note 7 references `aki_stage_smoothed` (a column in
+        the upstream `mimiciv_derived.kdigo_stages` table) which is
+        not part of the benchmark output schema. Informational only,
+        not material to scoring.
+
+      ## ground-truth SQL
+      - Thin wrapper aggregating the upstream
+        `mimiciv_derived.kdigo_stages` time-series table; the actual
+        KDIGO computational logic (creatinine baseline, UO rate
+        windows, CRRT detection) lives in mimic-code's component
+        scripts (kdigo_creatinine.sql, kdigo_uo.sql, kdigo_stages.sql).
+        The benchmark is therefore testing whether the agent can
+        reproduce the upstream mimic-code logic, not whether the
+        agent can independently derive the staging math.
+      - Standard variant drops only `mimiciv_derived.kdigo_stages`.
+        Raw variant drops 12 derived tables (kdigo_stages,
+        kdigo_creatinine, kdigo_uo, crrt, chemistry, first_day_lab,
+        first_day_rrt, first_day_sofa, first_day_urine_output,
+        first_day_weight, icustay_detail, icustay_hourly,
+        icustay_times). Raw-variant agent must derive the entire
+        KDIGO pipeline from `chartevents`, `inputevents`,
+        `outputevents`, `labevents`, and `procedureevents` directly.
+      - 48h window enforced via charttime filter against icustay intime.
+
+      Defensible benchmark conventions / mimic-code-aligned choices:
+        - **Baseline creatinine = lowest Cr in past 7 days**: a
+          mimic-code-specific operationalization. KDIGO 2012 itself
+          defines baseline as "known or presumed within 3 months,"
+          which is intentionally open-ended; "lowest in past 7 days"
+          is one widely-used choice but not the only valid one. See
+          benchmark/tasks/creatinine-baseline/PROVENANCE.yaml for
+          the parallel discussion of baseline-Cr methodology.
+        - **CRRT inclusion (any CRRT row -> Stage 3)**: KDIGO 2012
+          specifies "initiation of RRT" as a Stage 3 criterion;
+          implementation flags any CRRT row as Stage 3 regardless of
+          initiation context. Edge case: chronic dialysis patients
+          on CRRT for ESRD would be flagged as Stage 3 AKI even
+          though they have no acute injury. Defensible
+          operationalization (matches mimic-code), but worth
+          documenting.
+        - **UO weight uncertainty**: weight in MIMIC is recorded from
+          multiple sources at varying times; UO rate calculation
+          inherits that uncertainty. Standard known limitation;
+          documented in SKILL.md note 5.
+
+      No clinical-accuracy bugs identified. Items above are
+      method-choice / operationalization notes, not errors. No
+      instruction.md changes applied (KDIGO criteria are well-
+      specified in the cited reference, and both not-specified
+      choices — baseline approach and CRRT inclusion — are
+      clinically inferable interpretations rather than arbitrary
+      conventions).
+
+      ## Raw-variant operationalization variance
+      The raw variant requires the agent to derive kdigo_creatinine,
+      kdigo_uo, and crrt from raw tables — each with multiple
+      clinically defensible operationalizations (baseline definition,
+      weight source, hourly UO aggregation, CRRT source events,
+      anuria threshold). SKILL.md anchors some choices (baseline =
+      lowest-in-7-days; +0.3 reference = lowest-in-48h; CRRT = any
+      row) but not others (weight source, hourly aggregation, CRRT
+      source events). The raw variant therefore tests reproduction
+      of mimic-code-specific operationalizations more than
+      independent KDIGO derivation; agents making clinically
+      defensible but different choices may score lower despite
+      correct reasoning. Worth disclosing in any paper using
+      raw-variant scores.
+
+      ## Forward-looking
+      KDIGO 2026 AKI Clinical Practice Guideline (public review
+      draft, March 2026) does not substantially change the staging
+      criteria themselves; the 2012 criteria remain authoritative.
+      Updates in the 2026 draft primarily concern baseline-Cr
+      methodology (covered in the creatinine-baseline review). No
+      KDIGO-staging-specific changes anticipated for this task.
+
+references:
+  - "KDIGO Clinical Practice Guideline for Acute Kidney Injury. Kidney International Supplements. 2012;2(1):1-138."
+  - "Kellum JA, Lameire N. Diagnosis, evaluation, and management of acute kidney injury: a KDIGO summary. Critical Care. 2013;17(1):204."
+  - "KDIGO 2026 AKI Clinical Practice Guideline (public review draft, March 2026)."
+
+changelog:
+  - version: "1.0"
+    date: 2026-05-04
+    summary: Initial clinical-accuracy review of KDIGO benchmark task family. Verified KDIGO 2012 staging criteria correctly implemented; documented baseline-Cr operationalization (lowest in 7 days), CRRT inclusion convention (any vs initiation), and UO weight uncertainty. No instruction.md or SQL changes.


### PR DESCRIPTION
PROVENANCE.yaml files added (clinician review attestation):
- apsiii: documents two discrepancies vs Knaus 1991 inherited from mimic-code (RR-vent rule too broad; PaO2/A-aDO2 selection gaps for vented+low-FiO2 and non-vented+high-FiO2)
- charlson: clean review; spot-checked Quan 2005 ICD lists for 11 of 17 conditions
- creatinine-baseline: covers both task variants; documents citation correction, race-coefficient ethics, and KDIGO 2026 draft forward-looking notes
- gcs: covers both eicu-gcs and mimic-gcs-24h-raw variants; documents per-database asymmetries (SAPS-II rule, carry-forward, schema differences)
- kdigo: documents baseline operationalization, CRRT inclusion convention, and raw-variant operationalization variance

Instruction.md clarifications applied for benchmark fairness in skills-decoy and no-skill conditions:
- creatinine-baseline (both variants): citation Siew 2012 -> KDIGO 2012; race-free MDRD directive added
- gcs MIMIC variant: gcs_verbal=0 sentinel for intubated patients
- gcs eICU variant: charted-total preference, range validation 3-15, tie-break by earliest offset
