### PR TITLE
Add Lincei agent integration surface

### DIFF
--- a/.github/workflows/deploy-webapp.yaml
+++ b/.github/workflows/deploy-webapp.yaml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install UV and Python
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
           python-version: "3.11"

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -8,12 +8,12 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install UV and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           version: "latest"
           python-version: "3.11"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,10 +16,10 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8
       with:
         version: "latest"
         python-version: "3.11"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         version: "latest"
         python-version: "3.11"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,10 +12,10 @@ jobs:
         python-version: ["3.10", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install UV and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install UV and Python
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -218,6 +218,22 @@ m4 status --all     # List all available datasets
 m4 status --derived # Show per-table derived materialization status
 ```
 
+For automation and external agents, M4 also provides non-interactive JSON
+commands that do not mutate active configuration unless explicitly documented:
+
+```bash
+m4 agent-env --dataset mimic-iv --backend duckdb --json
+m4 list-datasets --json --no-interactive
+m4 schema --dataset mimic-iv --backend duckdb --json --no-interactive
+m4 describe-table mimiciv_hosp.patients --dataset mimic-iv --json --no-interactive
+m4 query --dataset mimic-iv --sql "SELECT COUNT(*) AS n FROM mimiciv_hosp.patients" --json --no-interactive
+m4 provenance export --json
+```
+
+Machine-facing status and backend metadata hide local filesystem paths by
+default. Use `--paths` or `M4_PATH_DISCLOSURE=1` only when the caller is allowed
+to see raw local paths.
+
 **Derived concept tables** (MIMIC-IV only):
 ```bash
 m4 init-derived mimic-iv         # Materialize ~63 derived tables (SOFA, sepsis3, KDIGO, etc.)

--- a/docs/BIGQUERY.md
+++ b/docs/BIGQUERY.md
@@ -73,10 +73,12 @@ The `mimiciv_derived` schema is accessible alongside the standard `mimiciv_hosp`
 
 ## Environment Variables
 
-You can also override the backend via environment variables (these take priority over `m4 backend`):
+You can also override the backend and dataset via environment variables. These
+take priority over saved CLI configuration for the current process:
 
 ```bash
 export M4_BACKEND=bigquery
+export M4_DATASET=mimic-iv
 export M4_PROJECT_ID=your-project-id
 ```
 

--- a/docs/CODE_EXECUTION.md
+++ b/docs/CODE_EXECUTION.md
@@ -69,7 +69,7 @@ from m4 import execute_query, get_schema, get_table_info
 
 # Schema exploration
 schema = get_schema()
-print(schema['backend_info'])  # 'DuckDB (local): /path/to/db'
+print(schema['backend_info'])  # Backend and active dataset summary
 print(schema['tables'])        # ['mimiciv_hosp.admissions', 'mimiciv_hosp.diagnoses_icd', ...]
 
 # Table details
@@ -90,6 +90,8 @@ print(df)
 ```
 
 > **Table naming convention:** Tables use canonical `schema.table` names (e.g., `mimiciv_hosp.patients`, `mimiciv_icu.icustays`) that work on both DuckDB and BigQuery backends. Use `get_schema()` to see all available tables.
+
+> **Path disclosure:** DuckDB backend metadata hides raw local database paths by default. Set `M4_PATH_DISCLOSURE=1` only when code is allowed to receive local filesystem paths.
 
 ### Clinical Notes
 

--- a/docs/CUSTOM_DATASETS.md
+++ b/docs/CUSTOM_DATASETS.md
@@ -4,7 +4,9 @@ M4 supports any PhysioNet dataset. This guide shows how to add your own.
 
 ## Quick Start: JSON Definition
 
-Create a JSON file in `m4_data/datasets/`:
+Create a JSON file in the M4 data directory under `datasets/`. By default this
+is `m4_data/datasets/`; if `M4_DATA_DIR` is set, it must point directly at the
+M4 data directory.
 
 **Example: `m4_data/datasets/mimic-iv-ed.json`**
 ```json
@@ -106,7 +108,7 @@ When you run `m4 init <dataset>`:
 
 ## Directory Structure
 
-M4 organizes data like this:
+M4 organizes data like this by default:
 
 ```
 m4_data/
@@ -121,6 +123,9 @@ m4_data/
 └── databases/          # DuckDB databases
     └── my_dataset.duckdb
 ```
+
+When `M4_DATA_DIR` is set, the same structure lives under that exact directory
+instead of `./m4_data`.
 
 ## Using Existing CSV Files
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -69,8 +69,6 @@ non-zero.
       "active": true,
       "parquet_present": true,
       "db_present": true,
-      "parquet_root": "/absolute/path/to/parquet",
-      "db_path": "/absolute/path/to/mimic_iv.duckdb",
       "bigquery_available": true,
       "row_count": 431231,
       "parquet_size_gb": 8.5,
@@ -85,6 +83,10 @@ non-zero.
   ]
 }
 ```
+
+Raw local paths are hidden by default in machine-facing output. Pass
+`--paths` or set `M4_PATH_DISCLOSURE=1` to include path fields such as
+`parquet_root` and `db_path`.
 
 Dataset `warnings` is a list of stable warning codes. Currently documented
 status warnings:
@@ -152,6 +154,45 @@ Init step status is one of `skipped`, `completed`, `blocked`, or `failed`.
 Credentialed/manual-download cases that the human CLI treats as informational
 return `ok: true` with blocked or skipped steps.
 
+Agent-oriented commands use a stable envelope with `version`, `ok`, `command`,
+`context`, `data`, `warnings`, and optional provenance fields:
+
+```bash
+m4 agent-env --dataset mimic-iv --backend duckdb --json
+m4 list-datasets --json --no-interactive
+m4 schema --dataset mimic-iv --backend duckdb --json --no-interactive
+m4 describe-table mimiciv_hosp.patients --dataset mimic-iv --json --no-interactive
+m4 query --dataset mimic-iv --backend duckdb --sql "SELECT 1 AS one" --json --no-interactive
+m4 provenance export --json
+```
+
+These commands accept `--dataset` and `--backend` to resolve context without
+changing saved active configuration. `agent-env --mode protected` omits
+`M4_DATA_DIR` so a caller can expose only a service, socket, MCP server, or
+gateway to agents.
+
+### Runtime Environment
+
+Durable environment controls:
+
+| Variable | Purpose |
+|----------|---------|
+| `M4_DATA_DIR` | Exact M4 data directory containing `databases/`, `parquet/`, `datasets/`, and `raw_files/`. |
+| `M4_HOME` | Runtime home for config and default telemetry when separate from the data directory. |
+| `M4_DATASET` | Active dataset override. |
+| `M4_BACKEND` | Active backend override, such as `duckdb` or `bigquery`. |
+| `M4_PROJECT_ID` | BigQuery billing/project override. |
+| `M4_TELEMETRY_DIR` | Directory for telemetry JSONL when `M4_EVENT_LOG` is not set. |
+| `M4_EVENT_LOG` | Exact telemetry/provenance JSONL file path. |
+| `M4_TELEMETRY` | Set to `off` to disable telemetry file output. |
+| `M4_LOG_SQL` | SQL logging mode: `full`, `hash`, or `off`. |
+| `M4_STUDY_ID`, `M4_SESSION_ID`, `M4_ACTOR` | Attribution fields added to telemetry/provenance records. |
+| `M4_PATH_DISCLOSURE` | Set to `1`, `true`, `yes`, `on`, or `paths` to disclose raw local paths. |
+
+`M4_DATA_DIR` now points directly at the data directory. Legacy values that
+point at a parent directory containing `m4_data/` are accepted only as a
+compatibility path and emit a deprecation warning.
+
 ### MCP Client Configuration
 
 ```bash
@@ -200,7 +241,10 @@ Point your MCP client to your local development environment:
 }
 ```
 
-The active backend is configured via `m4 backend duckdb` (or `bigquery`), not through the MCP env block.
+For normal local development, configure the active backend with
+`m4 backend duckdb` or `m4 backend bigquery`. For isolated agents or MCP
+servers, `M4_BACKEND` and `M4_DATASET` may be supplied in the environment to
+override saved configuration for that process.
 
 ## Architecture Overview
 

--- a/docs/OAUTH2_AUTHENTICATION.md
+++ b/docs/OAUTH2_AUTHENTICATION.md
@@ -32,7 +32,9 @@ For manual MCP client configuration with OAuth2 enabled:
 }
 ```
 
-> **Note:** The active backend is configured via `m4 backend duckdb` (or `bigquery`), not through MCP env vars.
+> **Note:** For normal use, configure the active backend with `m4 backend duckdb`
+> or `m4 backend bigquery`. Use `M4_BACKEND` and `M4_DATASET` in MCP env blocks
+> only when that server process should override saved configuration.
 
 ## Environment Variables
 

--- a/src/m4/__init__.py
+++ b/src/m4/__init__.py
@@ -13,7 +13,7 @@ Quick Start:
 For MCP server usage, run: m4 serve
 """
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 
 # Expose API functions at package level for easy imports
 from vitrine import show

--- a/src/m4/api.py
+++ b/src/m4/api.py
@@ -26,6 +26,7 @@ that work on both DuckDB and BigQuery backends. Use set_dataset()
 to switch between datasets.
 """
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -374,5 +375,9 @@ def get_telemetry_path() -> Path:
     """
     from m4.config import get_telemetry_dir
     from m4.core.telemetry import TELEMETRY_FILENAME
+
+    event_log = os.environ.get("M4_EVENT_LOG")
+    if event_log:
+        return Path(event_log).expanduser()
 
     return get_telemetry_dir() / TELEMETRY_FILENAME

--- a/src/m4/cli.py
+++ b/src/m4/cli.py
@@ -1,10 +1,12 @@
 import json
 import logging
+import math
 import os
 import subprocess
 import sys
 from contextlib import contextmanager, nullcontext
 from dataclasses import is_dataclass
+from datetime import date, datetime, time
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -101,7 +103,7 @@ def _silence_m4_logging():
 
 
 def _emit_json(payload: dict[str, Any]) -> None:
-    typer.echo(json.dumps(payload, indent=2))
+    typer.echo(json.dumps(_jsonable(payload), indent=2, allow_nan=False))
 
 
 def _emit_command_json(result: CommandResult | CommandError) -> None:
@@ -217,21 +219,55 @@ def _dataframe_payload(df: pd.DataFrame | None) -> dict[str, Any] | None:
         return None
     return {
         "columns": [str(column) for column in df.columns],
-        "rows": df.to_dict(orient="records"),
+        "rows": _jsonable(df.to_dict(orient="records")),
         "row_count": len(df),
     }
 
 
 def _jsonable(value: Any) -> Any:
+    if value is None:
+        return None
     if isinstance(value, pd.DataFrame):
         return _dataframe_payload(value)
     if isinstance(value, dict):
         return {str(key): _jsonable(item) for key, item in value.items()}
-    if isinstance(value, list | tuple):
+    if isinstance(value, list | tuple | set):
         return [_jsonable(item) for item in value]
     if is_dataclass(value):
         return _jsonable(value.__dict__)
+    if _is_missing_value(value):
+        return None
+    if isinstance(value, datetime | date | time | pd.Timestamp):
+        return value.isoformat()
+    if hasattr(value, "tolist"):
+        try:
+            return _jsonable(value.tolist())
+        except (TypeError, ValueError):
+            pass
+    if hasattr(value, "item"):
+        try:
+            return _jsonable(value.item())
+        except (AttributeError, TypeError, ValueError):
+            pass
+    if isinstance(value, float) and not math.isfinite(value):
+        return str(value)
+    try:
+        json.dumps(value, allow_nan=False)
+    except (TypeError, ValueError):
+        return str(value)
     return value
+
+
+def _is_missing_value(value: Any) -> bool:
+    try:
+        missing = pd.isna(value)
+    except (TypeError, ValueError):
+        return False
+    if isinstance(missing, bool):
+        return missing
+    if getattr(missing, "shape", None) == ():
+        return bool(missing)
+    return False
 
 
 @contextmanager

--- a/src/m4/cli.py
+++ b/src/m4/cli.py
@@ -1,11 +1,14 @@
 import json
 import logging
+import os
 import subprocess
 import sys
 from contextlib import contextmanager, nullcontext
+from dataclasses import is_dataclass
 from pathlib import Path
 from typing import Annotated, Any
 
+import pandas as pd
 import typer
 
 from m4.config import (
@@ -14,7 +17,9 @@ from m4.config import (
     get_bigquery_project_id,
     get_dataset_parquet_root,
     get_default_database_path,
+    get_telemetry_dir,
     logger,
+    resolve_runtime_context,
     set_active_backend,
     set_active_dataset,
     set_bigquery_project_id,
@@ -47,7 +52,14 @@ from m4.core.derived.materializer import (
     list_materialized_tables,
     materialize_all,
 )
-from m4.core.exceptions import DatasetError
+from m4.core.exceptions import DatasetError, M4Error
+from m4.core.telemetry import invoke_tracked, set_interface
+from m4.core.tools import ToolRegistry, init_tools
+from m4.core.tools.tabular import (
+    ExecuteQueryInput,
+    GetDatabaseSchemaInput,
+    GetTableInfoInput,
+)
 from m4.data_io import (
     convert_csv_to_parquet,
     download_dataset,
@@ -66,6 +78,9 @@ app = typer.Typer(
     add_completion=False,
     rich_markup_mode="markdown",
 )
+
+provenance_app = typer.Typer(help="Inspect and export M4 provenance events.")
+app.add_typer(provenance_app, name="provenance")
 
 
 def version_callback(value: bool):
@@ -98,6 +113,174 @@ def _json_error(command: str, code: str, message: str, hint: str | None = None) 
         CommandError(command=command, code=code, message=message, hint=hint)
     )
     raise typer.Exit(code=1)
+
+
+def _agent_error_payload(
+    command: str,
+    code: str,
+    message: str,
+    *,
+    hint: str | None = None,
+    context: dict[str, Any] | None = None,
+    warnings: list[str] | None = None,
+) -> dict[str, Any]:
+    error_payload: dict[str, Any] = {"code": code, "message": message}
+    if hint:
+        error_payload["hint"] = hint
+    return {
+        "version": 1,
+        "ok": False,
+        "command": command,
+        "context": context or {},
+        "error": error_payload,
+        "warnings": warnings or [],
+    }
+
+
+def _agent_success_payload(
+    command: str,
+    data: dict[str, Any],
+    *,
+    context: dict[str, Any],
+    warnings: list[str] | None = None,
+    provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "version": 1,
+        "ok": True,
+        "command": command,
+        "context": context,
+        "data": data,
+        "warnings": warnings or [],
+        "provenance": provenance or {},
+    }
+
+
+def _emit_agent_error(
+    command: str,
+    code: str,
+    message: str,
+    *,
+    hint: str | None = None,
+    context: dict[str, Any] | None = None,
+    warnings: list[str] | None = None,
+) -> None:
+    message = _redact_known_paths(message)
+    hint = _redact_known_paths(hint) if hint else None
+    _emit_json(
+        _agent_error_payload(
+            command,
+            code,
+            message,
+            hint=hint,
+            context=context,
+            warnings=warnings,
+        )
+    )
+    raise typer.Exit(code=1)
+
+
+def _path_disclosure_enabled() -> bool:
+    return os.getenv("M4_PATH_DISCLOSURE", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+        "paths",
+    }
+
+
+def _redact_known_paths(message: str) -> str:
+    if _path_disclosure_enabled():
+        return message
+
+    replacements: dict[str, str] = {}
+    for env_name, label in (
+        ("M4_DATA_DIR", "<M4_DATA_DIR>"),
+        ("M4_HOME", "<M4_HOME>"),
+        ("M4_TELEMETRY_DIR", "<M4_TELEMETRY_DIR>"),
+    ):
+        value = os.getenv(env_name)
+        if value:
+            path = str(Path(value).expanduser().resolve())
+            replacements[path] = label
+
+    for raw_path, label in sorted(
+        replacements.items(), key=lambda item: len(item[0]), reverse=True
+    ):
+        message = message.replace(raw_path, label)
+    return message
+
+
+def _dataframe_payload(df: pd.DataFrame | None) -> dict[str, Any] | None:
+    if df is None:
+        return None
+    return {
+        "columns": [str(column) for column in df.columns],
+        "rows": df.to_dict(orient="records"),
+        "row_count": len(df),
+    }
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, pd.DataFrame):
+        return _dataframe_payload(value)
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_jsonable(item) for item in value]
+    if is_dataclass(value):
+        return _jsonable(value.__dict__)
+    return value
+
+
+@contextmanager
+def _runtime_env_override(*, dataset: str | None = None, backend: str | None = None):
+    previous: dict[str, str | None] = {
+        "M4_DATASET": os.environ.get("M4_DATASET"),
+        "M4_BACKEND": os.environ.get("M4_BACKEND"),
+    }
+    try:
+        if dataset:
+            os.environ["M4_DATASET"] = dataset
+        if backend:
+            os.environ["M4_BACKEND"] = backend
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _resolve_agent_dataset(
+    command: str, dataset_name: str | None, context: dict[str, Any]
+):
+    from m4.core.datasets import DatasetRegistry
+
+    try:
+        effective = dataset_name or get_active_dataset()
+    except DatasetError:
+        _emit_agent_error(
+            command,
+            "dataset_required",
+            "No dataset was provided and no active dataset is configured.",
+            hint=f"Use: m4 {command} --dataset <dataset> --json",
+            context=context,
+        )
+
+    dataset = DatasetRegistry.get(effective)
+    if dataset is None:
+        supported = ", ".join(ds.name for ds in DatasetRegistry.list_all())
+        _emit_agent_error(
+            command,
+            "dataset_not_found",
+            f"Dataset '{effective}' is not supported or not configured.",
+            hint=f"Supported datasets: {supported}",
+            context=context,
+        )
+    return dataset
 
 
 @app.callback()
@@ -719,6 +902,34 @@ def status_cmd(
             help="Print status as JSON for scripts and automation.",
         ),
     ] = False,
+    dataset_name: Annotated[
+        str | None,
+        typer.Option(
+            "--dataset",
+            help="Dataset to inspect without changing active config.",
+        ),
+    ] = None,
+    backend_name: Annotated[
+        str | None,
+        typer.Option(
+            "--backend",
+            help="Backend to inspect without changing active config.",
+        ),
+    ] = None,
+    no_interactive: Annotated[
+        bool,
+        typer.Option(
+            "--no-interactive",
+            help="Accepted for automation; status never prompts.",
+        ),
+    ] = False,
+    include_paths: Annotated[
+        bool,
+        typer.Option(
+            "--paths",
+            help="Include raw local filesystem paths in output.",
+        ),
+    ] = False,
 ):
     """Show active dataset status. Use --all for all supported datasets."""
     if show_derived and json_output:
@@ -730,8 +941,13 @@ def status_cmd(
         )
 
     if json_output:
-        with _silence_m4_logging():
-            snapshot = collect_status_snapshot(show_all=show_all)
+        with (
+            _silence_m4_logging(),
+            _runtime_env_override(dataset=dataset_name, backend=backend_name),
+        ):
+            snapshot = collect_status_snapshot(
+                show_all=show_all, include_paths=include_paths
+            )
         _emit_json(snapshot)
         return
 
@@ -777,7 +993,10 @@ def status_cmd(
     print_logo(show_tagline=False, show_version=True)
     console.print()
 
-    snapshot = collect_status_snapshot(show_all=show_all)
+    with _runtime_env_override(dataset=dataset_name, backend=backend_name):
+        snapshot = collect_status_snapshot(
+            show_all=show_all, include_paths=include_paths
+        )
     active = snapshot["active_dataset"]
     datasets = snapshot["datasets"]
 
@@ -844,8 +1063,8 @@ def status_cmd(
         name=active,
         parquet_present=dataset["parquet_present"],
         db_present=dataset["db_present"],
-        parquet_root=dataset["parquet_root"] or "",
-        db_path=dataset["db_path"] or "",
+        parquet_root=dataset.get("parquet_root") or "",
+        db_path=dataset.get("db_path") or "",
         parquet_size_gb=dataset["parquet_size_gb"],
         bigquery_available=dataset["bigquery_available"],
         row_count=dataset["row_count"],
@@ -855,6 +1074,428 @@ def status_cmd(
         derived_has_support=dataset["derived"]["supported"],
         derived_is_bigquery=dataset["derived"]["bigquery"],
     )
+
+
+@app.command("list-datasets")
+def list_datasets_cmd(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print result as JSON for automation."),
+    ] = False,
+    dataset_name: Annotated[
+        str | None,
+        typer.Option("--dataset", help="Dataset to mark as active in this result."),
+    ] = None,
+    backend_name: Annotated[
+        str | None,
+        typer.Option("--backend", help="Backend to use for compatibility checks."),
+    ] = None,
+    no_interactive: Annotated[
+        bool,
+        typer.Option("--no-interactive", help="Accepted for automation."),
+    ] = False,
+    include_paths: Annotated[
+        bool,
+        typer.Option("--paths", help="Include raw local filesystem paths."),
+    ] = False,
+):
+    """List available datasets without mutating active config."""
+    with _silence_m4_logging() if json_output else nullcontext():
+        with _runtime_env_override(dataset=dataset_name, backend=backend_name):
+            ctx = resolve_runtime_context(
+                dataset=dataset_name,
+                backend=backend_name,
+                path_disclosure=include_paths,
+            )
+            snapshot = collect_status_snapshot(
+                show_all=True, include_paths=include_paths
+            )
+
+    if json_output:
+        _emit_json(
+            _agent_success_payload(
+                "list-datasets",
+                {
+                    "active_dataset": snapshot["active_dataset"],
+                    "backend": snapshot["backend"],
+                    "datasets": snapshot["datasets"],
+                    "raw_paths_hidden": not include_paths,
+                },
+                context=ctx.public_context(),
+            )
+        )
+        return
+
+    datasets_info = [
+        {
+            "name": dataset["name"],
+            "parquet_present": dataset["parquet_present"],
+            "db_present": dataset["db_present"],
+            "bigquery_available": dataset["bigquery_available"],
+            "parquet_size_gb": dataset["parquet_size_gb"],
+            "derived_materialized": dataset["derived"]["materialized"],
+            "derived_total": dataset["derived"]["total"],
+        }
+        for dataset in snapshot["datasets"]
+    ]
+    print_datasets_table(datasets_info, active_dataset=snapshot["active_dataset"])
+
+
+@app.command("schema")
+def schema_cmd(
+    dataset_name: Annotated[
+        str | None,
+        typer.Option("--dataset", help="Dataset to inspect."),
+    ] = None,
+    backend_name: Annotated[
+        str | None,
+        typer.Option("--backend", help="Backend to use."),
+    ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print result as JSON for automation."),
+    ] = False,
+    no_interactive: Annotated[
+        bool,
+        typer.Option("--no-interactive", help="Accepted for automation."),
+    ] = False,
+):
+    """List tables for a dataset/backend pair without mutating active config."""
+    command = "schema"
+    init_tools()
+    set_interface("cli")
+    with _silence_m4_logging() if json_output else nullcontext():
+        with _runtime_env_override(dataset=dataset_name, backend=backend_name):
+            ctx = resolve_runtime_context(dataset=dataset_name, backend=backend_name)
+            dataset = _resolve_agent_dataset(
+                command, dataset_name, ctx.public_context()
+            )
+            try:
+                tool = ToolRegistry.get("get_database_schema")
+                result = invoke_tracked(tool, dataset, GetDatabaseSchemaInput())
+            except M4Error as exc:
+                if json_output:
+                    _emit_agent_error(
+                        command,
+                        "schema_failed",
+                        str(exc),
+                        context=ctx.public_context(),
+                    )
+                error(str(exc))
+                raise typer.Exit(code=1)
+
+    if json_output:
+        _emit_json(
+            _agent_success_payload(
+                command,
+                {"tables": result.get("tables", [])},
+                context=ctx.public_context(),
+            )
+        )
+        return
+
+    for table in result.get("tables", []):
+        typer.echo(table)
+
+
+@app.command("describe-table")
+def describe_table_cmd(
+    table_name: Annotated[
+        str,
+        typer.Argument(
+            help="Table name to inspect, for example mimiciv_hosp.admissions."
+        ),
+    ],
+    dataset_name: Annotated[
+        str | None,
+        typer.Option("--dataset", help="Dataset to inspect."),
+    ] = None,
+    backend_name: Annotated[
+        str | None,
+        typer.Option("--backend", help="Backend to use."),
+    ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print result as JSON for automation."),
+    ] = False,
+    no_interactive: Annotated[
+        bool,
+        typer.Option("--no-interactive", help="Accepted for automation."),
+    ] = False,
+    show_sample: Annotated[
+        bool,
+        typer.Option("--sample/--no-sample", help="Include up to three sample rows."),
+    ] = True,
+):
+    """Describe a single table without mutating active config."""
+    command = "describe-table"
+    init_tools()
+    set_interface("cli")
+    with _silence_m4_logging() if json_output else nullcontext():
+        with _runtime_env_override(dataset=dataset_name, backend=backend_name):
+            ctx = resolve_runtime_context(dataset=dataset_name, backend=backend_name)
+            dataset = _resolve_agent_dataset(
+                command, dataset_name, ctx.public_context()
+            )
+            try:
+                tool = ToolRegistry.get("get_table_info")
+                result = invoke_tracked(
+                    tool,
+                    dataset,
+                    GetTableInfoInput(
+                        table_name=table_name,
+                        show_sample=show_sample,
+                    ),
+                )
+            except M4Error as exc:
+                if json_output:
+                    _emit_agent_error(
+                        command,
+                        "describe_table_failed",
+                        str(exc),
+                        context=ctx.public_context(),
+                    )
+                error(str(exc))
+                raise typer.Exit(code=1)
+
+    if json_output:
+        _emit_json(
+            _agent_success_payload(
+                command,
+                {
+                    "table_name": table_name,
+                    "schema": _dataframe_payload(result.get("schema")),
+                    "sample": _dataframe_payload(result.get("sample")),
+                },
+                context=ctx.public_context(),
+            )
+        )
+        return
+
+    schema = result.get("schema")
+    if isinstance(schema, pd.DataFrame):
+        typer.echo(schema.to_string(index=False))
+    sample = result.get("sample")
+    if isinstance(sample, pd.DataFrame) and not sample.empty:
+        typer.echo("\nSample:")
+        typer.echo(sample.to_string(index=False))
+
+
+@app.command("query")
+def query_cmd(
+    sql: Annotated[
+        str,
+        typer.Option("--sql", help="SQL SELECT query to execute."),
+    ],
+    dataset_name: Annotated[
+        str | None,
+        typer.Option("--dataset", help="Dataset to query."),
+    ] = None,
+    backend_name: Annotated[
+        str | None,
+        typer.Option("--backend", help="Backend to use."),
+    ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print result as JSON for automation."),
+    ] = False,
+    no_interactive: Annotated[
+        bool,
+        typer.Option("--no-interactive", help="Accepted for automation."),
+    ] = False,
+):
+    """Execute a read-only SQL query without mutating active config."""
+    command = "query"
+    init_tools()
+    set_interface("cli")
+    with _silence_m4_logging() if json_output else nullcontext():
+        with _runtime_env_override(dataset=dataset_name, backend=backend_name):
+            ctx = resolve_runtime_context(dataset=dataset_name, backend=backend_name)
+            dataset = _resolve_agent_dataset(
+                command, dataset_name, ctx.public_context()
+            )
+            try:
+                tool = ToolRegistry.get("execute_query")
+                result = invoke_tracked(tool, dataset, ExecuteQueryInput(sql_query=sql))
+            except M4Error as exc:
+                if json_output:
+                    _emit_agent_error(
+                        command,
+                        "query_failed",
+                        str(exc),
+                        context=ctx.public_context(),
+                    )
+                error(str(exc))
+                raise typer.Exit(code=1)
+
+    if json_output:
+        _emit_json(
+            _agent_success_payload(
+                command,
+                {
+                    "result": _dataframe_payload(result),
+                },
+                context=ctx.public_context(),
+            )
+        )
+        return
+
+    typer.echo(
+        result.to_string(index=False) if not result.empty else "No results found"
+    )
+
+
+@app.command("agent-env")
+def agent_env_cmd(
+    mode: Annotated[
+        str,
+        typer.Option("--mode", help="Agent mode: local or protected."),
+    ] = "local",
+    dataset_name: Annotated[
+        str | None,
+        typer.Option("--dataset", help="Default dataset for agent sessions."),
+    ] = None,
+    backend_name: Annotated[
+        str | None,
+        typer.Option("--backend", help="Default backend for agent sessions."),
+    ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print result as JSON."),
+    ] = False,
+    include_paths: Annotated[
+        bool,
+        typer.Option("--paths", help="Disclose raw local paths in metadata."),
+    ] = False,
+):
+    """Return environment variables and command recommendations for agents."""
+    if mode not in {"local", "protected"}:
+        if json_output:
+            _emit_agent_error(
+                "agent-env",
+                "invalid_mode",
+                f"Unsupported mode '{mode}'.",
+                hint="Use --mode local or --mode protected.",
+            )
+        error("Unsupported mode. Use 'local' or 'protected'.")
+        raise typer.Exit(code=1)
+
+    ctx = resolve_runtime_context(
+        dataset=dataset_name, backend=backend_name, path_disclosure=include_paths
+    )
+    env = {
+        "M4_HOME": str(ctx.home),
+        "M4_DATASET": ctx.dataset,
+        "M4_BACKEND": ctx.backend,
+        "M4_STUDY_ID": ctx.study_id,
+        "M4_SESSION_ID": ctx.session_id,
+        "M4_ACTOR": ctx.actor,
+        "M4_TELEMETRY_DIR": str(ctx.telemetry_dir),
+    }
+    if mode == "local":
+        env["M4_DATA_DIR"] = str(ctx.data_dir)
+    else:
+        env["M4_TELEMETRY_DIR"] = str(ctx.telemetry_dir)
+
+    warnings_list: list[str] = []
+    if ctx.dataset and not DatasetRegistry.get(ctx.dataset):
+        warnings_list.append(f"Dataset '{ctx.dataset}' is not registered.")
+    if ctx.backend == "bigquery" and ctx.dataset:
+        ds = DatasetRegistry.get(ctx.dataset)
+        if ds and not ds.bigquery_dataset_ids:
+            warnings_list.append(
+                f"Dataset '{ctx.dataset}' is not available on the BigQuery backend."
+            )
+    if mode == "protected":
+        warnings_list.append(
+            "Protected mode omits M4_DATA_DIR; expose only an M4 service, socket, MCP server, or gateway to agents."
+        )
+
+    data = {
+        "mode": mode,
+        "environment": {key: value for key, value in env.items() if value is not None},
+        "path_recommendations": {
+            "python": sys.executable,
+            "cli": "m4",
+        },
+        "defaults": {
+            "dataset": ctx.dataset,
+            "backend": ctx.backend,
+        },
+        "telemetry_destination": str(ctx.telemetry_dir),
+        "raw_paths_hidden": not include_paths,
+        "recommended_commands": [
+            "m4 status --json --no-interactive",
+            "m4 list-datasets --json --no-interactive",
+            "m4 schema --dataset <dataset> --backend <backend> --json --no-interactive",
+            "m4 describe-table <table> --dataset <dataset> --backend <backend> --json --no-interactive",
+            "m4 query --dataset <dataset> --backend <backend> --sql <sql> --json --no-interactive",
+        ],
+    }
+
+    if json_output:
+        _emit_json(
+            _agent_success_payload(
+                "agent-env",
+                data,
+                context=ctx.public_context(),
+                warnings=warnings_list,
+            )
+        )
+        return
+
+    for key, value in data["environment"].items():
+        typer.echo(f"{key}={value}")
+
+
+@provenance_app.command("export")
+def provenance_export_cmd(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print provenance as JSON."),
+    ] = False,
+):
+    """Export telemetry/provenance events from the configured event log."""
+    event_log = os.getenv("M4_EVENT_LOG")
+    path = (
+        Path(event_log).expanduser()
+        if event_log
+        else get_telemetry_dir() / "tool_calls.jsonl"
+    )
+    events: list[dict[str, Any]] = []
+    warnings_list: list[str] = []
+
+    if path.exists():
+        for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                warnings_list.append(f"Skipped malformed JSONL line {line_number}.")
+    else:
+        warnings_list.append(f"Provenance log does not exist: {path}")
+
+    ctx = resolve_runtime_context()
+    data = {
+        "event_log": str(path),
+        "event_count": len(events),
+        "events": _jsonable(events),
+    }
+
+    if json_output:
+        _emit_json(
+            _agent_success_payload(
+                "provenance export",
+                data,
+                context=ctx.public_context(),
+                warnings=warnings_list,
+            )
+        )
+        return
+
+    for event in events:
+        typer.echo(json.dumps(event, default=str))
 
 
 def _prompt_select_tools() -> list[str]:

--- a/src/m4/config.py
+++ b/src/m4/config.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+import warnings
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -19,8 +21,35 @@ logger = logging.getLogger(APP_NAME)
 
 
 # -------------------------------------------------------------------
-# Data directory rooted at project root (two levels up from this file)
+# Runtime context and data directory resolution
 # -------------------------------------------------------------------
+@dataclass(frozen=True)
+class M4Context:
+    """Resolved runtime context for agent and human interfaces."""
+
+    home: Path
+    data_dir: Path
+    dataset: str | None
+    backend: str
+    study_id: str | None
+    session_id: str | None
+    actor: str | None
+    project_id: str | None
+    telemetry_dir: Path
+    path_disclosure: bool = False
+
+    def public_context(self) -> dict[str, str | None]:
+        """Return non-path attribution fields suitable for JSON envelopes."""
+        return {
+            "dataset": self.dataset,
+            "backend": self.backend,
+            "study_id": self.study_id,
+            "session_id": self.session_id,
+            "actor": self.actor,
+            "project_id": self.project_id,
+        }
+
+
 def _find_project_root_from_cwd() -> Path:
     """
     Search upwards from CWD for a valid 'm4_data' directory.
@@ -43,22 +72,14 @@ def _find_project_root_from_cwd() -> Path:
     return cwd
 
 
-def _get_project_root() -> Path:
+def _get_legacy_project_root() -> Path:
     """
-    Determine project root:
-    - Priority 1: M4_DATA_DIR environment variable (use parent of specified data dir)
-    - Priority 2: If cloned repo: use repository root (two levels up from this file)
-    - Priority 3: If pip installed: Search upwards from CWD for existing 'm4_data' directory, or use CWD.
-    """
-    # Check for explicit data directory override
-    env_data_dir = os.getenv("M4_DATA_DIR")
-    if env_data_dir:
-        data_path = Path(env_data_dir).resolve()
-        if data_path.exists():
-            return data_path.parent
-        # If specified but doesn't exist, use its parent anyway (will be created)
-        return data_path.parent
+    Determine the legacy project root used when no explicit data/home path is set.
 
+    - If cloned repo: use repository root (two levels up from this file)
+    - If pip installed: Search upwards from CWD for existing 'm4_data' directory,
+      or use CWD.
+    """
     package_root = Path(__file__).resolve().parents[2]
 
     # Check if we're in a cloned repository (has pyproject.toml at root)
@@ -69,12 +90,73 @@ def _get_project_root() -> Path:
     return _find_project_root_from_cwd()
 
 
+def _looks_like_legacy_data_parent(path: Path) -> bool:
+    """Return True when M4_DATA_DIR appears to be an old parent/root hint."""
+    direct_markers = (
+        "config.json",
+        "databases",
+        "parquet",
+        "datasets",
+        "raw_files",
+    )
+    if any((path / marker).exists() for marker in direct_markers):
+        return False
+    nested = path / "m4_data"
+    return nested.exists() and any(
+        (nested / marker).exists() for marker in direct_markers
+    )
+
+
+def _get_project_root() -> Path:
+    """Compatibility root for callers that still reason in project-root terms."""
+    env_data_dir = os.getenv("M4_DATA_DIR")
+    if env_data_dir:
+        data_path = Path(env_data_dir).expanduser().resolve()
+        if _looks_like_legacy_data_parent(data_path):
+            return data_path
+        return data_path.parent
+
+    env_home = os.getenv("M4_HOME")
+    if env_home:
+        return Path(env_home).expanduser().resolve()
+
+    return _get_legacy_project_root()
+
+
+def _get_project_data_dir() -> Path:
+    """Resolve the exact M4 data directory.
+
+    M4_DATA_DIR now means the data directory itself.  For a compatibility
+    window, values that clearly point at a parent containing m4_data are mapped
+    to that nested directory with a deprecation warning.
+    """
+    env_data_dir = os.getenv("M4_DATA_DIR")
+    if env_data_dir:
+        data_path = Path(env_data_dir).expanduser().resolve()
+        if _looks_like_legacy_data_parent(data_path):
+            warnings.warn(
+                "M4_DATA_DIR should point directly to the M4 data directory. "
+                "Using the nested m4_data directory for compatibility.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return data_path / "m4_data"
+        return data_path
+
+    return _get_project_root() / "m4_data"
+
+
 _PROJECT_ROOT = _get_project_root()
-_PROJECT_DATA_DIR = _PROJECT_ROOT / "m4_data"
+_PROJECT_DATA_DIR = _get_project_data_dir()
+_M4_HOME = (
+    Path(os.environ["M4_HOME"]).expanduser().resolve()
+    if os.getenv("M4_HOME")
+    else _PROJECT_DATA_DIR
+)
 
 _DEFAULT_DATABASES_DIR = _PROJECT_DATA_DIR / "databases"
 _DEFAULT_PARQUET_DIR = _PROJECT_DATA_DIR / "parquet"
-_RUNTIME_CONFIG_PATH = _PROJECT_DATA_DIR / "config.json"
+_RUNTIME_CONFIG_PATH = _M4_HOME / "config.json"
 _CUSTOM_DATASETS_DIR = _PROJECT_DATA_DIR / "datasets"
 
 
@@ -86,6 +168,47 @@ _CUSTOM_DATASETS_DIR = _PROJECT_DATA_DIR / "datasets"
 def _ensure_custom_datasets_loaded():
     """Ensure custom datasets are loaded from the custom datasets directory."""
     DatasetRegistry.load_custom_datasets(_CUSTOM_DATASETS_DIR)
+
+
+def resolve_runtime_context(
+    *,
+    dataset: str | None = None,
+    backend: str | None = None,
+    path_disclosure: bool | None = None,
+) -> M4Context:
+    """Resolve runtime context with CLI flag > env > config/default precedence."""
+    resolved_dataset = dataset
+    if resolved_dataset is None:
+        try:
+            resolved_dataset = get_active_dataset()
+        except DatasetError:
+            resolved_dataset = None
+
+    resolved_backend = (backend or get_active_backend()).lower()
+    env_home = os.getenv("M4_HOME")
+    home = Path(env_home).expanduser().resolve() if env_home else _M4_HOME
+
+    if path_disclosure is None:
+        path_disclosure = os.getenv("M4_PATH_DISCLOSURE", "").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+            "paths",
+        }
+
+    return M4Context(
+        home=home,
+        data_dir=_PROJECT_DATA_DIR,
+        dataset=resolved_dataset,
+        backend=resolved_backend,
+        study_id=os.getenv("M4_STUDY_ID"),
+        session_id=os.getenv("M4_SESSION_ID"),
+        actor=os.getenv("M4_ACTOR"),
+        project_id=get_bigquery_project_id(),
+        telemetry_dir=get_telemetry_dir(),
+        path_disclosure=bool(path_disclosure),
+    )
 
 
 def get_default_database_path(dataset_name: str) -> Path | None:
@@ -132,6 +255,7 @@ def _ensure_data_dirs():
     _DEFAULT_DATABASES_DIR.mkdir(parents=True, exist_ok=True)
     _DEFAULT_PARQUET_DIR.mkdir(parents=True, exist_ok=True)
     _PROJECT_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    _RUNTIME_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     _CUSTOM_DATASETS_DIR.mkdir(parents=True, exist_ok=True)
 
 
@@ -331,7 +455,12 @@ def set_bigquery_project_id(project_id: str | None) -> None:
 
 def get_telemetry_dir() -> Path:
     """Return the telemetry directory, creating it if needed."""
-    path = _PROJECT_DATA_DIR / "telemetry"
+    env_telemetry_dir = os.getenv("M4_TELEMETRY_DIR")
+    path = (
+        Path(env_telemetry_dir).expanduser().resolve()
+        if env_telemetry_dir
+        else _M4_HOME / "telemetry"
+    )
     path.mkdir(parents=True, exist_ok=True)
     return path
 

--- a/src/m4/core/backends/duckdb.py
+++ b/src/m4/core/backends/duckdb.py
@@ -317,13 +317,14 @@ class DuckDBBackend:
         Returns:
             Formatted string with backend details
         """
-        try:
-            db_path = self._get_db_path(dataset)
-        except ConnectionError:
-            db_path = "unknown"
-
-        return (
+        info = (
             f"**Current Backend:** DuckDB (local database)\n"
-            f"**Active Dataset:** {dataset.name}\n"
-            f"**Database Path:** {db_path}"
+            f"**Active Dataset:** {dataset.name}"
         )
+        if os.getenv("M4_PATH_DISCLOSURE", "").lower() in {"1", "true", "yes", "on"}:
+            try:
+                db_path = self._get_db_path(dataset)
+            except ConnectionError:
+                db_path = "unknown"
+            info += f"\n**Database Path:** {db_path}"
+        return info

--- a/src/m4/core/telemetry.py
+++ b/src/m4/core/telemetry.py
@@ -9,6 +9,7 @@ via the standard logging module. Disable file output with M4_TELEMETRY=off.
 """
 
 import dataclasses
+import hashlib
 import json
 import logging
 import os
@@ -110,6 +111,10 @@ class ToolCallRecord:
     error_message: str | None
     params_summary: dict[str, Any]
     row_count: int | None
+    study_id: str | None = None
+    session_id: str | None = None
+    actor: str | None = None
+    query_hash: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -147,11 +152,17 @@ class TelemetryWriter:
         if os.environ.get("M4_TELEMETRY", "").lower() == "off":
             return
 
-        from m4.config import get_telemetry_dir
+        event_log = os.environ.get("M4_EVENT_LOG")
+        if event_log:
+            log_path = os.path.expanduser(event_log)
+            os.makedirs(os.path.dirname(log_path) or ".", exist_ok=True)
+        else:
+            from m4.config import get_telemetry_dir
 
-        telemetry_dir = get_telemetry_dir()
+            log_path = str(get_telemetry_dir() / TELEMETRY_FILENAME)
+
         self._handler = RotatingFileHandler(
-            telemetry_dir / TELEMETRY_FILENAME,
+            log_path,
             maxBytes=10 * 1024 * 1024,  # 10 MB
             backupCount=3,
         )
@@ -205,6 +216,17 @@ def invoke_tracked(tool: Tool, dataset: DatasetDefinition, params: ToolInput) ->
     except (TypeError, AttributeError):
         params_summary = {}
 
+    query_hash = None
+    sql_value = params_summary.get("sql_query")
+    if isinstance(sql_value, str):
+        query_hash = hashlib.sha256(sql_value.encode("utf-8")).hexdigest()
+        log_sql = os.environ.get("M4_LOG_SQL", "full").lower()
+        if log_sql == "hash":
+            params_summary["sql_query_hash"] = query_hash
+            params_summary.pop("sql_query", None)
+        elif log_sql == "off":
+            params_summary.pop("sql_query", None)
+
     start = time.monotonic()
     success = True
     error_type = None
@@ -238,6 +260,10 @@ def invoke_tracked(tool: Tool, dataset: DatasetDefinition, params: ToolInput) ->
             error_message=error_message,
             params_summary=params_summary,
             row_count=row_count,
+            study_id=os.environ.get("M4_STUDY_ID"),
+            session_id=os.environ.get("M4_SESSION_ID"),
+            actor=os.environ.get("M4_ACTOR") or agent_id,
+            query_hash=query_hash,
         )
 
         record_json = _to_json(dataclasses.asdict(record))

--- a/src/m4/services/status.py
+++ b/src/m4/services/status.py
@@ -33,6 +33,7 @@ def _collect_dataset_status(
     backend: str,
     *,
     include_row_count: bool,
+    include_paths: bool,
 ) -> dict[str, Any]:
     ds_def = DatasetRegistry.get(name)
     parquet_present = bool(ds_info.get("parquet_present"))
@@ -84,13 +85,11 @@ def _collect_dataset_status(
         except Exception:
             pass
 
-    return {
+    result = {
         "name": name,
         "active": name == active_dataset,
         "parquet_present": parquet_present,
         "db_present": db_present,
-        "parquet_root": parquet_root,
-        "db_path": db_path,
         "bigquery_available": bigquery_available,
         "row_count": row_count,
         "parquet_size_gb": parquet_size_gb,
@@ -103,8 +102,16 @@ def _collect_dataset_status(
         "warnings": warnings,
     }
 
+    if include_paths:
+        result["parquet_root"] = parquet_root
+        result["db_path"] = db_path
 
-def collect_status_snapshot(show_all: bool) -> dict[str, Any]:
+    return result
+
+
+def collect_status_snapshot(
+    show_all: bool, include_paths: bool = False
+) -> dict[str, Any]:
     try:
         active = get_active_dataset()
     except DatasetError:
@@ -126,6 +133,7 @@ def collect_status_snapshot(show_all: bool) -> dict[str, Any]:
                 active,
                 backend,
                 include_row_count=not show_all,
+                include_paths=include_paths,
             )
         )
 

--- a/src/m4/skills/system/m4-api/SKILL.md
+++ b/src/m4/skills/system/m4-api/SKILL.md
@@ -67,6 +67,9 @@ df = execute_query("SELECT gender, COUNT(*) as n FROM mimiciv_hosp.patients GROU
 | `get_table_info(table, show_sample=True)` | `dict` | `{'schema': DataFrame, 'sample': DataFrame}` |
 | `execute_query(sql)` | `DataFrame` | Query results as pandas DataFrame |
 
+`backend_info` summarizes the backend and active dataset. Local DuckDB paths are
+hidden unless `M4_PATH_DISCLOSURE=1` is set for the process.
+
 ### Clinical Notes (requires NOTES modality)
 
 | Function | Returns | Description |

--- a/src/m4/skills/system/m4-setup/SKILL.md
+++ b/src/m4/skills/system/m4-setup/SKILL.md
@@ -29,6 +29,7 @@ print("active:", get_active_dataset())
 print("datasets:", list_datasets())
 PY
 uv run m4 status --all
+uv run m4 agent-env --json
 uv run m4 skills --list
 uv run vitrine status
 ```
@@ -46,14 +47,18 @@ Expected built-in datasets:
 | `mimic-iv-note` | MIMIC-IV notes |
 | `eicu` | eICU tabular data |
 
-Custom datasets live in `m4_data/datasets/*.json` and should appear in `m4 status --all`.
+Custom datasets live under the M4 data directory in `datasets/*.json` and should
+appear in `m4 status --all`. By default the data directory is `m4_data`; if
+`M4_DATA_DIR` is set, it must point directly at the data directory.
 
 Common checks:
 
 ```bash
-cat m4_data/config.json
-find m4_data/databases -maxdepth 1 -type f -name '*.duckdb' -print
-find m4_data/datasets -maxdepth 1 -type f -name '*.json' -print
+uv run m4 agent-env --json
+M4_CONFIG_DIR="${M4_HOME:-${M4_DATA_DIR:-m4_data}}"
+cat "$M4_CONFIG_DIR/config.json"
+find "${M4_DATA_DIR:-m4_data}/databases" -maxdepth 1 -type f -name '*.duckdb' -print
+find "${M4_DATA_DIR:-m4_data}/datasets" -maxdepth 1 -type f -name '*.json' -print
 ```
 
 Use `set_dataset("name")` before querying, then inspect schema with `get_schema()` and `get_table_info()`.
@@ -71,7 +76,7 @@ Filtered installs are additive; existing non-matching skills are left in place. 
 
 ## Backend Repair
 
-Check `m4_data/config.json`:
+Check `${M4_HOME:-${M4_DATA_DIR:-m4_data}}/config.json`:
 
 | Field | Meaning |
 |-------|---------|
@@ -79,7 +84,9 @@ Check `m4_data/config.json`:
 | `active_dataset` | Dataset used by API calls |
 | `bigquery_project_id` | Billing/project id for BigQuery |
 
-For local work, `backend: "duckdb"` requires the matching file in `m4_data/databases`. For BigQuery work, credentialed datasets require valid Google credentials and a configured project.
+For local work, `backend: "duckdb"` requires the matching file in the data
+directory's `databases/` folder. For BigQuery work, credentialed datasets
+require valid Google credentials and a configured project.
 
 ## Vitrine Repair
 
@@ -98,5 +105,5 @@ Use the `vitrine-api` skill for display API details.
 
 - Prefer `uv run ...` commands to avoid using the wrong environment.
 - Do not guess table names. Call `get_schema()` and `get_table_info()` after `set_dataset()`.
-- If a dataset appears in `m4 status --all` but not in `list_datasets()`, check `m4_data/datasets/*.json` and reload through the M4 API.
+- If a dataset appears in `m4 status --all` but not in `list_datasets()`, check the data directory's `datasets/*.json` files and reload through the M4 API.
 - If skills reference missing functions or outdated tables, compare the installed copy with `src/m4/skills` and reinstall from the canonical source.

--- a/tests/core/backends/test_duckdb.py
+++ b/tests/core/backends/test_duckdb.py
@@ -220,8 +220,21 @@ class TestDuckDBTableOperations:
 class TestDuckDBBackendInfo:
     """Test backend info generation."""
 
-    def test_backend_info(self, test_dataset, temp_db):
-        """Test getting backend info."""
+    def test_backend_info_hides_paths_by_default(self, test_dataset, temp_db):
+        """Backend info omits raw paths unless path disclosure is enabled."""
+        backend = DuckDBBackend(db_path_override=temp_db)
+
+        info = backend.get_backend_info(test_dataset)
+
+        assert "DuckDB" in info
+        assert test_dataset.name in info
+        assert str(temp_db) not in info
+
+    def test_backend_info_discloses_paths_when_enabled(
+        self, test_dataset, temp_db, monkeypatch
+    ):
+        """Backend info includes raw paths when explicitly requested."""
+        monkeypatch.setenv("M4_PATH_DISCLOSURE", "1")
         backend = DuckDBBackend(db_path_override=temp_db)
 
         info = backend.get_backend_info(test_dataset)
@@ -230,8 +243,25 @@ class TestDuckDBBackendInfo:
         assert test_dataset.name in info
         assert str(temp_db) in info
 
-    def test_backend_info_missing_db(self, test_dataset):
+    def test_backend_info_missing_db_hides_unknown_path_by_default(self, test_dataset):
         """Test backend info when database path can't be determined."""
+        backend = DuckDBBackend()
+
+        with patch(
+            "m4.core.backends.duckdb.get_default_database_path"
+        ) as mock_get_path:
+            mock_get_path.return_value = None
+
+            info = backend.get_backend_info(test_dataset)
+
+            assert "DuckDB" in info
+            assert "unknown" not in info
+
+    def test_backend_info_missing_db_discloses_unknown_when_enabled(
+        self, test_dataset, monkeypatch
+    ):
+        """Path disclosure mode shows unknown when DB path resolution fails."""
+        monkeypatch.setenv("M4_PATH_DISCLOSURE", "1")
         backend = DuckDBBackend()
 
         with patch(

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -125,6 +125,7 @@ class TestInvokeTracked:
 
         assert record["interface"] == "mcp"
         assert record["agent_id"] == "agent-42"
+        assert record["actor"] == "agent-42"
 
     def test_params_captured(self, mock_dataset):
         params = MockInput(sql_query="SELECT * FROM patients", limit=5)
@@ -132,6 +133,32 @@ class TestInvokeTracked:
 
         assert record["params_summary"]["sql_query"] == "SELECT * FROM patients"
         assert record["params_summary"]["limit"] == 5
+        assert record["query_hash"] is not None
+
+    def test_env_attribution_fields(self, mock_dataset):
+        with patch.dict(
+            os.environ,
+            {
+                "M4_STUDY_ID": "study-1",
+                "M4_SESSION_ID": "session-1",
+                "M4_ACTOR": "actor-1",
+            },
+        ):
+            record = _capture_record(mock_dataset)
+
+        assert record["study_id"] == "study-1"
+        assert record["session_id"] == "session-1"
+        assert record["actor"] == "actor-1"
+
+    def test_log_sql_hash_mode_redacts_full_sql(self, mock_dataset):
+        with patch.dict(os.environ, {"M4_LOG_SQL": "hash"}):
+            record = _capture_record(
+                mock_dataset,
+                params=MockInput(sql_query="SELECT * FROM patients", limit=5),
+            )
+
+        assert "sql_query" not in record["params_summary"]
+        assert record["params_summary"]["sql_query_hash"] == record["query_hash"]
 
 
 class TestJSONLFile:
@@ -162,6 +189,15 @@ class TestJSONLFile:
 
         jsonl_path = tmp_path / "tool_calls.jsonl"
         assert not jsonl_path.exists()
+
+    def test_event_log_env_overrides_default_path(self, mock_dataset, tmp_path):
+        event_log = tmp_path / "events.jsonl"
+        with patch.dict(os.environ, {"M4_EVENT_LOG": str(event_log)}):
+            with patch("m4.config.get_telemetry_dir", return_value=tmp_path / "unused"):
+                invoke_tracked(MockTool(), mock_dataset, MockInput())
+
+        assert event_log.exists()
+        assert not (tmp_path / "unused" / "tool_calls.jsonl").exists()
 
 
 class TestContextVars:

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -3,6 +3,7 @@
 import json
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from unittest.mock import patch
 
 import pandas as pd
@@ -282,8 +283,26 @@ class TestTelemetryFilename:
 
 class TestGetTelemetryPath:
     def test_returns_correct_path(self, tmp_path):
-        with patch("m4.config.get_telemetry_dir", return_value=tmp_path):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("M4_EVENT_LOG", None)
+            with patch("m4.config.get_telemetry_dir", return_value=tmp_path):
+                from m4.api import get_telemetry_path
+
+                path = get_telemetry_path()
+        assert path == tmp_path / "tool_calls.jsonl"
+
+    def test_returns_event_log_env_path(self, tmp_path):
+        event_log = tmp_path / "custom-events.jsonl"
+        with patch.dict(os.environ, {"M4_EVENT_LOG": str(event_log)}):
+            with patch("m4.config.get_telemetry_dir", return_value=tmp_path / "unused"):
+                from m4.api import get_telemetry_path
+
+                path = get_telemetry_path()
+        assert path == event_log
+
+    def test_expands_event_log_env_path(self):
+        with patch.dict(os.environ, {"M4_EVENT_LOG": "~/custom-events.jsonl"}):
             from m4.api import get_telemetry_path
 
             path = get_telemetry_path()
-        assert path == tmp_path / "tool_calls.jsonl"
+        assert path == Path("~/custom-events.jsonl").expanduser()

--- a/tests/test_cli_subprocess.py
+++ b/tests/test_cli_subprocess.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import duckdb
+
 RICH_FRAGMENTS = ["[bold]", "[success]", "__  __", "Medical Data", "─", "│"]
 
 
@@ -41,6 +43,25 @@ def test_status_json_subprocess_is_parseable(tmp_path):
     assert "ok" not in payload
 
 
+def test_status_json_hides_paths_by_default(tmp_path):
+    result = _run_m4(["status", "--all", "--json"], tmp_path)
+
+    assert result.returncode == 0
+    payload = _assert_single_json_stdout(result)
+    assert "parquet_root" not in payload["datasets"][0]
+    assert "db_path" not in payload["datasets"][0]
+    assert str(tmp_path) not in result.stdout
+
+
+def test_status_json_paths_flag_discloses_paths(tmp_path):
+    result = _run_m4(["status", "--all", "--json", "--paths"], tmp_path)
+
+    assert result.returncode == 0
+    payload = _assert_single_json_stdout(result)
+    assert "parquet_root" in payload["datasets"][0]
+    assert "db_path" in payload["datasets"][0]
+
+
 def test_status_all_json_subprocess_is_parseable(tmp_path):
     result = _run_m4(["status", "--all", "--json"], tmp_path)
 
@@ -51,6 +72,117 @@ def test_status_all_json_subprocess_is_parseable(tmp_path):
         "mimic-iv-demo",
         "mimic-iv",
     }
+
+
+def test_agent_env_json_subprocess_is_parseable(tmp_path):
+    result = _run_m4(
+        [
+            "agent-env",
+            "--dataset",
+            "mimic-iv-demo",
+            "--backend",
+            "duckdb",
+            "--json",
+        ],
+        tmp_path,
+    )
+
+    assert result.returncode == 0
+    payload = _assert_single_json_stdout(result)
+    assert payload["ok"] is True
+    assert payload["command"] == "agent-env"
+    assert payload["context"]["dataset"] == "mimic-iv-demo"
+    assert payload["data"]["environment"]["M4_DATA_DIR"] == str(tmp_path / "m4_data")
+    assert payload["data"]["raw_paths_hidden"] is True
+
+
+def test_agent_env_protected_mode_omits_data_dir(tmp_path):
+    result = _run_m4(
+        ["agent-env", "--mode", "protected", "--json"],
+        tmp_path,
+    )
+
+    assert result.returncode == 0
+    payload = _assert_single_json_stdout(result)
+    assert payload["ok"] is True
+    assert "M4_DATA_DIR" not in payload["data"]["environment"]
+    assert payload["warnings"]
+
+
+def test_list_datasets_json_subprocess_is_parseable(tmp_path):
+    result = _run_m4(["list-datasets", "--json", "--no-interactive"], tmp_path)
+
+    assert result.returncode == 0
+    payload = _assert_single_json_stdout(result)
+    assert payload["ok"] is True
+    assert payload["command"] == "list-datasets"
+    assert payload["data"]["raw_paths_hidden"] is True
+    assert {dataset["name"] for dataset in payload["data"]["datasets"]} >= {
+        "mimic-iv-demo",
+        "mimic-iv",
+    }
+
+
+def test_schema_json_error_redacts_data_dir(tmp_path):
+    result = _run_m4(
+        [
+            "schema",
+            "--dataset",
+            "mimic-iv-demo",
+            "--backend",
+            "duckdb",
+            "--json",
+            "--no-interactive",
+        ],
+        tmp_path,
+    )
+
+    assert result.returncode != 0
+    payload = _assert_single_json_stdout(result)
+    assert payload["ok"] is False
+    assert payload["command"] == "schema"
+    assert "<M4_DATA_DIR>" in payload["error"]["message"]
+    assert str(tmp_path) not in result.stdout
+
+
+def test_query_json_subprocess_returns_stable_envelope(tmp_path):
+    db_path = tmp_path / "m4_data" / "databases" / "mimic_iv_demo.duckdb"
+    db_path.parent.mkdir(parents=True)
+    conn = duckdb.connect(str(db_path))
+    conn.close()
+
+    result = _run_m4(
+        [
+            "query",
+            "--dataset",
+            "mimic-iv-demo",
+            "--backend",
+            "duckdb",
+            "--sql",
+            "SELECT 1 AS one",
+            "--json",
+            "--no-interactive",
+        ],
+        tmp_path,
+    )
+
+    assert result.returncode == 0
+    payload = _assert_single_json_stdout(result)
+    assert payload["ok"] is True
+    assert payload["command"] == "query"
+    assert payload["context"]["dataset"] == "mimic-iv-demo"
+    assert payload["data"]["result"]["columns"] == ["one"]
+    assert payload["data"]["result"]["rows"] == [{"one": 1}]
+
+
+def test_provenance_export_json_subprocess_is_parseable(tmp_path):
+    result = _run_m4(["provenance", "export", "--json"], tmp_path)
+
+    assert result.returncode == 0
+    payload = _assert_single_json_stdout(result)
+    assert payload["ok"] is True
+    assert payload["command"] == "provenance export"
+    assert payload["data"]["event_count"] == 0
 
 
 def test_use_json_subprocess_is_parseable(tmp_path):

--- a/tests/test_cli_subprocess.py
+++ b/tests/test_cli_subprocess.py
@@ -175,6 +175,42 @@ def test_query_json_subprocess_returns_stable_envelope(tmp_path):
     assert payload["data"]["result"]["rows"] == [{"one": 1}]
 
 
+def test_query_json_subprocess_serializes_date_timestamp_and_null(tmp_path):
+    db_path = tmp_path / "m4_data" / "databases" / "mimic_iv_demo.duckdb"
+    db_path.parent.mkdir(parents=True)
+    conn = duckdb.connect(str(db_path))
+    conn.close()
+
+    result = _run_m4(
+        [
+            "query",
+            "--dataset",
+            "mimic-iv-demo",
+            "--backend",
+            "duckdb",
+            "--sql",
+            (
+                "SELECT DATE '2026-05-29' AS event_date, "
+                "TIMESTAMP '2026-05-29 12:34:56' AS event_time, "
+                "NULL AS missing_value"
+            ),
+            "--json",
+            "--no-interactive",
+        ],
+        tmp_path,
+    )
+
+    assert result.returncode == 0
+    payload = _assert_single_json_stdout(result)
+    assert payload["ok"] is True
+    row = payload["data"]["result"]["rows"][0]
+    assert row == {
+        "event_date": "2026-05-29T00:00:00",
+        "event_time": "2026-05-29T12:34:56",
+        "missing_value": None,
+    }
+
+
 def test_provenance_export_json_subprocess_is_parseable(tmp_path):
     result = _run_m4(["provenance", "export", "--json"], tmp_path)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,6 +78,27 @@ def test_find_project_root_search(tmp_path, monkeypatch):
         assert _find_project_root_from_cwd() == tmp_path
 
 
+def test_m4_data_dir_means_exact_data_directory(tmp_path, monkeypatch):
+    import m4.config as cfg_mod
+
+    data_dir = tmp_path / "datasets" / "m4_data"
+    monkeypatch.setenv("M4_DATA_DIR", str(data_dir))
+
+    assert cfg_mod._get_project_data_dir() == data_dir.resolve()
+
+
+def test_legacy_m4_data_dir_parent_is_supported_with_warning(tmp_path, monkeypatch):
+    import m4.config as cfg_mod
+
+    legacy_parent = tmp_path / "project"
+    nested_data = legacy_parent / "m4_data"
+    (nested_data / "databases").mkdir(parents=True)
+    monkeypatch.setenv("M4_DATA_DIR", str(legacy_parent))
+
+    with pytest.warns(DeprecationWarning, match="M4_DATA_DIR should point directly"):
+        assert cfg_mod._get_project_data_dir() == nested_data.resolve()
+
+
 # ----------------------------------------------------------------
 # Backend configuration tests
 # ----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add explicit runtime context resolution for M4_HOME, exact M4_DATA_DIR, dataset/backend, actor, study, session, telemetry, and path disclosure
- add Lincei-friendly JSON commands for agent-env, list-datasets, schema, describe-table, query, and provenance export
- hide raw local paths in status and DuckDB backend info by default, with --paths / M4_PATH_DISCLOSURE opt-in
- extend telemetry provenance with study/session/actor attribution, query hashes, M4_EVENT_LOG, and M4_LOG_SQL modes
- bump package version to 0.4.5

## Testing
- uv run pytest -q
- uv run ruff check src/m4/__init__.py src/m4/config.py src/m4/cli.py src/m4/services/status.py src/m4/core/telemetry.py src/m4/core/backends/duckdb.py tests/test_config.py tests/test_cli_subprocess.py tests/core/test_telemetry.py tests/core/backends/test_duckdb.py
- uv run ruff format --check src/m4/__init__.py src/m4/config.py src/m4/cli.py src/m4/services/status.py src/m4/core/telemetry.py src/m4/core/backends/duckdb.py tests/test_config.py tests/test_cli_subprocess.py tests/core/test_telemetry.py tests/core/backends/test_duckdb.py
- manual temp DuckDB flow for agent-env, status, list-datasets, schema, describe-table, query, unsafe query rejection, provenance export, protected agent-env
- manual temp DuckDB flow for Python API: list_datasets, set_dataset, get_active_dataset, get_schema, get_table_info, execute_query, get_telemetry_path

## Notes
- M4_DATA_DIR now means the exact M4 data directory. A narrow compatibility window maps unambiguous legacy parent directories containing m4_data and emits a deprecation warning.
- Default path redaction is a behavior change for machine-facing status/backend metadata. Use --paths or M4_PATH_DISCLOSURE=1 when raw paths are needed.
- Full ruff over src tests still reports unrelated existing unused-variable findings in tests/core/test_validation.py and tests/test_integration.py; changed-file ruff passes.