### PR TITLE
Add service-backed JSON CLI output

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -125,6 +125,33 @@ Stable command error codes are `dataset_not_found`, `backend_incompatible`,
 `invalid_backend`, `invalid_option`, `project_id_required`, and
 `dataset_incompatible`.
 
+`m4 init DATASET --json` uses the same result/error envelope and runs
+non-interactively. Human prompts, progress panels, and download output are
+suppressed from stdout. Successful results include deterministic paths and step
+states:
+
+```json
+{
+  "version": 1,
+  "ok": true,
+  "command": "init",
+  "dataset": "mimic-iv",
+  "db_path": "/absolute/path/to/mimic_iv.duckdb",
+  "parquet_root": "/absolute/path/to/parquet/mimic-iv",
+  "raw_root": "/absolute/path/to/raw_files/mimic-iv",
+  "steps": [
+    {"name": "raw_files", "status": "blocked", "message": "Download manually and rerun init."},
+    {"name": "parquet", "status": "skipped"},
+    {"name": "database", "status": "skipped"}
+  ],
+  "warnings": []
+}
+```
+
+Init step status is one of `skipped`, `completed`, `blocked`, or `failed`.
+Credentialed/manual-download cases that the human CLI treats as informational
+return `ok: true` with blocked or skipped steps.
+
 ### MCP Client Configuration
 
 ```bash

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -49,6 +49,82 @@ uv run m4 status --all
 uv run m4 status --derived
 ```
 
+### CLI JSON Output
+
+Automation-friendly commands print JSON only to stdout when `--json` is used.
+Validation errors handled inside the command use a stable envelope and exit
+non-zero.
+
+`m4 status --json` prints a status snapshot:
+
+```json
+{
+  "version": 1,
+  "active_dataset": "mimic-iv",
+  "backend": "duckdb",
+  "bigquery_project_id": "my-project",
+  "datasets": [
+    {
+      "name": "mimic-iv",
+      "active": true,
+      "parquet_present": true,
+      "db_present": true,
+      "parquet_root": "/absolute/path/to/parquet",
+      "db_path": "/absolute/path/to/mimic_iv.duckdb",
+      "bigquery_available": true,
+      "row_count": 431231,
+      "parquet_size_gb": 8.5,
+      "derived": {
+        "supported": true,
+        "total": 42,
+        "materialized": 42,
+        "bigquery": false
+      },
+      "warnings": []
+    }
+  ]
+}
+```
+
+Dataset `warnings` is a list of stable warning codes. Currently documented
+status warnings:
+
+- `parquet_path_mismatch`: row-count verification could not read the Parquet
+  path referenced by the local DuckDB views.
+
+`m4 use TARGET --json` and `m4 backend BACKEND --json` wrap command results in
+an `ok` envelope:
+
+```json
+{
+  "version": 1,
+  "ok": true,
+  "command": "use",
+  "active_dataset": "mimic-iv",
+  "backend": "duckdb",
+  "warnings": ["local_db_missing"]
+}
+```
+
+Command errors use the same envelope with `ok: false`:
+
+```json
+{
+  "version": 1,
+  "ok": false,
+  "command": "backend",
+  "error": {
+    "code": "project_id_required",
+    "message": "BigQuery backend requires a project ID.",
+    "hint": "Set it with: m4 backend bigquery --project-id <ID>"
+  }
+}
+```
+
+Stable command error codes are `dataset_not_found`, `backend_incompatible`,
+`invalid_backend`, `invalid_option`, `project_id_required`, and
+`dataset_incompatible`.
+
 ### MCP Client Configuration
 
 ```bash

--- a/src/m4/__init__.py
+++ b/src/m4/__init__.py
@@ -13,7 +13,7 @@ Quick Start:
 For MCP server usage, run: m4 serve
 """
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 
 # Expose API functions at package level for easy imports
 from vitrine import show

--- a/src/m4/cli.py
+++ b/src/m4/cli.py
@@ -9,8 +9,6 @@ from typing import Annotated, Any
 import typer
 
 from m4.config import (
-    VALID_BACKENDS,
-    detect_available_local_datasets,
     get_active_backend,
     get_active_dataset,
     get_bigquery_project_id,
@@ -56,7 +54,11 @@ from m4.data_io import (
     init_duckdb_from_parquet,
     verify_table_rowcount,
 )
+from m4.services.backend import set_active_backend_service
+from m4.services.init import initialize_dataset_service
+from m4.services.results import CommandError, CommandResult
 from m4.services.status import collect_status_snapshot
+from m4.services.use import set_active_dataset_service
 
 app = typer.Typer(
     name="m4",
@@ -87,33 +89,15 @@ def _emit_json(payload: dict[str, Any]) -> None:
     typer.echo(json.dumps(payload, indent=2))
 
 
+def _emit_command_json(result: CommandResult | CommandError) -> None:
+    _emit_json(result.to_json_dict())
+
+
 def _json_error(command: str, code: str, message: str, hint: str | None = None) -> None:
-    payload: dict[str, Any] = {
-        "version": 1,
-        "ok": False,
-        "command": command,
-        "error": {
-            "code": code,
-            "message": message,
-        },
-    }
-    if hint:
-        payload["error"]["hint"] = hint
-    _emit_json(payload)
+    _emit_command_json(
+        CommandError(command=command, code=code, message=message, hint=hint)
+    )
     raise typer.Exit(code=1)
-
-
-def _absolute_path_or_none(path_value: str | Path | None) -> str | None:
-    if not path_value:
-        return None
-    return str(Path(path_value).expanduser().resolve())
-
-
-def _get_active_dataset_or_none() -> str | None:
-    try:
-        return get_active_dataset()
-    except DatasetError:
-        return None
 
 
 @app.callback()
@@ -188,6 +172,13 @@ def dataset_init_cmd(
             help="Force recreation of DuckDB even if it exists.",
         ),
     ] = False,
+    json_output: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            help="Print result as JSON for scripts and automation.",
+        ),
+    ] = False,
 ):
     """
     Initialize a local dataset in one step by detecting what's already present:
@@ -200,6 +191,19 @@ def dataset_init_cmd(
     - For datasets without a download URL (e.g. mimic-iv-full), you must provide the --src path or place files in the expected location.
     """
     logger.info(f"CLI 'init' called for dataset: '{dataset_name}'")
+
+    if json_output:
+        with _silence_m4_logging():
+            result = initialize_dataset_service(
+                dataset_name,
+                src=src,
+                db_path_str=db_path_str,
+                force=force,
+            )
+        _emit_command_json(result)
+        if isinstance(result, CommandError):
+            raise typer.Exit(code=1)
+        return
 
     dataset_key = dataset_name.lower()
     ds = DatasetRegistry.get(dataset_key)
@@ -586,83 +590,31 @@ def use_cmd(
     ] = False,
 ):
     """Set the active dataset selection for the project."""
-    target = target.lower()
-
-    # 1. Check if dataset is registered
     with _silence_m4_logging() if json_output else nullcontext():
-        availability = detect_available_local_datasets().get(target)
+        result = set_active_dataset_service(target)
 
-    if not availability:
-        supported = ", ".join([ds.name for ds in DatasetRegistry.list_all()])
+    if isinstance(result, CommandError):
         if json_output:
-            _json_error(
-                "use",
-                "dataset_not_found",
-                f"Dataset '{target}' not found or not registered.",
-                hint=f"Supported datasets: {supported}",
-            )
-        print_error_panel(
-            "Dataset Not Found",
-            f"Dataset '{target}' not found or not registered.",
-            hint=f"Supported datasets: {supported}",
-        )
+            _emit_command_json(result)
+            raise typer.Exit(code=1)
+
+        title = {
+            "dataset_not_found": "Dataset Not Found",
+            "backend_incompatible": "Backend Incompatible",
+        }.get(result.code, "Command Failed")
+        print_error_panel(title, result.message, hint=result.hint)
         raise typer.Exit(code=1)
 
-    # 2. Block if dataset is incompatible with current backend
-    ds_def = DatasetRegistry.get(target)
-    backend_name = get_active_backend()
-
-    if ds_def and not ds_def.bigquery_dataset_ids and backend_name == "bigquery":
-        if json_output:
-            _json_error(
-                "use",
-                "backend_incompatible",
-                f"Dataset '{target}' is not available on the BigQuery backend.",
-                hint="Switch to DuckDB first: m4 backend duckdb",
-            )
-        print_error_panel(
-            "Backend Incompatible",
-            f"Dataset '{target}' is not available on the BigQuery backend.",
-            hint="Switch to DuckDB first: m4 backend duckdb",
-        )
-        raise typer.Exit(code=1)
-
-    # 3. Set it active
-    set_active_dataset(target)
     if json_output:
-        warnings = []
-        if not availability["parquet_present"]:
-            warnings.append("local_parquet_missing")
-        if backend_name == "duckdb" and not availability["db_present"]:
-            warnings.append("local_db_missing")
-
-        _emit_json(
-            {
-                "version": 1,
-                "ok": True,
-                "command": "use",
-                "active_dataset": target,
-                "backend": backend_name,
-                "dataset": {
-                    "name": target,
-                    "parquet_present": bool(availability["parquet_present"]),
-                    "db_present": bool(availability["db_present"]),
-                    "parquet_root": _absolute_path_or_none(
-                        availability.get("parquet_root")
-                    ),
-                    "db_path": _absolute_path_or_none(availability.get("db_path")),
-                    "bigquery_available": bool(ds_def and ds_def.bigquery_dataset_ids),
-                },
-                "warnings": warnings,
-            }
-        )
+        _emit_command_json(result)
         return
 
+    target = result.data["active_dataset"]
+    dataset = result.data["dataset"]
     success(f"Active dataset set to '{target}'")
 
-    # 4. Warn if local files are missing (helpful info, not a blocker)
-    if not availability["parquet_present"]:
-        warning(f"Local Parquet files not found at {availability['parquet_root']}")
+    if not dataset["parquet_present"]:
+        warning(f"Local Parquet files not found at {dataset['parquet_root']}")
         console.print(
             "  [muted]This is fine if you are using the BigQuery backend.[/muted]"
         )
@@ -672,13 +624,12 @@ def use_cmd(
     else:
         info("Local: Available", prefix="status")
 
-    # 5. Show BigQuery status
-    if ds_def:
-        if ds_def.bigquery_dataset_ids:
-            info(
-                f"BigQuery: Available (Project: {ds_def.bigquery_project_id})",
-                prefix="status",
-            )
+    if dataset["bigquery_available"]:
+        ds_def = DatasetRegistry.get(target)
+        info(
+            f"BigQuery: Available (Project: {ds_def.bigquery_project_id if ds_def else None})",
+            prefix="status",
+        )
 
 
 @app.command("backend")
@@ -703,95 +654,30 @@ def backend_cmd(
     ] = False,
 ):
     """Set the active backend (duckdb or bigquery)."""
-    target = target.lower()
+    with _silence_m4_logging() if json_output else nullcontext():
+        result = set_active_backend_service(target, project_id=project_id)
 
-    if target not in VALID_BACKENDS:
+    if isinstance(result, CommandError):
         if json_output:
-            _json_error(
-                "backend",
-                "invalid_backend",
-                f"Backend '{target}' is not valid.",
-                hint=f"Valid backends: {', '.join(sorted(VALID_BACKENDS))}",
-            )
-        print_error_panel(
-            "Invalid Backend",
-            f"Backend '{target}' is not valid.",
-            hint=f"Valid backends: {', '.join(sorted(VALID_BACKENDS))}",
-        )
-        raise typer.Exit(code=1)
-
-    # Reject --project-id for duckdb
-    if target == "duckdb" and project_id:
-        if json_output:
-            _json_error(
-                "backend",
-                "invalid_option",
-                "--project-id can only be used with bigquery backend.",
-            )
-        error("--project-id can only be used with bigquery backend")
-        raise typer.Exit(code=1)
-
-    # Block if current dataset is incompatible with new backend
-    active_dataset = _get_active_dataset_or_none()
-    if target == "bigquery":
-        if active_dataset:
-            ds_def = DatasetRegistry.get(active_dataset)
-            if ds_def and not ds_def.bigquery_dataset_ids:
-                if json_output:
-                    _json_error(
-                        "backend",
-                        "dataset_incompatible",
-                        f"Current dataset '{active_dataset}' is not available on BigQuery.",
-                        hint="Switch dataset first: m4 use <dataset>",
-                    )
-                print_error_panel(
-                    "Dataset Incompatible",
-                    f"Current dataset '{active_dataset}' is not available on BigQuery.",
-                    hint="Switch dataset first: m4 use <dataset>",
-                )
-                raise typer.Exit(code=1)
-
-    # BigQuery requires a project ID — either provided now or already in config
-    effective_project_id = None
-    if target == "bigquery":
-        effective_project_id = project_id or get_bigquery_project_id()
-        if not effective_project_id:
-            if json_output:
-                _json_error(
-                    "backend",
-                    "project_id_required",
-                    "BigQuery backend requires a project ID.",
-                    hint="Set it with: m4 backend bigquery --project-id <ID>",
-                )
-            print_error_panel(
-                "Project ID Required",
-                "BigQuery backend requires a project ID.",
-                hint="Set it with: m4 backend bigquery --project-id <ID>",
-            )
+            _emit_command_json(result)
             raise typer.Exit(code=1)
 
-    set_active_backend(target)
-
-    # Persist project ID if provided
-    if project_id:
-        set_bigquery_project_id(project_id)
+        if result.code == "invalid_option":
+            error(result.message.removesuffix("."))
+        else:
+            title = {
+                "invalid_backend": "Invalid Backend",
+                "dataset_incompatible": "Dataset Incompatible",
+                "project_id_required": "Project ID Required",
+            }.get(result.code, "Command Failed")
+            print_error_panel(title, result.message, hint=result.hint)
+        raise typer.Exit(code=1)
 
     if json_output:
-        _emit_json(
-            {
-                "version": 1,
-                "ok": True,
-                "command": "backend",
-                "backend": target,
-                "active_dataset": active_dataset,
-                "bigquery_project_id": project_id
-                or effective_project_id
-                or get_bigquery_project_id(),
-                "warnings": [],
-            }
-        )
+        _emit_command_json(result)
         return
 
+    target = result.data["backend"]
     success(f"Active backend set to '{target}'")
 
     # Show helpful context

--- a/src/m4/cli.py
+++ b/src/m4/cli.py
@@ -1,8 +1,10 @@
+import json
 import logging
 import subprocess
 import sys
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 
@@ -49,12 +51,12 @@ from m4.core.derived.materializer import (
 )
 from m4.core.exceptions import DatasetError
 from m4.data_io import (
-    compute_parquet_dir_size,
     convert_csv_to_parquet,
     download_dataset,
     init_duckdb_from_parquet,
     verify_table_rowcount,
 )
+from m4.services.status import collect_status_snapshot
 
 app = typer.Typer(
     name="m4",
@@ -68,6 +70,50 @@ def version_callback(value: bool):
     if value:
         print_logo(show_tagline=True, show_version=True)
         raise typer.Exit()
+
+
+@contextmanager
+def _silence_m4_logging():
+    """Temporarily silence m4 logging so machine output stays parseable."""
+    previous_disable_level = logging.root.manager.disable
+    logging.disable(logging.CRITICAL)
+    try:
+        yield
+    finally:
+        logging.disable(previous_disable_level)
+
+
+def _emit_json(payload: dict[str, Any]) -> None:
+    typer.echo(json.dumps(payload, indent=2))
+
+
+def _json_error(command: str, code: str, message: str, hint: str | None = None) -> None:
+    payload: dict[str, Any] = {
+        "version": 1,
+        "ok": False,
+        "command": command,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }
+    if hint:
+        payload["error"]["hint"] = hint
+    _emit_json(payload)
+    raise typer.Exit(code=1)
+
+
+def _absolute_path_or_none(path_value: str | Path | None) -> str | None:
+    if not path_value:
+        return None
+    return str(Path(path_value).expanduser().resolve())
+
+
+def _get_active_dataset_or_none() -> str | None:
+    try:
+        return get_active_dataset()
+    except DatasetError:
+        return None
 
 
 @app.callback()
@@ -531,15 +577,30 @@ def use_cmd(
             help="Select active dataset: name (e.g., mimic-iv-full)", metavar="TARGET"
         ),
     ],
+    json_output: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            help="Print result as JSON for scripts and automation.",
+        ),
+    ] = False,
 ):
     """Set the active dataset selection for the project."""
     target = target.lower()
 
     # 1. Check if dataset is registered
-    availability = detect_available_local_datasets().get(target)
+    with _silence_m4_logging() if json_output else nullcontext():
+        availability = detect_available_local_datasets().get(target)
 
     if not availability:
         supported = ", ".join([ds.name for ds in DatasetRegistry.list_all()])
+        if json_output:
+            _json_error(
+                "use",
+                "dataset_not_found",
+                f"Dataset '{target}' not found or not registered.",
+                hint=f"Supported datasets: {supported}",
+            )
         print_error_panel(
             "Dataset Not Found",
             f"Dataset '{target}' not found or not registered.",
@@ -552,6 +613,13 @@ def use_cmd(
     backend_name = get_active_backend()
 
     if ds_def and not ds_def.bigquery_dataset_ids and backend_name == "bigquery":
+        if json_output:
+            _json_error(
+                "use",
+                "backend_incompatible",
+                f"Dataset '{target}' is not available on the BigQuery backend.",
+                hint="Switch to DuckDB first: m4 backend duckdb",
+            )
         print_error_panel(
             "Backend Incompatible",
             f"Dataset '{target}' is not available on the BigQuery backend.",
@@ -561,6 +629,35 @@ def use_cmd(
 
     # 3. Set it active
     set_active_dataset(target)
+    if json_output:
+        warnings = []
+        if not availability["parquet_present"]:
+            warnings.append("local_parquet_missing")
+        if backend_name == "duckdb" and not availability["db_present"]:
+            warnings.append("local_db_missing")
+
+        _emit_json(
+            {
+                "version": 1,
+                "ok": True,
+                "command": "use",
+                "active_dataset": target,
+                "backend": backend_name,
+                "dataset": {
+                    "name": target,
+                    "parquet_present": bool(availability["parquet_present"]),
+                    "db_present": bool(availability["db_present"]),
+                    "parquet_root": _absolute_path_or_none(
+                        availability.get("parquet_root")
+                    ),
+                    "db_path": _absolute_path_or_none(availability.get("db_path")),
+                    "bigquery_available": bool(ds_def and ds_def.bigquery_dataset_ids),
+                },
+                "warnings": warnings,
+            }
+        )
+        return
+
     success(f"Active dataset set to '{target}'")
 
     # 4. Warn if local files are missing (helpful info, not a blocker)
@@ -597,11 +694,25 @@ def backend_cmd(
             help="Google Cloud project ID for billing (bigquery only)",
         ),
     ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            help="Print result as JSON for scripts and automation.",
+        ),
+    ] = False,
 ):
     """Set the active backend (duckdb or bigquery)."""
     target = target.lower()
 
     if target not in VALID_BACKENDS:
+        if json_output:
+            _json_error(
+                "backend",
+                "invalid_backend",
+                f"Backend '{target}' is not valid.",
+                hint=f"Valid backends: {', '.join(sorted(VALID_BACKENDS))}",
+            )
         print_error_panel(
             "Invalid Backend",
             f"Backend '{target}' is not valid.",
@@ -611,28 +722,47 @@ def backend_cmd(
 
     # Reject --project-id for duckdb
     if target == "duckdb" and project_id:
+        if json_output:
+            _json_error(
+                "backend",
+                "invalid_option",
+                "--project-id can only be used with bigquery backend.",
+            )
         error("--project-id can only be used with bigquery backend")
         raise typer.Exit(code=1)
 
     # Block if current dataset is incompatible with new backend
+    active_dataset = _get_active_dataset_or_none()
     if target == "bigquery":
-        try:
-            active = get_active_dataset()
-            ds_def = DatasetRegistry.get(active)
+        if active_dataset:
+            ds_def = DatasetRegistry.get(active_dataset)
             if ds_def and not ds_def.bigquery_dataset_ids:
+                if json_output:
+                    _json_error(
+                        "backend",
+                        "dataset_incompatible",
+                        f"Current dataset '{active_dataset}' is not available on BigQuery.",
+                        hint="Switch dataset first: m4 use <dataset>",
+                    )
                 print_error_panel(
                     "Dataset Incompatible",
-                    f"Current dataset '{active}' is not available on BigQuery.",
+                    f"Current dataset '{active_dataset}' is not available on BigQuery.",
                     hint="Switch dataset first: m4 use <dataset>",
                 )
                 raise typer.Exit(code=1)
-        except (ValueError, DatasetError):
-            pass  # No active dataset set
 
     # BigQuery requires a project ID — either provided now or already in config
+    effective_project_id = None
     if target == "bigquery":
         effective_project_id = project_id or get_bigquery_project_id()
         if not effective_project_id:
+            if json_output:
+                _json_error(
+                    "backend",
+                    "project_id_required",
+                    "BigQuery backend requires a project ID.",
+                    hint="Set it with: m4 backend bigquery --project-id <ID>",
+                )
             print_error_panel(
                 "Project ID Required",
                 "BigQuery backend requires a project ID.",
@@ -645,6 +775,22 @@ def backend_cmd(
     # Persist project ID if provided
     if project_id:
         set_bigquery_project_id(project_id)
+
+    if json_output:
+        _emit_json(
+            {
+                "version": 1,
+                "ok": True,
+                "command": "backend",
+                "backend": target,
+                "active_dataset": active_dataset,
+                "bigquery_project_id": project_id
+                or effective_project_id
+                or get_bigquery_project_id(),
+                "warnings": [],
+            }
+        )
+        return
 
     success(f"Active backend set to '{target}'")
 
@@ -680,12 +826,35 @@ def status_cmd(
             help="Show detailed derived table status grouped by category.",
         ),
     ] = False,
+    json_output: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            help="Print status as JSON for scripts and automation.",
+        ),
+    ] = False,
 ):
     """Show active dataset status. Use --all for all supported datasets."""
+    if show_derived and json_output:
+        _json_error(
+            "status",
+            "invalid_option",
+            "--json cannot be combined with --derived.",
+            hint="Run either: m4 status --json or m4 status --derived",
+        )
+
+    if json_output:
+        with _silence_m4_logging():
+            snapshot = collect_status_snapshot(show_all=show_all)
+        _emit_json(snapshot)
+        return
 
     # --derived: detailed per-table view (early return)
     if show_derived:
-        active = get_active_dataset()
+        try:
+            active = get_active_dataset()
+        except DatasetError:
+            active = None
         if not active:
             console.print("[warning]No active dataset set.[/warning]")
             raise typer.Exit()
@@ -722,53 +891,29 @@ def status_cmd(
     print_logo(show_tagline=False, show_version=True)
     console.print()
 
-    active = get_active_dataset()
-    availability = detect_available_local_datasets()
+    snapshot = collect_status_snapshot(show_all=show_all)
+    active = snapshot["active_dataset"]
+    datasets = snapshot["datasets"]
 
     if show_all:
         # Table view of all datasets
-        if not availability:
+        if not datasets:
             console.print("[muted]No datasets detected.[/muted]")
             return
 
         # Build dataset info list for table
-        datasets_info = []
-        for label, ds_info in availability.items():
-            ds_def = DatasetRegistry.get(label)
-            bigquery_available = bool(ds_def and ds_def.bigquery_dataset_ids)
-
-            # Get size if parquet present
-            parquet_size_gb = None
-            if ds_info["parquet_present"]:
-                try:
-                    size_bytes = compute_parquet_dir_size(Path(ds_info["parquet_root"]))
-                    parquet_size_gb = float(size_bytes) / (1024**3)
-                except Exception:
-                    pass
-
-            # Get derived counts if supported and db present
-            derived_materialized = None
-            derived_total = None
-            if has_derived_support(label) and ds_info["db_present"]:
-                try:
-                    derived_total = len(list_builtins(label))
-                    derived_materialized = get_derived_table_count(
-                        Path(ds_info["db_path"])
-                    )
-                except Exception:
-                    pass
-
-            datasets_info.append(
-                {
-                    "name": label,
-                    "parquet_present": ds_info["parquet_present"],
-                    "db_present": ds_info["db_present"],
-                    "bigquery_available": bigquery_available,
-                    "parquet_size_gb": parquet_size_gb,
-                    "derived_materialized": derived_materialized,
-                    "derived_total": derived_total,
-                }
-            )
+        datasets_info = [
+            {
+                "name": dataset["name"],
+                "parquet_present": dataset["parquet_present"],
+                "db_present": dataset["db_present"],
+                "bigquery_available": dataset["bigquery_available"],
+                "parquet_size_gb": dataset["parquet_size_gb"],
+                "derived_materialized": dataset["derived"]["materialized"],
+                "derived_total": dataset["derived"]["total"],
+            }
+            for dataset in datasets
+        ]
 
         print_datasets_table(datasets_info, active_dataset=active)
         return
@@ -787,17 +932,15 @@ def status_cmd(
 
     console.print(f"[bold]Active dataset:[/bold] [success]{active}[/success]")
 
-    backend = get_active_backend()
+    backend = snapshot["backend"]
     backend_label = backend
-    if backend == "bigquery":
-        bq_project = get_bigquery_project_id()
-        if bq_project:
-            backend_label = f"{backend} ({bq_project})"
+    if backend == "bigquery" and snapshot["bigquery_project_id"]:
+        backend_label = f"{backend} ({snapshot['bigquery_project_id']})"
     console.print(f"[bold]Backend:[/bold] [success]{backend_label}[/success]")
 
     # Get info for active dataset
-    ds_info = availability.get(active)
-    if not ds_info:
+    dataset = datasets[0] if datasets else None
+    if not dataset:
         console.print()
         warning(f"Dataset '{active}' is set but not found locally.")
         console.print(
@@ -805,60 +948,26 @@ def status_cmd(
         )
         return
 
-    # Get size if parquet present
-    parquet_size_gb = None
-    if ds_info["parquet_present"]:
-        try:
-            size_bytes = compute_parquet_dir_size(Path(ds_info["parquet_root"]))
-            parquet_size_gb = float(size_bytes) / (1024**3)
-        except Exception:
-            pass
-
-    # Get dataset definition for BigQuery status and verification
-    ds_def = DatasetRegistry.get(active)
-    bigquery_available = bool(ds_def and ds_def.bigquery_dataset_ids)
-
-    # Get row count if possible
-    row_count = None
-    if ds_info["db_present"] and ds_def and ds_def.primary_verification_table:
-        try:
-            row_count = verify_table_rowcount(
-                Path(ds_info["db_path"]), ds_def.primary_verification_table
-            )
-        except Exception as e:
-            # Show hint if it looks like a path mismatch
-            if "No files found" in str(e) or "no such file" in str(e).lower():
-                warning("Database views may point to wrong parquet location")
-                console.print(
-                    f"  [muted]Try:[/muted] [command]m4 init {active} --force[/command]"
-                )
-
-    # Gather derived table info
-    derived_has_support = has_derived_support(active)
-    derived_is_bigquery = bigquery_available and backend == "bigquery"
-    derived_materialized = None
-    derived_total = None
-    if derived_has_support and not derived_is_bigquery and ds_info["db_present"]:
-        try:
-            derived_total = len(list_builtins(active))
-            derived_materialized = get_derived_table_count(Path(ds_info["db_path"]))
-        except Exception:
-            pass
+    if "parquet_path_mismatch" in dataset["warnings"]:
+        warning("Database views may point to wrong parquet location")
+        console.print(
+            f"  [muted]Try:[/muted] [command]m4 init {active} --force[/command]"
+        )
 
     print_dataset_status(
         name=active,
-        parquet_present=ds_info["parquet_present"],
-        db_present=ds_info["db_present"],
-        parquet_root=str(ds_info["parquet_root"]),
-        db_path=str(ds_info["db_path"]),
-        parquet_size_gb=parquet_size_gb,
-        bigquery_available=bigquery_available,
-        row_count=row_count,
+        parquet_present=dataset["parquet_present"],
+        db_present=dataset["db_present"],
+        parquet_root=dataset["parquet_root"] or "",
+        db_path=dataset["db_path"] or "",
+        parquet_size_gb=dataset["parquet_size_gb"],
+        bigquery_available=dataset["bigquery_available"],
+        row_count=dataset["row_count"],
         is_active=True,
-        derived_materialized=derived_materialized,
-        derived_total=derived_total,
-        derived_has_support=derived_has_support,
-        derived_is_bigquery=derived_is_bigquery,
+        derived_materialized=dataset["derived"]["materialized"],
+        derived_total=dataset["derived"]["total"],
+        derived_has_support=dataset["derived"]["supported"],
+        derived_is_bigquery=dataset["derived"]["bigquery"],
     )
 
 

--- a/src/m4/cli.py
+++ b/src/m4/cli.py
@@ -190,8 +190,6 @@ def dataset_init_cmd(
     - Auto-download is based on the dataset definition URL.
     - For datasets without a download URL (e.g. mimic-iv-full), you must provide the --src path or place files in the expected location.
     """
-    logger.info(f"CLI 'init' called for dataset: '{dataset_name}'")
-
     if json_output:
         with _silence_m4_logging():
             result = initialize_dataset_service(
@@ -204,6 +202,8 @@ def dataset_init_cmd(
         if isinstance(result, CommandError):
             raise typer.Exit(code=1)
         return
+
+    logger.info(f"CLI 'init' called for dataset: '{dataset_name}'")
 
     dataset_key = dataset_name.lower()
     ds = DatasetRegistry.get(dataset_key)

--- a/src/m4/services/__init__.py
+++ b/src/m4/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service-layer helpers for programmatic M4 reuse."""

--- a/src/m4/services/backend.py
+++ b/src/m4/services/backend.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from m4.config import (
+    VALID_BACKENDS,
+    get_active_dataset,
+    get_bigquery_project_id,
+    set_active_backend,
+    set_bigquery_project_id,
+)
+from m4.core.datasets import DatasetRegistry
+from m4.core.exceptions import DatasetError
+from m4.services.results import (
+    ERROR_DATASET_INCOMPATIBLE,
+    ERROR_INVALID_BACKEND,
+    ERROR_INVALID_OPTION,
+    ERROR_PROJECT_ID_REQUIRED,
+    CommandError,
+    CommandResult,
+)
+
+
+def _get_active_dataset_or_none() -> str | None:
+    try:
+        return get_active_dataset()
+    except DatasetError:
+        return None
+
+
+def set_active_backend_service(
+    target: str, project_id: str | None = None
+) -> CommandResult | CommandError:
+    """Set the active backend and return a machine-readable command result."""
+    target = target.lower()
+
+    if target not in VALID_BACKENDS:
+        return CommandError(
+            command="backend",
+            code=ERROR_INVALID_BACKEND,
+            message=f"Backend '{target}' is not valid.",
+            hint=f"Valid backends: {', '.join(sorted(VALID_BACKENDS))}",
+        )
+
+    if target == "duckdb" and project_id:
+        return CommandError(
+            command="backend",
+            code=ERROR_INVALID_OPTION,
+            message="--project-id can only be used with bigquery backend.",
+        )
+
+    active_dataset = _get_active_dataset_or_none()
+    if target == "bigquery" and active_dataset:
+        ds_def = DatasetRegistry.get(active_dataset)
+        if ds_def and not ds_def.bigquery_dataset_ids:
+            return CommandError(
+                command="backend",
+                code=ERROR_DATASET_INCOMPATIBLE,
+                message=(
+                    f"Current dataset '{active_dataset}' is not available on BigQuery."
+                ),
+                hint="Switch dataset first: m4 use <dataset>",
+            )
+
+    effective_project_id = None
+    if target == "bigquery":
+        effective_project_id = project_id or get_bigquery_project_id()
+        if not effective_project_id:
+            return CommandError(
+                command="backend",
+                code=ERROR_PROJECT_ID_REQUIRED,
+                message="BigQuery backend requires a project ID.",
+                hint="Set it with: m4 backend bigquery --project-id <ID>",
+            )
+
+    set_active_backend(target)
+    if project_id:
+        set_bigquery_project_id(project_id)
+
+    return CommandResult(
+        command="backend",
+        data={
+            "backend": target,
+            "active_dataset": active_dataset,
+            "bigquery_project_id": (
+                project_id or effective_project_id or get_bigquery_project_id()
+            ),
+        },
+        warnings=[],
+    )

--- a/src/m4/services/init.py
+++ b/src/m4/services/init.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+
+from m4.config import (
+    get_active_backend,
+    get_dataset_parquet_root,
+    get_default_database_path,
+    set_active_dataset,
+)
+from m4.console import console
+from m4.core.datasets import DatasetRegistry
+from m4.core.derived.builtins import has_derived_support
+from m4.core.derived.materializer import get_derived_table_count, materialize_all
+from m4.data_io import (
+    convert_csv_to_parquet,
+    download_dataset,
+    init_duckdb_from_parquet,
+    verify_table_rowcount,
+)
+from m4.services.results import (
+    ERROR_DATASET_NOT_FOUND,
+    ERROR_INVALID_OPTION,
+    CommandError,
+    CommandResult,
+)
+
+STEP_STATUSES = {"skipped", "completed", "blocked", "failed"}
+
+
+def _step(
+    name: str,
+    status: str,
+    message: str | None = None,
+) -> dict[str, str]:
+    if status not in STEP_STATUSES:
+        raise ValueError(f"Invalid init step status: {status}")
+    result = {"name": name, "status": status}
+    if message:
+        result["message"] = message
+    return result
+
+
+@contextmanager
+def _silence_console_output():
+    previous_quiet = console.quiet
+    console.quiet = True
+    try:
+        yield
+    finally:
+        console.quiet = previous_quiet
+
+
+def _build_data(
+    dataset_key: str,
+    db_path: Path | None,
+    pq_root: Path | None,
+    raw_root: Path | None,
+    steps: list[dict[str, str]],
+) -> dict:
+    return {
+        "dataset": dataset_key,
+        "db_path": str(db_path.resolve()) if db_path else None,
+        "parquet_root": str(pq_root.resolve()) if pq_root else None,
+        "raw_root": str(raw_root.resolve()) if raw_root else None,
+        "steps": steps,
+    }
+
+
+def initialize_dataset_service(
+    dataset_name: str,
+    src: str | None = None,
+    db_path_str: str | None = None,
+    force: bool = False,
+) -> CommandResult | CommandError:
+    """Run the non-interactive dataset initialization workflow."""
+    dataset_key = dataset_name.lower()
+    ds = DatasetRegistry.get(dataset_key)
+    if not ds:
+        supported = ", ".join([d.name for d in DatasetRegistry.list_all()])
+        return CommandError(
+            command="init",
+            code=ERROR_DATASET_NOT_FOUND,
+            message=f"Dataset '{dataset_name}' is not supported or not configured.",
+            hint=f"Supported datasets: {supported}",
+        )
+
+    with _silence_console_output():
+        pq_root = get_dataset_parquet_root(dataset_key)
+        if pq_root is None:
+            return CommandError(
+                command="init",
+                code=ERROR_INVALID_OPTION,
+                message="Could not determine dataset directories.",
+            )
+
+        csv_root_default = pq_root.parent.parent / "raw_files" / dataset_key
+        csv_root = Path(src).resolve() if src else csv_root_default
+        final_db_path = (
+            Path(db_path_str).resolve()
+            if db_path_str
+            else get_default_database_path(dataset_key)
+        )
+
+        steps: list[dict[str, str]] = []
+        parquet_present = any(pq_root.rglob("*.parquet"))
+        raw_present = any(csv_root.rglob("*.csv.gz"))
+
+        if not raw_present and not parquet_present:
+            if ds.requires_authentication:
+                steps.extend(
+                    [
+                        _step(
+                            "raw_files",
+                            "blocked",
+                            (
+                                f"Files not found for credentialed dataset "
+                                f"'{dataset_key}'. Download manually and rerun init."
+                            ),
+                        ),
+                        _step("parquet", "skipped", "Raw files are not available."),
+                        _step(
+                            "database", "skipped", "Parquet files are not available."
+                        ),
+                        _step(
+                            "derived",
+                            "skipped",
+                            "Database initialization did not run.",
+                        ),
+                    ]
+                )
+                return CommandResult(
+                    command="init",
+                    data=_build_data(
+                        dataset_key, final_db_path, pq_root, csv_root, steps
+                    ),
+                    warnings=[],
+                )
+
+            listing_url = ds.file_listing_url
+            if not listing_url:
+                steps.extend(
+                    [
+                        _step(
+                            "raw_files",
+                            "blocked",
+                            (
+                                f"Auto-download is not available for '{dataset_key}'. "
+                                "Place raw CSV.gz files in the expected location or use --src."
+                            ),
+                        ),
+                        _step("parquet", "skipped", "Raw files are not available."),
+                        _step(
+                            "database", "skipped", "Parquet files are not available."
+                        ),
+                        _step(
+                            "derived",
+                            "skipped",
+                            "Database initialization did not run.",
+                        ),
+                    ]
+                )
+                return CommandResult(
+                    command="init",
+                    data=_build_data(
+                        dataset_key, final_db_path, pq_root, csv_root, steps
+                    ),
+                    warnings=[],
+                )
+
+            csv_root_default.mkdir(parents=True, exist_ok=True)
+            if not download_dataset(dataset_key, csv_root_default):
+                return CommandError(
+                    command="init",
+                    code=ERROR_INVALID_OPTION,
+                    message="Download failed. Please check logs for details.",
+                )
+            csv_root = csv_root_default
+            raw_present = True
+            steps.append(_step("raw_files", "completed", "Downloaded raw files."))
+        elif raw_present:
+            steps.append(_step("raw_files", "completed", "Raw files are present."))
+        else:
+            steps.append(
+                _step("raw_files", "skipped", "Parquet files are already present.")
+            )
+
+        if not parquet_present:
+            if not raw_present:
+                steps.append(
+                    _step("parquet", "skipped", "Raw files are not available.")
+                )
+            elif not convert_csv_to_parquet(dataset_key, csv_root, pq_root):
+                return CommandError(
+                    command="init",
+                    code=ERROR_INVALID_OPTION,
+                    message="Conversion failed. Please check logs for details.",
+                )
+            else:
+                parquet_present = True
+                steps.append(_step("parquet", "completed", "Converted CSV to Parquet."))
+        else:
+            steps.append(_step("parquet", "skipped", "Parquet files are present."))
+
+        if not final_db_path:
+            return CommandError(
+                command="init",
+                code=ERROR_INVALID_OPTION,
+                message=f"Could not determine database path for '{dataset_name}'.",
+            )
+
+        final_db_path.parent.mkdir(parents=True, exist_ok=True)
+        if force and final_db_path.exists():
+            final_db_path.unlink()
+
+        if not pq_root.exists():
+            return CommandError(
+                command="init",
+                code=ERROR_INVALID_OPTION,
+                message=f"Parquet directory not found at {pq_root}",
+            )
+
+        if not init_duckdb_from_parquet(
+            dataset_name=dataset_key, db_target_path=final_db_path
+        ):
+            return CommandError(
+                command="init",
+                code=ERROR_INVALID_OPTION,
+                message=(
+                    f"Dataset '{dataset_name}' initialization FAILED. "
+                    "Please check logs for details."
+                ),
+            )
+        steps.append(_step("database", "completed", "Created DuckDB views."))
+
+        verification_table_name = ds.primary_verification_table
+        if verification_table_name:
+            try:
+                record_count = verify_table_rowcount(
+                    final_db_path, verification_table_name
+                )
+                steps.append(
+                    _step(
+                        "verification",
+                        "completed",
+                        f"Verified {record_count} records in '{verification_table_name}'.",
+                    )
+                )
+            except Exception as exc:
+                steps.append(
+                    _step("verification", "failed", f"Verification failed: {exc}")
+                )
+        else:
+            steps.append(
+                _step("verification", "skipped", "No verification table configured.")
+            )
+
+        set_active_dataset(dataset_key)
+
+        if has_derived_support(dataset_key) and get_active_backend() == "duckdb":
+            try:
+                existing_derived = get_derived_table_count(final_db_path)
+            except Exception as exc:
+                steps.append(
+                    _step(
+                        "derived", "failed", f"Could not inspect derived tables: {exc}"
+                    )
+                )
+            else:
+                if existing_derived > 0 and force:
+                    try:
+                        created = materialize_all(dataset_key, final_db_path)
+                        steps.append(
+                            _step(
+                                "derived",
+                                "completed",
+                                f"Materialized {len(created)} derived tables.",
+                            )
+                        )
+                    except Exception as exc:
+                        steps.append(
+                            _step(
+                                "derived",
+                                "failed",
+                                f"Derived table materialization failed: {exc}",
+                            )
+                        )
+                elif existing_derived > 0:
+                    steps.append(
+                        _step(
+                            "derived",
+                            "skipped",
+                            (
+                                f"Derived tables already materialized "
+                                f"({existing_derived} tables)."
+                            ),
+                        )
+                    )
+                else:
+                    steps.append(
+                        _step(
+                            "derived",
+                            "skipped",
+                            "Derived materialization is skipped in non-interactive mode.",
+                        )
+                    )
+        else:
+            steps.append(
+                _step(
+                    "derived",
+                    "skipped",
+                    "Derived materialization is not available for this configuration.",
+                )
+            )
+
+        return CommandResult(
+            command="init",
+            data=_build_data(dataset_key, final_db_path, pq_root, csv_root, steps),
+            warnings=[],
+        )

--- a/src/m4/services/results.py
+++ b/src/m4/services/results.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+WARNING_LOCAL_PARQUET_MISSING = "local_parquet_missing"
+WARNING_LOCAL_DB_MISSING = "local_db_missing"
+WARNING_PARQUET_PATH_MISMATCH = "parquet_path_mismatch"
+LOCAL_PARQUET_MISSING = WARNING_LOCAL_PARQUET_MISSING
+LOCAL_DB_MISSING = WARNING_LOCAL_DB_MISSING
+PARQUET_PATH_MISMATCH = WARNING_PARQUET_PATH_MISMATCH
+
+ERROR_DATASET_NOT_FOUND = "dataset_not_found"
+ERROR_BACKEND_INCOMPATIBLE = "backend_incompatible"
+ERROR_INVALID_BACKEND = "invalid_backend"
+ERROR_INVALID_OPTION = "invalid_option"
+ERROR_PROJECT_ID_REQUIRED = "project_id_required"
+ERROR_DATASET_INCOMPATIBLE = "dataset_incompatible"
+DATASET_NOT_FOUND = ERROR_DATASET_NOT_FOUND
+BACKEND_INCOMPATIBLE = ERROR_BACKEND_INCOMPATIBLE
+INVALID_BACKEND = ERROR_INVALID_BACKEND
+INVALID_OPTION = ERROR_INVALID_OPTION
+PROJECT_ID_REQUIRED = ERROR_PROJECT_ID_REQUIRED
+DATASET_INCOMPATIBLE = ERROR_DATASET_INCOMPATIBLE
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    command: str
+    data: dict[str, Any] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+    version: int = SCHEMA_VERSION
+    ok: bool = True
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "ok": self.ok,
+            "command": self.command,
+            **self.data,
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class CommandError:
+    command: str
+    code: str
+    message: str
+    hint: str | None = None
+    version: int = SCHEMA_VERSION
+    ok: bool = False
+
+    def to_json_dict(self) -> dict[str, Any]:
+        error: dict[str, Any] = {
+            "code": self.code,
+            "message": self.message,
+        }
+        if self.hint:
+            error["hint"] = self.hint
+
+        return {
+            "version": self.version,
+            "ok": self.ok,
+            "command": self.command,
+            "error": error,
+        }

--- a/src/m4/services/status.py
+++ b/src/m4/services/status.py
@@ -31,6 +31,8 @@ def _collect_dataset_status(
     ds_info: dict[str, Any],
     active_dataset: str | None,
     backend: str,
+    *,
+    include_row_count: bool,
 ) -> dict[str, Any]:
     ds_def = DatasetRegistry.get(name)
     parquet_present = bool(ds_info.get("parquet_present"))
@@ -49,7 +51,13 @@ def _collect_dataset_status(
             pass
 
     row_count = None
-    if db_present and db_path and ds_def and ds_def.primary_verification_table:
+    if (
+        include_row_count
+        and db_present
+        and db_path
+        and ds_def
+        and ds_def.primary_verification_table
+    ):
         try:
             row_count = verify_table_rowcount(
                 Path(db_path), ds_def.primary_verification_table
@@ -111,7 +119,15 @@ def collect_status_snapshot(show_all: bool) -> dict[str, Any]:
         ds_info = availability.get(name)
         if not ds_info:
             continue
-        datasets.append(_collect_dataset_status(name, ds_info, active, backend))
+        datasets.append(
+            _collect_dataset_status(
+                name,
+                ds_info,
+                active,
+                backend,
+                include_row_count=not show_all,
+            )
+        )
 
     return {
         "version": 1,

--- a/src/m4/services/status.py
+++ b/src/m4/services/status.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+from typing import Any
+
+from m4.config import (
+    detect_available_local_datasets,
+    get_active_backend,
+    get_active_dataset,
+    get_bigquery_project_id,
+)
+from m4.core.datasets import DatasetRegistry
+from m4.core.derived.builtins import has_derived_support, list_builtins
+from m4.core.derived.materializer import get_derived_table_count
+from m4.core.exceptions import DatasetError
+from m4.data_io import compute_parquet_dir_size, verify_table_rowcount
+
+
+def _absolute_path_or_none(path_value: str | Path | None) -> str | None:
+    if not path_value:
+        return None
+    return str(Path(path_value).expanduser().resolve())
+
+
+def _is_path_mismatch_error(exc: Exception) -> bool:
+    message = str(exc)
+    return "No files found" in message or "no such file" in message.lower()
+
+
+def _collect_dataset_status(
+    name: str,
+    ds_info: dict[str, Any],
+    active_dataset: str | None,
+    backend: str,
+) -> dict[str, Any]:
+    ds_def = DatasetRegistry.get(name)
+    parquet_present = bool(ds_info.get("parquet_present"))
+    db_present = bool(ds_info.get("db_present"))
+    parquet_root = _absolute_path_or_none(ds_info.get("parquet_root"))
+    db_path = _absolute_path_or_none(ds_info.get("db_path"))
+    bigquery_available = bool(ds_def and ds_def.bigquery_dataset_ids)
+    warnings: list[str] = []
+
+    parquet_size_gb = None
+    if parquet_present and parquet_root:
+        try:
+            size_bytes = compute_parquet_dir_size(Path(parquet_root))
+            parquet_size_gb = float(size_bytes) / (1024**3)
+        except Exception:
+            pass
+
+    row_count = None
+    if db_present and db_path and ds_def and ds_def.primary_verification_table:
+        try:
+            row_count = verify_table_rowcount(
+                Path(db_path), ds_def.primary_verification_table
+            )
+        except Exception as exc:
+            if _is_path_mismatch_error(exc):
+                warnings.append("parquet_path_mismatch")
+
+    derived_supported = has_derived_support(name)
+    derived_bigquery = (
+        backend == "bigquery" and bigquery_available and derived_supported
+    )
+    derived_total = None
+    derived_materialized = None
+    if derived_supported:
+        try:
+            derived_total = len(list_builtins(name))
+        except Exception:
+            pass
+
+    if derived_supported and not derived_bigquery and db_present and db_path:
+        try:
+            derived_materialized = get_derived_table_count(Path(db_path))
+        except Exception:
+            pass
+
+    return {
+        "name": name,
+        "active": name == active_dataset,
+        "parquet_present": parquet_present,
+        "db_present": db_present,
+        "parquet_root": parquet_root,
+        "db_path": db_path,
+        "bigquery_available": bigquery_available,
+        "row_count": row_count,
+        "parquet_size_gb": parquet_size_gb,
+        "derived": {
+            "supported": derived_supported,
+            "total": derived_total,
+            "materialized": derived_materialized,
+            "bigquery": derived_bigquery,
+        },
+        "warnings": warnings,
+    }
+
+
+def collect_status_snapshot(show_all: bool) -> dict[str, Any]:
+    try:
+        active = get_active_dataset()
+    except DatasetError:
+        active = None
+
+    backend = get_active_backend()
+    availability = detect_available_local_datasets()
+
+    dataset_names = list(availability) if show_all else ([active] if active else [])
+    datasets = []
+    for name in dataset_names:
+        ds_info = availability.get(name)
+        if not ds_info:
+            continue
+        datasets.append(_collect_dataset_status(name, ds_info, active, backend))
+
+    return {
+        "version": 1,
+        "active_dataset": active,
+        "backend": backend,
+        "bigquery_project_id": get_bigquery_project_id(),
+        "datasets": datasets,
+    }

--- a/src/m4/services/status.py
+++ b/src/m4/services/status.py
@@ -12,6 +12,7 @@ from m4.core.derived.builtins import has_derived_support, list_builtins
 from m4.core.derived.materializer import get_derived_table_count
 from m4.core.exceptions import DatasetError
 from m4.data_io import compute_parquet_dir_size, verify_table_rowcount
+from m4.services.results import WARNING_PARQUET_PATH_MISMATCH
 
 
 def _absolute_path_or_none(path_value: str | Path | None) -> str | None:
@@ -55,7 +56,7 @@ def _collect_dataset_status(
             )
         except Exception as exc:
             if _is_path_mismatch_error(exc):
-                warnings.append("parquet_path_mismatch")
+                warnings.append(WARNING_PARQUET_PATH_MISMATCH)
 
     derived_supported = has_derived_support(name)
     derived_bigquery = (

--- a/src/m4/services/use.py
+++ b/src/m4/services/use.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from m4.config import (
+    detect_available_local_datasets,
+    get_active_backend,
+    set_active_dataset,
+)
+from m4.core.datasets import DatasetRegistry
+from m4.services.results import (
+    ERROR_BACKEND_INCOMPATIBLE,
+    ERROR_DATASET_NOT_FOUND,
+    WARNING_LOCAL_DB_MISSING,
+    WARNING_LOCAL_PARQUET_MISSING,
+    CommandError,
+    CommandResult,
+)
+
+
+def _absolute_path_or_none(path_value: str | Path | None) -> str | None:
+    if not path_value:
+        return None
+    return str(Path(path_value).expanduser().resolve())
+
+
+def _supported_datasets_text() -> str:
+    return ", ".join([ds.name for ds in DatasetRegistry.list_all()])
+
+
+def set_active_dataset_service(target: str) -> CommandResult | CommandError:
+    """Set the active dataset and return a machine-readable command result."""
+    target = target.lower()
+
+    availability = detect_available_local_datasets().get(target)
+    if not availability:
+        return CommandError(
+            command="use",
+            code=ERROR_DATASET_NOT_FOUND,
+            message=f"Dataset '{target}' not found or not registered.",
+            hint=f"Supported datasets: {_supported_datasets_text()}",
+        )
+
+    ds_def = DatasetRegistry.get(target)
+    backend_name = get_active_backend()
+
+    if ds_def and not ds_def.bigquery_dataset_ids and backend_name == "bigquery":
+        return CommandError(
+            command="use",
+            code=ERROR_BACKEND_INCOMPATIBLE,
+            message=f"Dataset '{target}' is not available on the BigQuery backend.",
+            hint="Switch to DuckDB first: m4 backend duckdb",
+        )
+
+    set_active_dataset(target)
+
+    warnings = []
+    if not availability["parquet_present"]:
+        warnings.append(WARNING_LOCAL_PARQUET_MISSING)
+    if backend_name == "duckdb" and not availability["db_present"]:
+        warnings.append(WARNING_LOCAL_DB_MISSING)
+
+    data: dict[str, Any] = {
+        "active_dataset": target,
+        "backend": backend_name,
+        "dataset": {
+            "name": target,
+            "parquet_present": bool(availability["parquet_present"]),
+            "db_present": bool(availability["db_present"]),
+            "parquet_root": _absolute_path_or_none(availability.get("parquet_root")),
+            "db_path": _absolute_path_or_none(availability.get("db_path")),
+            "bigquery_available": bool(ds_def and ds_def.bigquery_dataset_ids),
+        },
+    }
+    return CommandResult(command="use", data=data, warnings=warnings)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -387,6 +387,35 @@ def test_status_all_json_includes_all_mocked_datasets(
     }
 
 
+@patch("m4.services.status.verify_table_rowcount")
+@patch("m4.services.status.get_bigquery_project_id", return_value=None)
+@patch("m4.services.status.get_active_backend", return_value="duckdb")
+@patch("m4.services.status.detect_available_local_datasets")
+@patch("m4.services.status.get_active_dataset", return_value="mimic-iv")
+def test_status_all_json_does_not_probe_row_counts(
+    mock_active,
+    mock_detect,
+    mock_backend,
+    mock_project,
+    mock_rowcount,
+):
+    mock_detect.return_value = {
+        "mimic-iv": {
+            "parquet_present": True,
+            "db_present": True,
+            "parquet_root": "/tmp/full",
+            "db_path": "/tmp/full.duckdb",
+        },
+    }
+
+    result = runner.invoke(app, ["status", "--all", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["datasets"][0]["row_count"] is None
+    mock_rowcount.assert_not_called()
+
+
 @patch("m4.services.status.get_bigquery_project_id", return_value=None)
 @patch("m4.services.status.get_active_backend", return_value="duckdb")
 @patch("m4.services.status.detect_available_local_datasets", return_value={})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -218,9 +219,77 @@ def test_use_full_happy_path(mock_detect, mock_set_active):
     mock_set_active.assert_called_once_with("mimic-iv")
 
 
-@patch("m4.cli.compute_parquet_dir_size", return_value=123)
-@patch("m4.cli.get_active_dataset", return_value="mimic-iv")
+@patch("m4.cli.get_active_backend", return_value="duckdb")
+@patch("m4.cli.set_active_dataset")
 @patch("m4.cli.detect_available_local_datasets")
+def test_use_json_success_includes_warning_codes(
+    mock_detect, mock_set_active, mock_backend
+):
+    mock_detect.return_value = {
+        "mimic-iv": {
+            "parquet_present": True,
+            "db_present": False,
+            "parquet_root": "/tmp/full",
+            "db_path": "/tmp/full.duckdb",
+        },
+    }
+
+    result = runner.invoke(app, ["use", "mimic-iv", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["command"] == "use"
+    assert payload["active_dataset"] == "mimic-iv"
+    assert payload["backend"] == "duckdb"
+    assert payload["dataset"]["name"] == "mimic-iv"
+    assert payload["dataset"]["db_present"] is False
+    assert payload["warnings"] == ["local_db_missing"]
+    assert "Active dataset set" not in result.stdout
+    mock_set_active.assert_called_once_with("mimic-iv")
+
+
+@patch("m4.cli.set_active_dataset")
+@patch("m4.cli.detect_available_local_datasets", return_value={})
+def test_use_json_dataset_not_found_emits_error(mock_detect, mock_set_active):
+    result = runner.invoke(app, ["use", "missing-dataset", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["command"] == "use"
+    assert payload["error"]["code"] == "dataset_not_found"
+    assert "Dataset Not Found" not in result.stdout
+    mock_set_active.assert_not_called()
+
+
+@patch("m4.cli.get_active_backend", return_value="bigquery")
+@patch("m4.cli.set_active_dataset")
+@patch("m4.cli.detect_available_local_datasets")
+def test_use_json_backend_incompatible_emits_error(
+    mock_detect, mock_set_active, mock_backend
+):
+    mock_detect.return_value = {
+        "mimic-iv-demo": {
+            "parquet_present": True,
+            "db_present": True,
+            "parquet_root": "/tmp/demo",
+            "db_path": "/tmp/demo.duckdb",
+        },
+    }
+
+    result = runner.invoke(app, ["use", "mimic-iv-demo", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "backend_incompatible"
+    assert "Backend Incompatible" not in result.stdout
+    mock_set_active.assert_not_called()
+
+
+@patch("m4.services.status.compute_parquet_dir_size", return_value=123)
+@patch("m4.services.status.get_active_dataset", return_value="mimic-iv")
+@patch("m4.services.status.detect_available_local_datasets")
 def test_status_happy_path(mock_detect, mock_active, mock_size):
     mock_detect.return_value = {
         "mimic-iv-demo": {
@@ -245,6 +314,234 @@ def test_status_happy_path(mock_detect, mock_active, mock_size):
     assert "Parquet size:" in result.stdout
     # Derived status line should be present
     assert "Derived:" in result.stdout
+
+
+@patch("m4.services.status.get_bigquery_project_id", return_value=None)
+@patch("m4.services.status.get_active_backend", return_value="duckdb")
+@patch("m4.services.status.verify_table_rowcount", return_value=123)
+@patch("m4.services.status.compute_parquet_dir_size", return_value=1024**3)
+@patch("m4.services.status.detect_available_local_datasets")
+@patch("m4.services.status.get_active_dataset", return_value="mimic-iv")
+def test_status_json_outputs_parseable_json_without_rich_markup(
+    mock_active,
+    mock_detect,
+    mock_size,
+    mock_rowcount,
+    mock_backend,
+    mock_project,
+):
+    mock_detect.return_value = {
+        "mimic-iv": {
+            "parquet_present": True,
+            "db_present": True,
+            "parquet_root": "/tmp/full",
+            "db_path": "/tmp/full.duckdb",
+        }
+    }
+
+    result = runner.invoke(app, ["status", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["version"] == 1
+    assert payload["active_dataset"] == "mimic-iv"
+    assert len(payload["datasets"]) == 1
+    assert payload["datasets"][0]["warnings"] == []
+
+    rich_fragments = ["[bold]", "[success]", "─", "│", "__  __", "Medical Data"]
+    assert not any(fragment in result.stdout for fragment in rich_fragments)
+
+
+@patch("m4.services.status.get_bigquery_project_id", return_value=None)
+@patch("m4.services.status.get_active_backend", return_value="duckdb")
+@patch("m4.services.status.detect_available_local_datasets")
+@patch("m4.services.status.get_active_dataset", return_value="mimic-iv")
+def test_status_all_json_includes_all_mocked_datasets(
+    mock_active,
+    mock_detect,
+    mock_backend,
+    mock_project,
+):
+    mock_detect.return_value = {
+        "mimic-iv-demo": {
+            "parquet_present": False,
+            "db_present": False,
+            "parquet_root": "/tmp/demo",
+            "db_path": "/tmp/demo.duckdb",
+        },
+        "mimic-iv": {
+            "parquet_present": False,
+            "db_present": False,
+            "parquet_root": "/tmp/full",
+            "db_path": "/tmp/full.duckdb",
+        },
+    }
+
+    result = runner.invoke(app, ["status", "--all", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert {dataset["name"] for dataset in payload["datasets"]} == {
+        "mimic-iv-demo",
+        "mimic-iv",
+    }
+
+
+@patch("m4.services.status.get_bigquery_project_id", return_value=None)
+@patch("m4.services.status.get_active_backend", return_value="duckdb")
+@patch("m4.services.status.detect_available_local_datasets", return_value={})
+@patch(
+    "m4.services.status.get_active_dataset",
+    side_effect=DatasetError("No active dataset"),
+)
+def test_status_json_no_active_dataset_returns_empty_dataset_list(
+    mock_active,
+    mock_detect,
+    mock_backend,
+    mock_project,
+):
+    result = runner.invoke(app, ["status", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "version": 1,
+        "active_dataset": None,
+        "backend": "duckdb",
+        "bigquery_project_id": None,
+        "datasets": [],
+    }
+
+
+@patch("m4.services.status.get_bigquery_project_id", return_value=None)
+@patch("m4.services.status.get_active_backend", return_value="duckdb")
+@patch("m4.services.status.compute_parquet_dir_size")
+@patch("m4.services.status.verify_table_rowcount")
+@patch("m4.services.status.detect_available_local_datasets")
+@patch("m4.services.status.get_active_dataset", return_value="mimic-iv")
+def test_status_json_missing_local_files_are_not_errors(
+    mock_active,
+    mock_detect,
+    mock_rowcount,
+    mock_size,
+    mock_backend,
+    mock_project,
+):
+    mock_detect.return_value = {
+        "mimic-iv": {
+            "parquet_present": False,
+            "db_present": False,
+            "parquet_root": "/tmp/full",
+            "db_path": "/tmp/full.duckdb",
+        }
+    }
+
+    result = runner.invoke(app, ["status", "--json"])
+
+    assert result.exit_code == 0
+    dataset = json.loads(result.stdout)["datasets"][0]
+    assert dataset["parquet_present"] is False
+    assert dataset["db_present"] is False
+    assert dataset["parquet_size_gb"] is None
+    assert dataset["row_count"] is None
+    mock_size.assert_not_called()
+    mock_rowcount.assert_not_called()
+
+
+@patch("m4.services.status.get_bigquery_project_id", return_value="allowed-project")
+@patch("m4.services.status.get_active_backend", return_value="bigquery")
+@patch("m4.services.status.detect_available_local_datasets")
+@patch("m4.services.status.get_active_dataset", return_value="mimic-iv")
+def test_status_json_excludes_secret_values_but_allows_project_id(
+    mock_active,
+    mock_detect,
+    mock_backend,
+    mock_project,
+    monkeypatch,
+):
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/tmp/secret-service.json")
+    monkeypatch.setenv("M4_PASSWORD", "super-secret-password")
+    mock_detect.return_value = {
+        "mimic-iv": {
+            "parquet_present": False,
+            "db_present": False,
+            "parquet_root": "/tmp/full",
+            "db_path": "/tmp/full.duckdb",
+        }
+    }
+
+    result = runner.invoke(app, ["status", "--json"])
+
+    assert result.exit_code == 0
+    assert "allowed-project" in result.stdout
+    assert "secret-service" not in result.stdout
+    assert "super-secret-password" not in result.stdout
+
+
+@patch("m4.services.status.get_bigquery_project_id", return_value=None)
+@patch("m4.services.status.get_active_backend", return_value="duckdb")
+@patch(
+    "m4.services.status.verify_table_rowcount",
+    side_effect=Exception("No files found that match the pattern"),
+)
+@patch("m4.services.status.detect_available_local_datasets")
+@patch("m4.services.status.get_active_dataset", return_value="mimic-iv")
+def test_status_json_path_mismatch_emits_warning(
+    mock_active, mock_detect, mock_rowcount, mock_backend, mock_project
+):
+    mock_detect.return_value = {
+        "mimic-iv": {
+            "parquet_present": False,
+            "db_present": True,
+            "parquet_root": "/tmp/full",
+            "db_path": "/tmp/full.duckdb",
+        }
+    }
+
+    result = runner.invoke(app, ["status", "--json"])
+
+    assert result.exit_code == 0
+    dataset = json.loads(result.stdout)["datasets"][0]
+    assert dataset["warnings"] == ["parquet_path_mismatch"]
+    assert "_row_count_error" not in dataset
+
+
+@patch("m4.services.status.get_bigquery_project_id", return_value=None)
+@patch("m4.services.status.get_active_backend", return_value="duckdb")
+@patch(
+    "m4.services.status.verify_table_rowcount",
+    side_effect=Exception("No files found that match the pattern"),
+)
+@patch("m4.services.status.detect_available_local_datasets")
+@patch("m4.services.status.get_active_dataset", return_value="mimic-iv")
+def test_status_human_path_mismatch_prints_warning(
+    mock_active, mock_detect, mock_rowcount, mock_backend, mock_project
+):
+    mock_detect.return_value = {
+        "mimic-iv": {
+            "parquet_present": False,
+            "db_present": True,
+            "parquet_root": "/tmp/full",
+            "db_path": "/tmp/full.duckdb",
+        }
+    }
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert "Database views may point to wrong parquet location" in result.stdout
+
+
+def test_status_derived_json_is_invalid_combination():
+    result = runner.invoke(app, ["status", "--derived", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["command"] == "status"
+    assert payload["error"]["code"] == "invalid_option"
+    assert "Active dataset" not in result.stdout
+    assert "__  __" not in result.stdout
 
 
 @patch("m4.cli.list_materialized_tables")
@@ -371,6 +668,106 @@ def test_backend_duckdb_shows_init_hint(mock_set_backend):
     assert result.exit_code == 0
     assert "DuckDB uses local database files" in result.stdout
     assert "m4 init" in result.stdout
+
+
+@patch("m4.cli.get_bigquery_project_id", return_value=None)
+@patch("m4.cli.get_active_dataset", return_value="mimic-iv")
+@patch("m4.cli.set_active_backend")
+def test_backend_json_duckdb_success(
+    mock_set_backend, mock_get_dataset, mock_get_project
+):
+    result = runner.invoke(app, ["backend", "duckdb", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "version": 1,
+        "ok": True,
+        "command": "backend",
+        "backend": "duckdb",
+        "active_dataset": "mimic-iv",
+        "bigquery_project_id": None,
+        "warnings": [],
+    }
+    assert "Active backend set" not in result.stdout
+    mock_set_backend.assert_called_once_with("duckdb")
+
+
+@patch("m4.cli.set_bigquery_project_id")
+@patch("m4.cli.get_active_dataset", return_value="mimic-iv")
+@patch("m4.cli.set_active_backend")
+def test_backend_json_bigquery_with_project_id_success(
+    mock_set_backend, mock_get_dataset, mock_set_project
+):
+    result = runner.invoke(
+        app, ["backend", "bigquery", "--project-id", "my-project", "--json"]
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["command"] == "backend"
+    assert payload["backend"] == "bigquery"
+    assert payload["active_dataset"] == "mimic-iv"
+    assert payload["bigquery_project_id"] == "my-project"
+    assert payload["warnings"] == []
+    mock_set_backend.assert_called_once_with("bigquery")
+    mock_set_project.assert_called_once_with("my-project")
+
+
+@patch("m4.cli.set_active_backend")
+def test_backend_json_invalid_backend_emits_error(mock_set_backend):
+    result = runner.invoke(app, ["backend", "mysql", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "invalid_backend"
+    assert "Invalid Backend" not in result.stdout
+    mock_set_backend.assert_not_called()
+
+
+@patch("m4.cli.set_bigquery_project_id")
+@patch("m4.cli.set_active_backend")
+def test_backend_json_duckdb_rejects_project_id(mock_set_backend, mock_set_project):
+    result = runner.invoke(app, ["backend", "duckdb", "--project-id", "x", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "invalid_option"
+    assert "project-id can only be used with bigquery" in payload["error"]["message"]
+    mock_set_backend.assert_not_called()
+    mock_set_project.assert_not_called()
+
+
+@patch("m4.cli.set_active_backend")
+@patch("m4.cli.get_active_dataset", return_value="mimic-iv-demo")
+def test_backend_json_bigquery_blocks_incompatible_active_dataset(
+    mock_get_dataset, mock_set_backend
+):
+    result = runner.invoke(app, ["backend", "bigquery", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "dataset_incompatible"
+    assert "Dataset Incompatible" not in result.stdout
+    mock_set_backend.assert_not_called()
+
+
+@patch("m4.cli.get_bigquery_project_id", return_value=None)
+@patch("m4.cli.set_bigquery_project_id")
+@patch("m4.cli.set_active_backend")
+@patch("m4.cli.get_active_dataset", side_effect=DatasetError("No active dataset"))
+def test_backend_json_bigquery_requires_project_id(
+    mock_get_dataset, mock_set_backend, mock_set_project, mock_get_project
+):
+    result = runner.invoke(app, ["backend", "bigquery", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "project_id_required"
+    assert "Project ID Required" not in result.stdout
+    mock_set_backend.assert_not_called()
+    mock_set_project.assert_not_called()
 
 
 # ----------------------------------------------------------------
@@ -624,11 +1021,11 @@ def test_config_universal_bigquery_persists_to_config(
 # ----------------------------------------------------------------
 
 
-@patch("m4.cli.get_bigquery_project_id", return_value="my-gcp-project")
-@patch("m4.cli.get_active_backend", return_value="bigquery")
-@patch("m4.cli.compute_parquet_dir_size", return_value=123)
-@patch("m4.cli.get_active_dataset", return_value="mimic-iv")
-@patch("m4.cli.detect_available_local_datasets")
+@patch("m4.services.status.get_bigquery_project_id", return_value="my-gcp-project")
+@patch("m4.services.status.get_active_backend", return_value="bigquery")
+@patch("m4.services.status.compute_parquet_dir_size", return_value=123)
+@patch("m4.services.status.get_active_dataset", return_value="mimic-iv")
+@patch("m4.services.status.detect_available_local_datasets")
 def test_status_bigquery_shows_project_id(
     mock_detect, mock_active, mock_size, mock_backend, mock_get_project
 ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -194,8 +194,8 @@ def test_config_claude_infers_db_path_full(
     assert "--db-path" not in call_args
 
 
-@patch("m4.cli.set_active_dataset")
-@patch("m4.cli.detect_available_local_datasets")
+@patch("m4.services.use.set_active_dataset")
+@patch("m4.services.use.detect_available_local_datasets")
 def test_use_full_happy_path(mock_detect, mock_set_active):
     mock_detect.return_value = {
         "mimic-iv-demo": {
@@ -219,9 +219,9 @@ def test_use_full_happy_path(mock_detect, mock_set_active):
     mock_set_active.assert_called_once_with("mimic-iv")
 
 
-@patch("m4.cli.get_active_backend", return_value="duckdb")
-@patch("m4.cli.set_active_dataset")
-@patch("m4.cli.detect_available_local_datasets")
+@patch("m4.services.use.get_active_backend", return_value="duckdb")
+@patch("m4.services.use.set_active_dataset")
+@patch("m4.services.use.detect_available_local_datasets")
 def test_use_json_success_includes_warning_codes(
     mock_detect, mock_set_active, mock_backend
 ):
@@ -249,8 +249,8 @@ def test_use_json_success_includes_warning_codes(
     mock_set_active.assert_called_once_with("mimic-iv")
 
 
-@patch("m4.cli.set_active_dataset")
-@patch("m4.cli.detect_available_local_datasets", return_value={})
+@patch("m4.services.use.set_active_dataset")
+@patch("m4.services.use.detect_available_local_datasets", return_value={})
 def test_use_json_dataset_not_found_emits_error(mock_detect, mock_set_active):
     result = runner.invoke(app, ["use", "missing-dataset", "--json"])
 
@@ -263,9 +263,9 @@ def test_use_json_dataset_not_found_emits_error(mock_detect, mock_set_active):
     mock_set_active.assert_not_called()
 
 
-@patch("m4.cli.get_active_backend", return_value="bigquery")
-@patch("m4.cli.set_active_dataset")
-@patch("m4.cli.detect_available_local_datasets")
+@patch("m4.services.use.get_active_backend", return_value="bigquery")
+@patch("m4.services.use.set_active_dataset")
+@patch("m4.services.use.detect_available_local_datasets")
 def test_use_json_backend_incompatible_emits_error(
     mock_detect, mock_set_active, mock_backend
 ):
@@ -585,7 +585,7 @@ def test_status_derived_flag_no_active_dataset(mock_active):
 # ----------------------------------------------------------------
 
 
-@patch("m4.cli.set_active_backend")
+@patch("m4.services.backend.set_active_backend")
 def test_backend_duckdb_happy_path(mock_set_backend):
     """Test setting backend to duckdb."""
     result = runner.invoke(app, ["backend", "duckdb"])
@@ -595,10 +595,10 @@ def test_backend_duckdb_happy_path(mock_set_backend):
     mock_set_backend.assert_called_once_with("duckdb")
 
 
-@patch("m4.cli.get_bigquery_project_id", return_value="my-project")
-@patch("m4.cli.set_active_backend")
-@patch("m4.cli.get_active_dataset")
-@patch("m4.cli.DatasetRegistry.get")
+@patch("m4.services.backend.get_bigquery_project_id", return_value="my-project")
+@patch("m4.services.backend.set_active_backend")
+@patch("m4.services.backend.get_active_dataset")
+@patch("m4.services.backend.DatasetRegistry.get")
 def test_backend_bigquery_happy_path(
     mock_registry, mock_get_dataset, mock_set_backend, mock_get_project
 ):
@@ -617,9 +617,9 @@ def test_backend_bigquery_happy_path(
     mock_set_backend.assert_called_once_with("bigquery")
 
 
-@patch("m4.cli.set_active_backend")
-@patch("m4.cli.get_active_dataset")
-@patch("m4.cli.DatasetRegistry.get")
+@patch("m4.services.backend.set_active_backend")
+@patch("m4.services.backend.get_active_dataset")
+@patch("m4.services.backend.DatasetRegistry.get")
 def test_backend_bigquery_blocks_unsupported_dataset(
     mock_registry, mock_get_dataset, mock_set_backend
 ):
@@ -649,9 +649,12 @@ def test_backend_invalid_choice():
     assert "duckdb" in result.stdout
 
 
-@patch("m4.cli.get_bigquery_project_id", return_value="my-project")
-@patch("m4.cli.set_active_backend")
-@patch("m4.cli.get_active_dataset", side_effect=DatasetError("No active dataset"))
+@patch("m4.services.backend.get_bigquery_project_id", return_value="my-project")
+@patch("m4.services.backend.set_active_backend")
+@patch(
+    "m4.services.backend.get_active_dataset",
+    side_effect=DatasetError("No active dataset"),
+)
 def test_backend_case_insensitive(mock_get_dataset, mock_set_backend, mock_get_project):
     """Test that backend choice is case-insensitive."""
     result = runner.invoke(app, ["backend", "BIGQUERY"])
@@ -660,7 +663,7 @@ def test_backend_case_insensitive(mock_get_dataset, mock_set_backend, mock_get_p
     mock_set_backend.assert_called_once_with("bigquery")
 
 
-@patch("m4.cli.set_active_backend")
+@patch("m4.services.backend.set_active_backend")
 def test_backend_duckdb_shows_init_hint(mock_set_backend):
     """Test that duckdb backend shows initialization hint."""
     result = runner.invoke(app, ["backend", "duckdb"])
@@ -670,9 +673,9 @@ def test_backend_duckdb_shows_init_hint(mock_set_backend):
     assert "m4 init" in result.stdout
 
 
-@patch("m4.cli.get_bigquery_project_id", return_value=None)
-@patch("m4.cli.get_active_dataset", return_value="mimic-iv")
-@patch("m4.cli.set_active_backend")
+@patch("m4.services.backend.get_bigquery_project_id", return_value=None)
+@patch("m4.services.backend.get_active_dataset", return_value="mimic-iv")
+@patch("m4.services.backend.set_active_backend")
 def test_backend_json_duckdb_success(
     mock_set_backend, mock_get_dataset, mock_get_project
 ):
@@ -693,9 +696,9 @@ def test_backend_json_duckdb_success(
     mock_set_backend.assert_called_once_with("duckdb")
 
 
-@patch("m4.cli.set_bigquery_project_id")
-@patch("m4.cli.get_active_dataset", return_value="mimic-iv")
-@patch("m4.cli.set_active_backend")
+@patch("m4.services.backend.set_bigquery_project_id")
+@patch("m4.services.backend.get_active_dataset", return_value="mimic-iv")
+@patch("m4.services.backend.set_active_backend")
 def test_backend_json_bigquery_with_project_id_success(
     mock_set_backend, mock_get_dataset, mock_set_project
 ):
@@ -715,7 +718,7 @@ def test_backend_json_bigquery_with_project_id_success(
     mock_set_project.assert_called_once_with("my-project")
 
 
-@patch("m4.cli.set_active_backend")
+@patch("m4.services.backend.set_active_backend")
 def test_backend_json_invalid_backend_emits_error(mock_set_backend):
     result = runner.invoke(app, ["backend", "mysql", "--json"])
 
@@ -726,8 +729,8 @@ def test_backend_json_invalid_backend_emits_error(mock_set_backend):
     mock_set_backend.assert_not_called()
 
 
-@patch("m4.cli.set_bigquery_project_id")
-@patch("m4.cli.set_active_backend")
+@patch("m4.services.backend.set_bigquery_project_id")
+@patch("m4.services.backend.set_active_backend")
 def test_backend_json_duckdb_rejects_project_id(mock_set_backend, mock_set_project):
     result = runner.invoke(app, ["backend", "duckdb", "--project-id", "x", "--json"])
 
@@ -739,8 +742,8 @@ def test_backend_json_duckdb_rejects_project_id(mock_set_backend, mock_set_proje
     mock_set_project.assert_not_called()
 
 
-@patch("m4.cli.set_active_backend")
-@patch("m4.cli.get_active_dataset", return_value="mimic-iv-demo")
+@patch("m4.services.backend.set_active_backend")
+@patch("m4.services.backend.get_active_dataset", return_value="mimic-iv-demo")
 def test_backend_json_bigquery_blocks_incompatible_active_dataset(
     mock_get_dataset, mock_set_backend
 ):
@@ -753,10 +756,13 @@ def test_backend_json_bigquery_blocks_incompatible_active_dataset(
     mock_set_backend.assert_not_called()
 
 
-@patch("m4.cli.get_bigquery_project_id", return_value=None)
-@patch("m4.cli.set_bigquery_project_id")
-@patch("m4.cli.set_active_backend")
-@patch("m4.cli.get_active_dataset", side_effect=DatasetError("No active dataset"))
+@patch("m4.services.backend.get_bigquery_project_id", return_value=None)
+@patch("m4.services.backend.set_bigquery_project_id")
+@patch("m4.services.backend.set_active_backend")
+@patch(
+    "m4.services.backend.get_active_dataset",
+    side_effect=DatasetError("No active dataset"),
+)
 def test_backend_json_bigquery_requires_project_id(
     mock_get_dataset, mock_set_backend, mock_set_project, mock_get_project
 ):
@@ -856,9 +862,12 @@ class TestInitDerivedTableSkipForce:
 # ----------------------------------------------------------------
 
 
-@patch("m4.cli.set_bigquery_project_id")
-@patch("m4.cli.set_active_backend")
-@patch("m4.cli.get_active_dataset", side_effect=DatasetError("No active dataset"))
+@patch("m4.services.backend.set_bigquery_project_id")
+@patch("m4.services.backend.set_active_backend")
+@patch(
+    "m4.services.backend.get_active_dataset",
+    side_effect=DatasetError("No active dataset"),
+)
 def test_backend_bigquery_with_project_id(
     mock_get_dataset, mock_set_backend, mock_set_project
 ):
@@ -873,8 +882,8 @@ def test_backend_bigquery_with_project_id(
     mock_set_project.assert_called_once_with("my-gcp-project")
 
 
-@patch("m4.cli.set_bigquery_project_id")
-@patch("m4.cli.set_active_backend")
+@patch("m4.services.backend.set_bigquery_project_id")
+@patch("m4.services.backend.set_active_backend")
 def test_backend_duckdb_rejects_project_id(mock_set_backend, mock_set_project):
     """Test backend duckdb --project-id is rejected."""
     result = runner.invoke(app, ["backend", "duckdb", "--project-id", "my-gcp-project"])
@@ -885,10 +894,13 @@ def test_backend_duckdb_rejects_project_id(mock_set_backend, mock_set_project):
     mock_set_project.assert_not_called()
 
 
-@patch("m4.cli.get_bigquery_project_id", return_value=None)
-@patch("m4.cli.set_bigquery_project_id")
-@patch("m4.cli.set_active_backend")
-@patch("m4.cli.get_active_dataset", side_effect=DatasetError("No active dataset"))
+@patch("m4.services.backend.get_bigquery_project_id", return_value=None)
+@patch("m4.services.backend.set_bigquery_project_id")
+@patch("m4.services.backend.set_active_backend")
+@patch(
+    "m4.services.backend.get_active_dataset",
+    side_effect=DatasetError("No active dataset"),
+)
 def test_backend_bigquery_without_project_id_errors(
     mock_get_dataset, mock_set_backend, mock_set_project, mock_get_project
 ):
@@ -902,10 +914,13 @@ def test_backend_bigquery_without_project_id_errors(
     mock_set_project.assert_not_called()
 
 
-@patch("m4.cli.get_bigquery_project_id", return_value="existing-project")
-@patch("m4.cli.set_bigquery_project_id")
-@patch("m4.cli.set_active_backend")
-@patch("m4.cli.get_active_dataset", side_effect=DatasetError("No active dataset"))
+@patch("m4.services.backend.get_bigquery_project_id", return_value="existing-project")
+@patch("m4.services.backend.set_bigquery_project_id")
+@patch("m4.services.backend.set_active_backend")
+@patch(
+    "m4.services.backend.get_active_dataset",
+    side_effect=DatasetError("No active dataset"),
+)
 def test_backend_bigquery_without_flag_uses_config_project_id(
     mock_get_dataset, mock_set_backend, mock_set_project, mock_get_project
 ):

--- a/tests/test_cli_subprocess.py
+++ b/tests/test_cli_subprocess.py
@@ -1,0 +1,107 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+RICH_FRAGMENTS = ["[bold]", "[success]", "__  __", "Medical Data", "─", "│"]
+
+
+def _run_m4(args: list[str], tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    env["M4_DATA_DIR"] = str(tmp_path / "m4_data")
+    env.pop("M4_BACKEND", None)
+    env.pop("M4_DATASET", None)
+    env.pop("M4_PROJECT_ID", None)
+    return subprocess.run(
+        [sys.executable, "-m", "m4.cli", *args],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def _assert_single_json_stdout(result: subprocess.CompletedProcess[str]) -> dict:
+    stdout = result.stdout.strip()
+    payload = json.loads(stdout)
+    assert stdout == json.dumps(payload, indent=2)
+    assert not any(fragment in stdout for fragment in RICH_FRAGMENTS)
+    return payload
+
+
+def test_status_json_subprocess_is_parseable(tmp_path):
+    result = _run_m4(["status", "--json"], tmp_path)
+
+    assert result.returncode == 0
+    payload = _assert_single_json_stdout(result)
+    assert payload["version"] == 1
+    assert "ok" not in payload
+
+
+def test_status_all_json_subprocess_is_parseable(tmp_path):
+    result = _run_m4(["status", "--all", "--json"], tmp_path)
+
+    assert result.returncode == 0
+    payload = _assert_single_json_stdout(result)
+    assert payload["version"] == 1
+    assert {dataset["name"] for dataset in payload["datasets"]} >= {
+        "mimic-iv-demo",
+        "mimic-iv",
+    }
+
+
+def test_use_json_subprocess_is_parseable(tmp_path):
+    pq_root = tmp_path / "m4_data" / "parquet" / "mimic-iv-demo"
+    pq_root.mkdir(parents=True)
+    (pq_root / "admissions.parquet").touch()
+
+    result = _run_m4(["use", "mimic-iv-demo", "--json"], tmp_path)
+
+    assert result.returncode == 0
+    payload = _assert_single_json_stdout(result)
+    assert payload["ok"] is True
+    assert payload["command"] == "use"
+    assert payload["active_dataset"] == "mimic-iv-demo"
+
+
+def test_backend_json_subprocess_is_parseable(tmp_path):
+    result = _run_m4(["backend", "duckdb", "--json"], tmp_path)
+
+    assert result.returncode == 0
+    payload = _assert_single_json_stdout(result)
+    assert payload["ok"] is True
+    assert payload["command"] == "backend"
+    assert payload["backend"] == "duckdb"
+
+
+def test_failing_json_subprocess_emits_one_parseable_error(tmp_path):
+    result = _run_m4(["backend", "mysql", "--json"], tmp_path)
+
+    assert result.returncode != 0
+    payload = _assert_single_json_stdout(result)
+    assert payload["ok"] is False
+    assert payload["command"] == "backend"
+    assert payload["error"]["code"] == "invalid_backend"
+
+
+def test_init_json_subprocess_error_is_parseable(tmp_path):
+    result = _run_m4(["init", "not-a-dataset", "--json"], tmp_path)
+
+    assert result.returncode != 0
+    payload = _assert_single_json_stdout(result)
+    assert payload["ok"] is False
+    assert payload["command"] == "init"
+    assert payload["error"]["code"] == "dataset_not_found"
+
+
+def test_init_json_subprocess_blocked_state_is_parseable(tmp_path):
+    result = _run_m4(["init", "mimic-iv", "--json"], tmp_path)
+
+    assert result.returncode == 0
+    payload = _assert_single_json_stdout(result)
+    assert payload["ok"] is True
+    assert payload["command"] == "init"
+    assert payload["dataset"] == "mimic-iv"
+    assert payload["steps"][0]["status"] == "blocked"

--- a/tests/test_cli_subprocess.py
+++ b/tests/test_cli_subprocess.py
@@ -27,6 +27,7 @@ def _assert_single_json_stdout(result: subprocess.CompletedProcess[str]) -> dict
     stdout = result.stdout.strip()
     payload = json.loads(stdout)
     assert stdout == json.dumps(payload, indent=2)
+    assert result.stderr.strip() == ""
     assert not any(fragment in stdout for fragment in RICH_FRAGMENTS)
     return payload
 

--- a/tests/test_services_init.py
+++ b/tests/test_services_init.py
@@ -1,0 +1,242 @@
+from unittest.mock import patch
+
+from m4.services.init import initialize_dataset_service
+from m4.services.results import CommandError, CommandResult
+
+
+def _step_by_name(result: CommandResult, name: str) -> dict:
+    return next(step for step in result.data["steps"] if step["name"] == name)
+
+
+def test_init_service_unsupported_dataset_error():
+    result = initialize_dataset_service("not-a-dataset")
+
+    assert isinstance(result, CommandError)
+    assert result.code == "dataset_not_found"
+
+
+@patch("m4.services.init.get_dataset_parquet_root", return_value=None)
+def test_init_service_missing_parquet_directory_resolution_error(mock_parquet_root):
+    result = initialize_dataset_service("mimic-iv-demo")
+
+    assert isinstance(result, CommandError)
+    assert result.code == "invalid_option"
+    assert "Could not determine dataset directories" in result.message
+
+
+@patch("m4.services.init.has_derived_support", return_value=False)
+@patch("m4.services.init.set_active_dataset")
+@patch("m4.services.init.verify_table_rowcount", return_value=100)
+@patch("m4.services.init.init_duckdb_from_parquet", return_value=True)
+@patch("m4.services.init.get_default_database_path")
+@patch("m4.services.init.get_dataset_parquet_root")
+def test_init_service_parquet_already_present_path(
+    mock_parquet_root,
+    mock_db_path,
+    mock_init,
+    mock_verify,
+    mock_set_active,
+    mock_derived_support,
+    tmp_path,
+):
+    pq_root = tmp_path / "parquet" / "mimic-iv-demo"
+    pq_root.mkdir(parents=True)
+    (pq_root / "admissions.parquet").touch()
+    db_path = tmp_path / "mimic.duckdb"
+    mock_parquet_root.return_value = pq_root
+    mock_db_path.return_value = db_path
+
+    result = initialize_dataset_service("mimic-iv-demo")
+
+    assert isinstance(result, CommandResult)
+    assert _step_by_name(result, "raw_files")["status"] == "skipped"
+    assert _step_by_name(result, "parquet")["status"] == "skipped"
+    assert _step_by_name(result, "database")["status"] == "completed"
+    mock_init.assert_called_once_with(
+        dataset_name="mimic-iv-demo", db_target_path=db_path
+    )
+    mock_set_active.assert_called_once_with("mimic-iv-demo")
+
+
+@patch("m4.services.init.has_derived_support", return_value=False)
+@patch("m4.services.init.set_active_dataset")
+@patch("m4.services.init.verify_table_rowcount", return_value=100)
+@patch("m4.services.init.init_duckdb_from_parquet", return_value=True)
+@patch("m4.services.init.convert_csv_to_parquet", return_value=True)
+@patch("m4.services.init.get_default_database_path")
+@patch("m4.services.init.get_dataset_parquet_root")
+def test_init_service_raw_to_parquet_conversion_path(
+    mock_parquet_root,
+    mock_db_path,
+    mock_convert,
+    mock_init,
+    mock_verify,
+    mock_set_active,
+    mock_derived_support,
+    tmp_path,
+):
+    pq_root = tmp_path / "parquet" / "mimic-iv-demo"
+    pq_root.mkdir(parents=True)
+    raw_root = tmp_path / "raw_files" / "mimic-iv-demo" / "hosp"
+    raw_root.mkdir(parents=True)
+    (raw_root / "admissions.csv.gz").touch()
+    db_path = tmp_path / "mimic.duckdb"
+    mock_parquet_root.return_value = pq_root
+    mock_db_path.return_value = db_path
+
+    result = initialize_dataset_service("mimic-iv-demo")
+
+    assert isinstance(result, CommandResult)
+    assert _step_by_name(result, "raw_files")["status"] == "completed"
+    assert _step_by_name(result, "parquet")["status"] == "completed"
+    mock_convert.assert_called_once()
+
+
+@patch("m4.services.init.get_default_database_path")
+@patch("m4.services.init.get_dataset_parquet_root")
+def test_init_service_credentialed_dataset_returns_blocked_state(
+    mock_parquet_root, mock_db_path, tmp_path
+):
+    pq_root = tmp_path / "parquet" / "mimic-iv"
+    pq_root.mkdir(parents=True)
+    db_path = tmp_path / "mimic.duckdb"
+    mock_parquet_root.return_value = pq_root
+    mock_db_path.return_value = db_path
+
+    result = initialize_dataset_service("mimic-iv")
+
+    assert isinstance(result, CommandResult)
+    assert _step_by_name(result, "raw_files")["status"] == "blocked"
+    assert _step_by_name(result, "database")["status"] == "skipped"
+
+
+@patch("m4.services.init.has_derived_support", return_value=False)
+@patch("m4.services.init.set_active_dataset")
+@patch("m4.services.init.verify_table_rowcount", return_value=100)
+@patch("m4.services.init.init_duckdb_from_parquet", return_value=True)
+@patch("m4.services.init.get_default_database_path")
+@patch("m4.services.init.get_dataset_parquet_root")
+def test_init_service_force_deletes_existing_database(
+    mock_parquet_root,
+    mock_db_path,
+    mock_init,
+    mock_verify,
+    mock_set_active,
+    mock_derived_support,
+    tmp_path,
+):
+    pq_root = tmp_path / "parquet" / "mimic-iv-demo"
+    pq_root.mkdir(parents=True)
+    (pq_root / "admissions.parquet").touch()
+    db_path = tmp_path / "mimic.duckdb"
+    db_path.write_text("old")
+    mock_parquet_root.return_value = pq_root
+    mock_db_path.return_value = db_path
+
+    result = initialize_dataset_service("mimic-iv-demo", force=True)
+
+    assert isinstance(result, CommandResult)
+    assert not db_path.exists()
+    mock_init.assert_called_once()
+
+
+@patch("m4.services.init.get_active_backend", return_value="duckdb")
+@patch("m4.services.init.get_derived_table_count", return_value=0)
+@patch("m4.services.init.has_derived_support", return_value=True)
+@patch("m4.services.init.set_active_dataset")
+@patch("m4.services.init.verify_table_rowcount", return_value=100)
+@patch("m4.services.init.init_duckdb_from_parquet", return_value=True)
+@patch("m4.services.init.get_default_database_path")
+@patch("m4.services.init.get_dataset_parquet_root")
+def test_init_service_derived_skipped_by_default(
+    mock_parquet_root,
+    mock_db_path,
+    mock_init,
+    mock_verify,
+    mock_set_active,
+    mock_derived_support,
+    mock_derived_count,
+    mock_backend,
+    tmp_path,
+):
+    pq_root = tmp_path / "parquet" / "mimic-iv"
+    pq_root.mkdir(parents=True)
+    (pq_root / "admissions.parquet").touch()
+    db_path = tmp_path / "mimic.duckdb"
+    mock_parquet_root.return_value = pq_root
+    mock_db_path.return_value = db_path
+
+    result = initialize_dataset_service("mimic-iv")
+
+    assert isinstance(result, CommandResult)
+    assert _step_by_name(result, "derived")["status"] == "skipped"
+
+
+@patch("m4.services.init.get_active_backend", return_value="duckdb")
+@patch("m4.services.init.materialize_all", return_value=["sofa", "sepsis3"])
+@patch("m4.services.init.get_derived_table_count", return_value=42)
+@patch("m4.services.init.has_derived_support", return_value=True)
+@patch("m4.services.init.set_active_dataset")
+@patch("m4.services.init.verify_table_rowcount", return_value=100)
+@patch("m4.services.init.init_duckdb_from_parquet", return_value=True)
+@patch("m4.services.init.get_default_database_path")
+@patch("m4.services.init.get_dataset_parquet_root")
+def test_init_service_force_materializes_existing_derived_tables(
+    mock_parquet_root,
+    mock_db_path,
+    mock_init,
+    mock_verify,
+    mock_set_active,
+    mock_derived_support,
+    mock_derived_count,
+    mock_materialize,
+    mock_backend,
+    tmp_path,
+):
+    pq_root = tmp_path / "parquet" / "mimic-iv"
+    pq_root.mkdir(parents=True)
+    (pq_root / "admissions.parquet").touch()
+    db_path = tmp_path / "mimic.duckdb"
+    mock_parquet_root.return_value = pq_root
+    mock_db_path.return_value = db_path
+
+    result = initialize_dataset_service("mimic-iv", force=True)
+
+    assert isinstance(result, CommandResult)
+    assert _step_by_name(result, "derived")["status"] == "completed"
+    mock_materialize.assert_called_once_with("mimic-iv", db_path)
+
+
+@patch("m4.services.init.get_active_backend", return_value="duckdb")
+@patch("m4.services.init.materialize_all", side_effect=RuntimeError("SQL failed"))
+@patch("m4.services.init.get_derived_table_count", return_value=42)
+@patch("m4.services.init.has_derived_support", return_value=True)
+@patch("m4.services.init.set_active_dataset")
+@patch("m4.services.init.verify_table_rowcount", return_value=100)
+@patch("m4.services.init.init_duckdb_from_parquet", return_value=True)
+@patch("m4.services.init.get_default_database_path")
+@patch("m4.services.init.get_dataset_parquet_root")
+def test_init_service_derived_failure_is_nonfatal_step(
+    mock_parquet_root,
+    mock_db_path,
+    mock_init,
+    mock_verify,
+    mock_set_active,
+    mock_derived_support,
+    mock_derived_count,
+    mock_materialize,
+    mock_backend,
+    tmp_path,
+):
+    pq_root = tmp_path / "parquet" / "mimic-iv"
+    pq_root.mkdir(parents=True)
+    (pq_root / "admissions.parquet").touch()
+    db_path = tmp_path / "mimic.duckdb"
+    mock_parquet_root.return_value = pq_root
+    mock_db_path.return_value = db_path
+
+    result = initialize_dataset_service("mimic-iv", force=True)
+
+    assert isinstance(result, CommandResult)
+    assert result.ok is True
+    assert _step_by_name(result, "derived")["status"] == "failed"

--- a/tests/test_services_results.py
+++ b/tests/test_services_results.py
@@ -1,0 +1,49 @@
+from m4.services.results import CommandError, CommandResult
+
+
+def test_command_result_serializes_envelope_with_data_and_warnings():
+    result = CommandResult(
+        command="use",
+        data={"active_dataset": "mimic-iv", "backend": "duckdb"},
+        warnings=["local_db_missing"],
+    )
+
+    assert result.to_json_dict() == {
+        "version": 1,
+        "ok": True,
+        "command": "use",
+        "active_dataset": "mimic-iv",
+        "backend": "duckdb",
+        "warnings": ["local_db_missing"],
+    }
+
+
+def test_command_error_serializes_without_empty_hint():
+    error = CommandError(
+        command="backend",
+        code="invalid_backend",
+        message="Backend 'mysql' is not valid.",
+    )
+
+    assert error.to_json_dict() == {
+        "version": 1,
+        "ok": False,
+        "command": "backend",
+        "error": {
+            "code": "invalid_backend",
+            "message": "Backend 'mysql' is not valid.",
+        },
+    }
+
+
+def test_command_error_serializes_hint_when_present():
+    error = CommandError(
+        command="backend",
+        code="project_id_required",
+        message="BigQuery backend requires a project ID.",
+        hint="Set it with: m4 backend bigquery --project-id <ID>",
+    )
+
+    assert error.to_json_dict()["error"]["hint"] == (
+        "Set it with: m4 backend bigquery --project-id <ID>"
+    )

--- a/tests/test_services_use_backend.py
+++ b/tests/test_services_use_backend.py
@@ -1,0 +1,145 @@
+from unittest.mock import patch
+
+from m4.core.exceptions import DatasetError
+from m4.services.backend import set_active_backend_service
+from m4.services.results import CommandError, CommandResult
+from m4.services.use import set_active_dataset_service
+
+
+@patch("m4.services.use.get_active_backend", return_value="duckdb")
+@patch("m4.services.use.set_active_dataset")
+@patch("m4.services.use.detect_available_local_datasets")
+def test_use_service_success_includes_dataset_and_warning_codes(
+    mock_detect, mock_set_active, mock_backend
+):
+    mock_detect.return_value = {
+        "mimic-iv": {
+            "parquet_present": True,
+            "db_present": False,
+            "parquet_root": "/tmp/full",
+            "db_path": "/tmp/full.duckdb",
+        }
+    }
+
+    result = set_active_dataset_service("MIMIC-IV")
+
+    assert isinstance(result, CommandResult)
+    payload = result.to_json_dict()
+    assert payload["active_dataset"] == "mimic-iv"
+    assert payload["backend"] == "duckdb"
+    assert payload["dataset"]["db_present"] is False
+    assert payload["warnings"] == ["local_db_missing"]
+    mock_set_active.assert_called_once_with("mimic-iv")
+
+
+@patch("m4.services.use.set_active_dataset")
+@patch("m4.services.use.detect_available_local_datasets", return_value={})
+def test_use_service_dataset_not_found_does_not_mutate(mock_detect, mock_set_active):
+    result = set_active_dataset_service("missing")
+
+    assert isinstance(result, CommandError)
+    assert result.code == "dataset_not_found"
+    mock_set_active.assert_not_called()
+
+
+@patch("m4.services.use.get_active_backend", return_value="bigquery")
+@patch("m4.services.use.set_active_dataset")
+@patch("m4.services.use.detect_available_local_datasets")
+def test_use_service_blocks_bigquery_incompatible_dataset(
+    mock_detect, mock_set_active, mock_backend
+):
+    mock_detect.return_value = {
+        "mimic-iv-demo": {
+            "parquet_present": True,
+            "db_present": True,
+            "parquet_root": "/tmp/demo",
+            "db_path": "/tmp/demo.duckdb",
+        }
+    }
+
+    result = set_active_dataset_service("mimic-iv-demo")
+
+    assert isinstance(result, CommandError)
+    assert result.code == "backend_incompatible"
+    mock_set_active.assert_not_called()
+
+
+@patch("m4.services.backend.get_bigquery_project_id", return_value=None)
+@patch("m4.services.backend.get_active_dataset", return_value="mimic-iv")
+@patch("m4.services.backend.set_active_backend")
+def test_backend_service_duckdb_success(
+    mock_set_backend, mock_get_dataset, mock_get_project
+):
+    result = set_active_backend_service("duckdb")
+
+    assert isinstance(result, CommandResult)
+    assert result.to_json_dict() == {
+        "version": 1,
+        "ok": True,
+        "command": "backend",
+        "backend": "duckdb",
+        "active_dataset": "mimic-iv",
+        "bigquery_project_id": None,
+        "warnings": [],
+    }
+    mock_set_backend.assert_called_once_with("duckdb")
+
+
+@patch("m4.services.backend.set_bigquery_project_id")
+@patch("m4.services.backend.get_active_dataset", side_effect=DatasetError("unset"))
+@patch("m4.services.backend.set_active_backend")
+def test_backend_service_bigquery_persists_project_id(
+    mock_set_backend, mock_get_dataset, mock_set_project
+):
+    result = set_active_backend_service("BIGQUERY", project_id="my-project")
+
+    assert isinstance(result, CommandResult)
+    assert result.data["backend"] == "bigquery"
+    assert result.data["bigquery_project_id"] == "my-project"
+    mock_set_backend.assert_called_once_with("bigquery")
+    mock_set_project.assert_called_once_with("my-project")
+
+
+@patch("m4.services.backend.set_active_backend")
+def test_backend_service_invalid_backend_does_not_mutate(mock_set_backend):
+    result = set_active_backend_service("mysql")
+
+    assert isinstance(result, CommandError)
+    assert result.code == "invalid_backend"
+    mock_set_backend.assert_not_called()
+
+
+@patch("m4.services.backend.set_bigquery_project_id")
+@patch("m4.services.backend.set_active_backend")
+def test_backend_service_duckdb_rejects_project_id(mock_set_backend, mock_set_project):
+    result = set_active_backend_service("duckdb", project_id="x")
+
+    assert isinstance(result, CommandError)
+    assert result.code == "invalid_option"
+    mock_set_backend.assert_not_called()
+    mock_set_project.assert_not_called()
+
+
+@patch("m4.services.backend.set_active_backend")
+@patch("m4.services.backend.get_active_dataset", return_value="mimic-iv-demo")
+def test_backend_service_bigquery_blocks_incompatible_active_dataset(
+    mock_get_dataset, mock_set_backend
+):
+    result = set_active_backend_service("bigquery", project_id="my-project")
+
+    assert isinstance(result, CommandError)
+    assert result.code == "dataset_incompatible"
+    mock_set_backend.assert_not_called()
+
+
+@patch("m4.services.backend.get_bigquery_project_id", return_value=None)
+@patch("m4.services.backend.set_active_backend")
+@patch("m4.services.backend.get_active_dataset", side_effect=DatasetError("unset"))
+def test_backend_service_bigquery_requires_project_id(
+    mock_get_dataset, mock_set_backend, mock_get_project
+):
+    result = set_active_backend_service("bigquery")
+
+    assert isinstance(result, CommandError)
+    assert result.code == "project_id_required"
+    mock_set_backend.assert_not_called()


### PR DESCRIPTION
## Summary

- add JSON output mode for CLI state commands used by automation
- move CLI command logic for init, use, backend, and status into service-layer helpers
- add subprocess coverage to ensure JSON stdout is parseable and free of Rich/human output
- document CLI automation behavior in development docs

## Testing

- `uv run pytest tests/test_cli.py tests/test_cli_subprocess.py tests/test_services_use_backend.py tests/test_services_init.py tests/test_services_results.py tests/test_config.py tests/test_dynamic_switching.py tests/test_data_io.py` -> 117 passed
- `uv run pytest` -> 884 passed, 1 skipped, 1 deselected
- direct subprocess matrix for human and JSON modes across `status`, `use`, `backend`, `init`, `init-derived`, and `skills --list`
- real local synthetic `mimic-iv-demo` Parquet init through `uv run m4`, verified DuckDB view and `status --json` row count

## Behavioral notes

JSON mode is currently implemented for `init`, `use`, `backend`, and `status`. Human-only commands keep their existing Rich output.
