### PR TITLE
Refactor CLI orchestration into services

### DIFF
--- a/.github/workflows/cohort-builder-ui.yaml
+++ b/.github/workflows/cohort-builder-ui.yaml
@@ -1,0 +1,41 @@
+name: Cohort Builder UI
+
+on:
+  push:
+    paths:
+      - "src/m4/apps/cohort_builder/ui/**"
+      - "src/m4/apps/cohort_builder/mcp-app.html"
+      - "scripts/check_cohort_builder_bundle.py"
+      - ".github/workflows/cohort-builder-ui.yaml"
+  pull_request:
+    paths:
+      - "src/m4/apps/cohort_builder/ui/**"
+      - "src/m4/apps/cohort_builder/mcp-app.html"
+      - "scripts/check_cohort_builder_bundle.py"
+      - ".github/workflows/cohort-builder-ui.yaml"
+
+jobs:
+  check-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install UV and Python
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+          python-version: "3.12"
+
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: "src/m4/apps/cohort_builder/ui/package-lock.json"
+
+      - name: Install UI dependencies
+        run: npm ci
+        working-directory: src/m4/apps/cohort_builder/ui
+
+      - name: Check packaged bundle
+        run: uv run python scripts/check_cohort_builder_bundle.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,12 @@ repos:
 
   - repo: local
     hooks:
+      - id: derived-docs
+        name: derived docs freshness
+        entry: uv run python scripts/update_derived_docs.py --check
+        language: system
+        files: '^(docs/TOOLS\.md|scripts/update_derived_docs\.py|src/m4/core/derived/builtins/.*\.sql)$'
+        pass_filenames: false
       - id: pytest
         name: pytest
         entry: uv run pytest

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Once connected, try asking:
 | Dataset | Modality | Size | Access | Local | BigQuery | Derived Tables |
 |---------|----------|------|--------|-------|----------|----------------|
 | **mimic-iv-demo** | Tabular | 100 patients | Free | Yes | No | No |
-| **mimic-iv** | Tabular | 365k patients | [PhysioNet credentialed](https://physionet.org/content/mimiciv/) | Yes | Yes | Yes (63 tables) |
+| **mimic-iv** | Tabular | 365k patients | [PhysioNet credentialed](https://physionet.org/content/mimiciv/) | Yes | Yes | Yes |
 | **mimic-iv-note** | Notes | 331k notes | [PhysioNet credentialed](https://physionet.org/content/mimic-iv-note/) | Yes | Yes | No |
 | **eicu** | Tabular | 200k+ patients | [PhysioNet credentialed](https://physionet.org/content/eicu-crd/) | Yes | Yes | No |
 
@@ -253,7 +253,7 @@ failures are emitted as `operation_failed.error`.
 
 **Derived concept tables** (MIMIC-IV only):
 ```bash
-m4 init-derived mimic-iv         # Materialize ~63 derived tables (SOFA, sepsis3, KDIGO, etc.)
+m4 init-derived mimic-iv         # Materialize derived tables (SOFA, sepsis3, KDIGO, etc.)
 m4 init-derived mimic-iv --list  # List available derived tables without materializing
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,7 +177,7 @@ The `ToolSelector` filters tools based on active dataset modalities.
 
 ### Derived Table System (`core/derived/`)
 
-Pre-computed clinical concept tables materialized from vendored SQL. This system provides ~63 derived tables for MIMIC-IV, covering severity scores, sepsis definitions, organ failure staging, medications, measurements, and more.
+Pre-computed clinical concept tables materialized from vendored SQL. This system provides derived tables for MIMIC-IV, covering severity scores, sepsis definitions, organ failure staging, medications, measurements, and more.
 
 **Architecture:**
 

--- a/docs/BIGQUERY.md
+++ b/docs/BIGQUERY.md
@@ -72,7 +72,7 @@ M4 uses these PhysioNet BigQuery datasets:
 
 ## Derived Tables on BigQuery
 
-BigQuery users already have access to ~63 pre-computed derived concept tables (SOFA scores, sepsis cohorts, KDIGO AKI staging, medications, etc.) via `physionet-data.mimiciv_derived`. These tables are maintained by PhysioNet and are the same concepts that local DuckDB users materialize with `m4 init-derived mimic-iv`.
+BigQuery users already have access to pre-computed derived concept tables (SOFA scores, sepsis cohorts, KDIGO AKI staging, medications, etc.) via `physionet-data.mimiciv_derived`. These tables are maintained by PhysioNet and are the same concepts that local DuckDB users materialize with `m4 init-derived mimic-iv`.
 
 You do **not** need to run `m4 init-derived` when using BigQuery -- the tables are already available. Query them directly:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -78,8 +78,8 @@ non-zero.
       "parquet_size_gb": 8.5,
       "derived": {
         "supported": true,
-        "total": 42,
-        "materialized": 42,
+        "total": 63,
+        "materialized": 63,
         "bigquery": false
       },
       "warnings": []
@@ -425,6 +425,17 @@ Run the full test suite before submitting PRs:
 uv run pre-commit run --all-files
 ```
 
+If you change the cohort-builder UI under `src/m4/apps/cohort_builder/ui/`,
+regenerate the packaged single-file app and verify it matches the tracked
+artifact:
+
+```bash
+cd src/m4/apps/cohort_builder/ui && npm ci
+cd -
+uv run python scripts/check_cohort_builder_bundle.py --update
+uv run python scripts/check_cohort_builder_bundle.py
+```
+
 ## Updating Vendored Derived SQL
 
 The derived table SQL in `src/m4/core/derived/builtins/mimic_iv/` is vendored from the [mimic-code](https://github.com/MIT-LCP/mimic-code) repository. When mimic-code releases updated SQL (e.g., bug fixes or new concept tables), follow these steps to update:
@@ -437,7 +448,7 @@ The derived table SQL in `src/m4/core/derived/builtins/mimic_iv/` is vendored fr
 
 4. **Test materialization:** Run `m4 init-derived mimic-iv` against a local MIMIC-IV database to verify all tables build successfully.
 
-5. **Update documentation:** If new table categories or tables were added, update `docs/TOOLS.md` (Derived Table Categories section) and `README.md`.
+5. **Update documentation:** If new table categories or tables were added, run `uv run python scripts/update_derived_docs.py` and update related README prose as needed. Use `uv run python scripts/update_derived_docs.py --check` to verify docs freshness.
 
 The vendored approach means M4 works offline and ensures reproducibility -- users get the exact SQL version bundled with their M4 release, regardless of upstream changes.
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -202,17 +202,19 @@ Use the `note_type` parameter to filter searches and listings.
 
 After running `m4 init-derived mimic-iv`, the following pre-computed tables become available in the `mimiciv_derived` schema. Query them with `execute_query` like any other table (e.g., `SELECT * FROM mimiciv_derived.sofa LIMIT 10`).
 
+<!-- BEGIN GENERATED DERIVED TABLES -->
 | Category | Tables | Description |
 |----------|--------|-------------|
-| **Scores** | `sofa`, `sapsii`, `apsiii`, `oasis`, `lods`, `sirs` | Severity and mortality prediction scores |
-| **Sepsis** | `sepsis3`, `suspicion_of_infection` | Sepsis-3 cohort identification and suspected infection events |
-| **Organ Failure** | `kdigo_creatinine`, `kdigo_uo`, `kdigo_stages`, `meld` | KDIGO AKI staging and MELD liver score |
-| **Medications** | `norepinephrine`, `epinephrine`, `dopamine`, `dobutamine`, `phenylephrine`, `vasopressin`, `milrinone`, `norepinephrine_equivalent_dose`, `vasoactive_agent`, `antibiotic`, `acei`, `nsaid`, `neuroblock` | Individual vasopressors, equivalents, and other drug classes |
-| **Measurements** | `vitalsign`, `bg`, `blood_gas`, `chemistry`, `complete_blood_count`, `coagulation`, `cardiac_marker`, `enzyme`, `inflammation`, `icp`, `height`, `urine_output`, `urine_output_rate`, `ventilator_setting`, `oxygen_delivery`, `rhythm`, `gcs`, `creatinine_baseline`, `blood_differential` | Labs, vitals, and clinical measurements |
-| **Demographics** | `age`, `icustay_detail`, `icustay_times`, `icustay_hourly`, `weight_durations` | Patient demographics and ICU stay metadata |
-| **First Day** | `first_day_bg`, `first_day_bg_art`, `first_day_gcs`, `first_day_height`, `first_day_lab`, `first_day_rrt`, `first_day_sofa`, `first_day_urine_output`, `first_day_vitalsign`, `first_day_weight` | Aggregated values from the first 24 hours of ICU admission |
-| **Treatment** | `ventilation`, `rrt`, `crrt`, `invasive_line` | Mechanical ventilation, renal replacement therapy, and lines |
+| **Demographics** | `icustay_times`, `icustay_hourly`, `weight_durations`, `age`, `icustay_detail` | Patient demographics and ICU stay metadata |
+| **Measurements** | `urine_output`, `bg`, `blood_differential`, `cardiac_marker`, `chemistry`, `coagulation`, `complete_blood_count`, `creatinine_baseline`, `enzyme`, `gcs`, `height`, `icp`, `inflammation`, `oxygen_delivery`, `rhythm`, `urine_output_rate`, `ventilator_setting`, `vitalsign` | Labs, vitals, and clinical measurements |
+| **Organ Failure** | `kdigo_uo`, `kdigo_creatinine`, `meld`, `kdigo_stages` | KDIGO AKI staging and MELD liver score |
 | **Comorbidity** | `charlson` | Charlson comorbidity index |
+| **Medications** | `acei`, `antibiotic`, `dobutamine`, `dopamine`, `epinephrine`, `milrinone`, `neuroblock`, `norepinephrine`, `nsaid`, `phenylephrine`, `vasopressin`, `vasoactive_agent`, `norepinephrine_equivalent_dose` | Individual vasopressors, equivalents, and other drug classes |
+| **Treatment** | `crrt`, `invasive_line`, `rrt`, `ventilation` | Mechanical ventilation, renal replacement therapy, and lines |
+| **First Day** | `first_day_bg`, `first_day_bg_art`, `first_day_gcs`, `first_day_height`, `first_day_lab`, `first_day_rrt`, `first_day_urine_output`, `first_day_vitalsign`, `first_day_weight`, `first_day_sofa` | Aggregated values from the first 24 hours of ICU admission |
+| **Scores** | `apsiii`, `lods`, `oasis`, `sapsii`, `sirs`, `sofa` | Severity and mortality prediction scores |
+| **Sepsis** | `suspicion_of_infection`, `sepsis3` | Sepsis-3 cohort identification and suspected infection events |
+<!-- END GENERATED DERIVED TABLES -->
 
 These tables are materialized from vendored [mimic-code](https://github.com/MIT-LCP/mimic-code) SQL and are available for MIMIC-IV only (not mimic-iv-demo or eICU). BigQuery users already have access via `physionet-data.mimiciv_derived`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,11 +74,11 @@ m4-mcp-server = "m4.mcp_server:main"  # Kept for backwards compatibility
 vitrine = "vitrine.cli:app"  # Standalone vitrine CLI (from vitrine package)
 
 [project.urls]
-Homepage = "https://github.com/rafiattrach/m4"
-Repository = "https://github.com/rafiattrach/m4"
-Documentation = "https://github.com/rafiattrach/m4#readme"
-Issues = "https://github.com/rafiattrach/m4/issues"
-Changelog = "https://github.com/rafiattrach/m4/releases"
+Homepage = "https://github.com/hannesill/m4"
+Repository = "https://github.com/hannesill/m4"
+Documentation = "https://github.com/hannesill/m4#readme"
+Issues = "https://github.com/hannesill/m4/issues"
+Changelog = "https://github.com/hannesill/m4/releases"
 
 [tool.pdm.version]
 source = "file"

--- a/scripts/check_cohort_builder_bundle.py
+++ b/scripts/check_cohort_builder_bundle.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_DIR = ROOT / "src" / "m4" / "apps" / "cohort_builder" / "ui"
+PACKAGED_HTML = ROOT / "src" / "m4" / "apps" / "cohort_builder" / "mcp-app.html"
+
+
+def normalize_html(text: str) -> str:
+    return "\n".join(line.rstrip() for line in text.splitlines()) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check that the packaged cohort-builder app matches a fresh Vite build."
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Replace the tracked packaged HTML with a fresh build.",
+    )
+    args = parser.parse_args()
+
+    if shutil.which("npm") is None:
+        print("npm is required to check the cohort-builder UI bundle.", file=sys.stderr)
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="m4-cohort-builder-") as tmp:
+        out_dir = Path(tmp)
+        env = os.environ.copy()
+        env["M4_COHORT_BUILDER_OUT_DIR"] = str(out_dir)
+        subprocess.run(["npm", "run", "build"], cwd=UI_DIR, env=env, check=True)
+        built_html = out_dir / "mcp-app.html"
+        if not built_html.exists():
+            print(f"Vite build did not create {built_html}", file=sys.stderr)
+            return 1
+
+        built = normalize_html(built_html.read_text())
+        packaged = normalize_html(PACKAGED_HTML.read_text())
+        if args.update:
+            PACKAGED_HTML.write_text(built)
+            return 0
+        if built != packaged:
+            print(
+                "Packaged cohort-builder HTML is stale. "
+                "Run: uv run python scripts/check_cohort_builder_bundle.py --update",
+                file=sys.stderr,
+            )
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_derived_docs.py
+++ b/scripts/update_derived_docs.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC_PATH = ROOT / "docs" / "TOOLS.md"
+START = "<!-- BEGIN GENERATED DERIVED TABLES -->"
+END = "<!-- END GENERATED DERIVED TABLES -->"
+
+CATEGORY_LABELS = {
+    "score": "Scores",
+    "sepsis": "Sepsis",
+    "organfailure": "Organ Failure",
+    "medication": "Medications",
+    "measurement": "Measurements",
+    "demographics": "Demographics",
+    "firstday": "First Day",
+    "treatment": "Treatment",
+    "comorbidity": "Comorbidity",
+}
+
+CATEGORY_DESCRIPTIONS = {
+    "score": "Severity and mortality prediction scores",
+    "sepsis": "Sepsis-3 cohort identification and suspected infection events",
+    "organfailure": "KDIGO AKI staging and MELD liver score",
+    "medication": "Individual vasopressors, equivalents, and other drug classes",
+    "measurement": "Labs, vitals, and clinical measurements",
+    "demographics": "Patient demographics and ICU stay metadata",
+    "firstday": "Aggregated values from the first 24 hours of ICU admission",
+    "treatment": "Mechanical ventilation, renal replacement therapy, and lines",
+    "comorbidity": "Charlson comorbidity index",
+}
+
+
+def generated_block() -> str:
+    sys.path.insert(0, str(ROOT / "src"))
+    from m4.core.derived.builtins import get_tables_by_category
+
+    categories = get_tables_by_category("mimic-iv")
+    lines = [
+        START,
+        "| Category | Tables | Description |",
+        "|----------|--------|-------------|",
+    ]
+    for category, tables in categories.items():
+        label = CATEGORY_LABELS.get(category, category.replace("_", " ").title())
+        table_list = ", ".join(f"`{table}`" for table in tables)
+        description = CATEGORY_DESCRIPTIONS.get(category, "")
+        lines.append(f"| **{label}** | {table_list} | {description} |")
+    lines.append(END)
+    return "\n".join(lines)
+
+
+def replace_block(text: str, block: str) -> str:
+    if START not in text or END not in text:
+        raise SystemExit(f"Missing generated derived table markers in {DOC_PATH}")
+    before, rest = text.split(START, 1)
+    _, after = rest.split(END, 1)
+    return before + block + after
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Update or check the generated derived table docs block."
+    )
+    parser.add_argument("--check", action="store_true", help="Fail if docs are stale.")
+    args = parser.parse_args()
+
+    current = DOC_PATH.read_text()
+    expected = replace_block(current, generated_block())
+    if args.check:
+        if current != expected:
+            print(
+                "docs/TOOLS.md derived table block is stale. "
+                "Run: uv run python scripts/update_derived_docs.py",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    DOC_PATH.write_text(expected)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/m4/__init__.py
+++ b/src/m4/__init__.py
@@ -13,7 +13,7 @@ Quick Start:
 For MCP server usage, run: m4 serve
 """
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 # Expose API functions at package level for easy imports
 from vitrine import show

--- a/src/m4/apps/cohort_builder/ui/vite.config.ts
+++ b/src/m4/apps/cohort_builder/ui/vite.config.ts
@@ -2,13 +2,17 @@ import { defineConfig } from "vite";
 import { viteSingleFile } from "vite-plugin-singlefile";
 import { resolve } from "path";
 
+const outDir = process.env.M4_COHORT_BUILDER_OUT_DIR
+  ? resolve(process.env.M4_COHORT_BUILDER_OUT_DIR)
+  : resolve(__dirname, "..");
+
 export default defineConfig({
   plugins: [viteSingleFile()],
   root: "src",
   // Disable publicDir since assets are inlined as base64 for single-file output
   publicDir: false,
   build: {
-    outDir: resolve(__dirname, ".."),
+    outDir,
     emptyOutDir: false,
     rollupOptions: {
       input: resolve(__dirname, "src/mcp-app.html"),

--- a/src/m4/cli.py
+++ b/src/m4/cli.py
@@ -2,8 +2,6 @@ import json
 import logging
 import math
 import os
-import subprocess
-import sys
 from contextlib import contextmanager, nullcontext
 from dataclasses import is_dataclass
 from datetime import date, datetime, time
@@ -17,15 +15,12 @@ from m4.client import M4Client
 from m4.config import (
     get_active_backend,
     get_active_dataset,
-    get_bigquery_project_id,
     get_dataset_parquet_root,
     get_default_database_path,
     get_telemetry_dir,
     logger,
     resolve_runtime_context,
-    set_active_backend,
     set_active_dataset,
-    set_bigquery_project_id,
 )
 from m4.console import (
     console,
@@ -48,7 +43,6 @@ from m4.core.datasets import DatasetRegistry
 from m4.core.derived.builtins import (
     get_tables_by_category,
     has_derived_support,
-    list_builtins,
 )
 from m4.core.derived.materializer import (
     get_derived_table_count,
@@ -64,10 +58,18 @@ from m4.data_io import (
     init_duckdb_from_parquet,
     verify_table_rowcount,
 )
+from m4.services.agent_env import build_agent_env_service
 from m4.services.backend import set_active_backend_service
+from m4.services.config import (
+    MCPConfigRequest,
+    configure_mcp_service,
+    install_config_skills_service,
+    summarize_generated_config,
+)
 from m4.services.download import build_wget_command, download_dataset_service
-from m4.services.events import EventReporter, NdjsonEventReporter
+from m4.services.events import NdjsonEventReporter
 from m4.services.init import initialize_dataset_service
+from m4.services.init_derived import init_derived_service
 from m4.services.results import CommandError, CommandResult
 from m4.services.setup import doctor_service, quickstart_service, setup_agent_service
 from m4.services.status import collect_status_snapshot
@@ -552,130 +554,6 @@ def download_cmd(
             console.print(f"  {item}")
         for hint in layout.get("recovery", []):
             console.print(f"  Hint: {hint}")
-
-
-def _init_derived_json_result(
-    dataset_name: str,
-    *,
-    list_only: bool,
-    force: bool,
-    event_reporter: EventReporter | None = None,
-) -> CommandResult | CommandError:
-    dataset_key = dataset_name.lower()
-    ds = DatasetRegistry.get(dataset_key)
-
-    if not ds:
-        supported = ", ".join([d.name for d in DatasetRegistry.list_all()])
-        return CommandError(
-            command="init-derived",
-            code="dataset_not_found",
-            message=f"Dataset '{dataset_name}' is not supported or not configured.",
-            hint=f"Supported datasets: {supported}",
-        )
-
-    if dataset_key in ("mimic-iv-demo",):
-        return CommandError(
-            command="init-derived",
-            code="derived_not_supported",
-            message=f"Derived tables are not supported for '{dataset_key}'.",
-            hint=(
-                "The demo dataset has only 100 patients; many derived concepts "
-                "produce empty or unreliable results. Use the full mimic-iv dataset."
-            ),
-        )
-
-    if get_active_backend() == "bigquery":
-        return CommandResult(
-            command="init-derived",
-            data={
-                "dataset": dataset_key,
-                "status": "skipped",
-                "reason": "bigquery_derived_tables_available",
-                "created_tables": [],
-                "table_count": 0,
-            },
-        )
-
-    if list_only:
-        try:
-            names = list_builtins(dataset_key)
-        except ValueError as exc:
-            return CommandError(
-                command="init-derived",
-                code="derived_not_supported",
-                message=str(exc),
-            )
-        return CommandResult(
-            command="init-derived",
-            data={
-                "dataset": dataset_key,
-                "status": "listed",
-                "tables": names,
-                "table_count": len(names),
-            },
-        )
-
-    db_path = get_default_database_path(dataset_key)
-    if not db_path or not db_path.exists():
-        return CommandError(
-            command="init-derived",
-            code="database_not_found",
-            message=f"No DuckDB database found for '{dataset_key}'.",
-            hint=f"Initialize first: m4 init {dataset_key}",
-        )
-
-    existing_count = get_derived_table_count(db_path)
-    if existing_count > 0 and not force:
-        return CommandResult(
-            command="init-derived",
-            data={
-                "dataset": dataset_key,
-                "status": "skipped",
-                "reason": "already_materialized",
-                "database": str(db_path),
-                "existing_table_count": existing_count,
-                "created_tables": [],
-                "table_count": 0,
-            },
-        )
-
-    try:
-        created = materialize_all(dataset_key, db_path, event_reporter=event_reporter)
-    except ValueError as exc:
-        return CommandError(
-            command="init-derived",
-            code="derived_not_supported",
-            message=str(exc),
-        )
-    except RuntimeError as exc:
-        return CommandError(
-            command="init-derived",
-            code="derived_materialization_failed",
-            message=str(exc),
-            hint=(
-                "If the database is locked, stop MCP servers or notebooks using it."
-                if "locked by another process" in str(exc)
-                else None
-            ),
-        )
-    except Exception as exc:
-        logger.error(f"Derived table materialization error: {exc}", exc_info=True)
-        return CommandError(
-            command="init-derived",
-            code="derived_materialization_failed",
-            message=f"Materialization failed: {exc}",
-        )
-
-    return CommandResult(
-        command="init-derived",
-        data={
-            "dataset": dataset_key,
-            "status": "completed",
-            "database": str(db_path),
-            "created_tables": created,
-            "table_count": len(created),
-        },
-    )
 
 
 @app.command("setup-agent")
@@ -1251,23 +1129,30 @@ def init_derived_cmd(
             hint="Use: m4 init-derived DATASET --json --events ndjson",
         )
 
-    if json_output:
-        reporter = (
-            NdjsonEventReporter(command="init-derived") if events == "ndjson" else None
+    reporter = (
+        NdjsonEventReporter(command="init-derived")
+        if json_output and events == "ndjson"
+        else None
+    )
+    if reporter:
+        reporter.operation_started(
+            dataset=dataset_name,
+            list_only=list_only,
+            force=force,
         )
-        if reporter:
-            reporter.operation_started(
-                dataset=dataset_name,
-                list_only=list_only,
-                force=force,
-            )
-        with _silence_m4_logging(), _silence_console_output():
-            result = _init_derived_json_result(
-                dataset_name,
-                list_only=list_only,
-                force=force,
-                event_reporter=reporter,
-            )
+
+    with (
+        _silence_m4_logging() if json_output else nullcontext(),
+        _silence_console_output() if json_output else nullcontext(),
+    ):
+        result = init_derived_service(
+            dataset_name,
+            list_only=list_only,
+            force=force,
+            event_reporter=reporter,
+        )
+
+    if json_output:
         if reporter:
             if isinstance(result, CommandError):
                 reporter.operation_failed(result.to_json_dict()["error"])
@@ -1279,90 +1164,43 @@ def init_derived_cmd(
             raise typer.Exit(code=1)
         return
 
-    dataset_key = dataset_name.lower()
-    ds = DatasetRegistry.get(dataset_key)
-
-    if not ds:
-        supported = ", ".join([d.name for d in DatasetRegistry.list_all()])
-        print_error_panel(
-            "Dataset Not Found",
-            f"Dataset '{dataset_name}' is not supported or not configured.",
-            hint=f"Supported datasets: {supported}",
-        )
+    if isinstance(result, CommandError):
+        title = {
+            "dataset_not_found": "Dataset Not Found",
+            "derived_not_supported": "Not Supported",
+            "database_not_found": "Database Not Found",
+            "derived_materialization_failed": "Materialization Failed",
+        }.get(result.code, "Init Derived Failed")
+        if result.hint:
+            print_error_panel(title, result.message, hint=result.hint)
+        else:
+            error(result.message)
         raise typer.Exit(code=1)
 
-    # Block unsupported datasets
-    if dataset_key in ("mimic-iv-demo",):
-        print_error_panel(
-            "Not Supported",
-            f"Derived tables are not supported for '{dataset_key}'.",
-            hint=(
-                "The demo dataset has only 100 patients; many derived concepts "
-                "produce empty or unreliable results. Use the full mimic-iv dataset."
-            ),
-        )
-        raise typer.Exit(code=1)
-
-    # Block if BigQuery backend
-    if get_active_backend() == "bigquery":
+    data = result.data
+    status = data.get("status")
+    if status == "listed":
+        console.print(f"\n[bold]Available derived tables for {data['dataset']}:[/bold]")
+        console.print(f"[muted]({data['table_count']} tables)[/muted]\n")
+        for name in data["tables"]:
+            console.print(f"  {name}")
+    elif (
+        status == "skipped"
+        and data.get("reason") == "bigquery_derived_tables_available"
+    ):
         info(
             "BigQuery backend active — built-in derived tables are already available "
             "on physionet-data.mimiciv_derived. No materialization needed."
         )
-        return
-
-    if list_only:
-        try:
-            names = list_builtins(dataset_key)
-            console.print(f"\n[bold]Available derived tables for {dataset_key}:[/bold]")
-            console.print(f"[muted]({len(names)} tables)[/muted]\n")
-            for name in names:
-                console.print(f"  {name}")
-        except ValueError as e:
-            error(str(e))
-            raise typer.Exit(code=1)
-        return
-
-    db_path = get_default_database_path(dataset_key)
-    if not db_path or not db_path.exists():
-        print_error_panel(
-            "Database Not Found",
-            f"No DuckDB database found for '{dataset_key}'.",
-            hint=f"Initialize first: m4 init {dataset_key}",
-        )
-        raise typer.Exit(code=1)
-
-    # Skip if derived tables already exist (unless --force)
-    existing_count = get_derived_table_count(db_path)
-    if existing_count > 0 and not force:
+    elif status == "skipped" and data.get("reason") == "already_materialized":
         info(
-            f"Derived tables already materialized ({existing_count} tables). "
+            f"Derived tables already materialized ({data['existing_table_count']} tables). "
             "Use --force to recreate."
         )
-        return
-
-    try:
-        created = materialize_all(dataset_key, db_path)
-        success(f"Created {len(created)} derived tables in mimiciv_derived schema")
-    except ValueError as e:
-        error(str(e))
-        raise typer.Exit(code=1)
-    except RuntimeError as e:
-        if "locked by another process" in str(e):
-            print_error_panel(
-                "Database Locked",
-                str(e),
-                hint="If the M4 MCP server is running, stop it before "
-                "materializing derived tables.",
-            )
-        else:
-            error(f"Materialization failed: {e}")
-            logger.error(f"Derived table materialization error: {e}", exc_info=True)
-        raise typer.Exit(code=1)
-    except Exception as e:
-        error(f"Materialization failed: {e}")
-        logger.error(f"Derived table materialization error: {e}", exc_info=True)
-        raise typer.Exit(code=1)
+    elif status == "completed":
+        success(
+            f"Created {data['table_count']} derived tables in mimiciv_derived schema"
+        )
 
 
 @app.command("use")
@@ -1998,79 +1836,33 @@ def agent_env_cmd(
         error("Unsupported format. Use 'dotenv', 'json', or 'text'.")
         raise typer.Exit(code=1)
 
-    if mode not in {"local", "protected"}:
+    result = build_agent_env_service(
+        mode=mode,
+        dataset=dataset_name,
+        backend=backend_name,
+        project_id=project_id,
+        include_paths=include_paths,
+    )
+    if isinstance(result, CommandError):
         if output_format == "json":
             _emit_agent_error(
                 "agent-env",
-                "invalid_mode",
-                f"Unsupported mode '{mode}'.",
-                hint="Use --mode local or --mode protected.",
+                result.code,
+                result.message,
+                hint=result.hint,
             )
         error("Unsupported mode. Use 'local' or 'protected'.")
         raise typer.Exit(code=1)
 
-    ctx = resolve_runtime_context(
-        dataset=dataset_name, backend=backend_name, path_disclosure=include_paths
-    )
-    env = {
-        "M4_HOME": str(ctx.home),
-        "M4_DATASET": ctx.dataset,
-        "M4_BACKEND": ctx.backend,
-        "M4_STUDY_ID": ctx.study_id,
-        "M4_SESSION_ID": ctx.session_id,
-        "M4_ACTOR": ctx.actor,
-        "M4_TELEMETRY_DIR": str(ctx.telemetry_dir),
-    }
-    if project_id or ctx.project_id:
-        env["M4_PROJECT_ID"] = project_id or ctx.project_id
-    if mode == "local":
-        env["M4_DATA_DIR"] = str(ctx.data_dir)
-    else:
-        env["M4_TELEMETRY_DIR"] = str(ctx.telemetry_dir)
-
-    warnings_list: list[str] = []
-    if ctx.dataset and not DatasetRegistry.get(ctx.dataset):
-        warnings_list.append(f"Dataset '{ctx.dataset}' is not registered.")
-    if ctx.backend == "bigquery" and ctx.dataset:
-        ds = DatasetRegistry.get(ctx.dataset)
-        if ds and not ds.bigquery_dataset_ids:
-            warnings_list.append(
-                f"Dataset '{ctx.dataset}' is not available on the BigQuery backend."
-            )
-    if mode == "protected":
-        warnings_list.append(
-            "Protected mode omits M4_DATA_DIR; expose only an M4 service, socket, MCP server, or gateway to agents."
-        )
-
-    data = {
-        "mode": mode,
-        "environment": {key: value for key, value in env.items() if value is not None},
-        "path_recommendations": {
-            "python": sys.executable,
-            "cli": "m4",
-        },
-        "defaults": {
-            "dataset": ctx.dataset,
-            "backend": ctx.backend,
-        },
-        "telemetry_destination": str(ctx.telemetry_dir),
-        "raw_paths_hidden": not include_paths,
-        "recommended_commands": [
-            "m4 status --json --no-interactive",
-            "m4 list-datasets --json --no-interactive",
-            "m4 schema --dataset <dataset> --backend <backend> --json --no-interactive",
-            "m4 describe-table <table> --dataset <dataset> --backend <backend> --json --no-interactive",
-            "m4 query --dataset <dataset> --backend <backend> --sql <sql> --json --no-interactive",
-        ],
-    }
+    data = result.data
 
     if output_format == "json":
         _emit_json(
             _agent_success_payload(
                 "agent-env",
                 data,
-                context=ctx.public_context(),
-                warnings=warnings_list,
+                context=result.context,
+                warnings=result.warnings,
             )
         )
         return
@@ -2561,174 +2353,68 @@ def config_cmd(
 
     • m4 config claude --backend bigquery --project-id my-project
     """
-    try:
-        from m4 import mcp_client_configs
-
-        script_dir = Path(mcp_client_configs.__file__).parent
-    except ImportError:
-        error("Could not find m4.mcp_client_configs package")
-        raise typer.Exit(code=1)
-
-    # Track whether backend/project_id were explicitly provided by the user
-    backend_explicit = backend is not None
-    project_id_explicit = project_id is not None
-    if backend is None:
-        backend = get_active_backend()
-
-    # Infer project_id from config when backend is bigquery and not explicitly passed
-    if backend == "bigquery" and not project_id:
-        project_id = get_bigquery_project_id()
-
-    # Validate backend-specific arguments only when --backend is explicit
-    if backend_explicit:
-        # duckdb: db_path allowed, project_id not allowed
-        if backend == "duckdb" and project_id:
-            error("--project-id can only be used with --backend bigquery")
-            raise typer.Exit(code=1)
-
-        # bigquery: requires project_id, db_path not allowed
-        if backend == "bigquery" and db_path:
-            error("--db-path can only be used with --backend duckdb")
-            raise typer.Exit(code=1)
-        if backend == "bigquery" and not project_id:
-            error("--project-id is required when using --backend bigquery")
-            raise typer.Exit(code=1)
-
-    # Even when inferred, bigquery still requires a project_id
-    if backend == "bigquery" and not project_id:
-        error(
-            "BigQuery backend requires a project ID. "
-            "Set it with: m4 backend bigquery --project-id <ID>"
+    if client != "claude":
+        info(
+            "Generating M4 MCP configuration..."
+            if quick
+            else "Starting interactive M4 MCP configuration..."
         )
+
+    result = configure_mcp_service(
+        MCPConfigRequest(
+            client=client,
+            backend=backend,
+            db_path=db_path,
+            project_id=project_id,
+            python_path=python_path,
+            working_directory=working_directory,
+            server_name=server_name,
+            output=output,
+            quick=quick,
+        )
+    )
+    if isinstance(result, CommandError):
+        error(result.message)
         raise typer.Exit(code=1)
 
     if client == "claude":
-        # Run the Claude Desktop setup script
-        script_path = script_dir / "setup_claude_desktop.py"
-
-        if not script_path.exists():
-            error(f"Claude Desktop setup script not found at {script_path}")
-            raise typer.Exit(code=1)
-
-        # Build command arguments with smart defaults inferred from runtime config
-        cmd = [sys.executable, str(script_path)]
-
-        # Always pass backend if not duckdb; duckdb is the script default
-        if backend != "duckdb":
-            cmd.extend(["--backend", backend])
-
-        # For duckdb, pass db_path only if explicitly provided.
-        # If omitted, the server will resolve it dynamically based on the active dataset.
-        if backend == "duckdb" and db_path:
-            inferred_db_path = Path(db_path).resolve()
-            cmd.extend(["--db-path", str(inferred_db_path)])
-
-        elif backend == "bigquery" and project_id:
-            cmd.extend(["--project-id", project_id])
-
-        try:
-            result = subprocess.run(cmd, check=True, capture_output=False)
-            if result.returncode == 0:
-                # Persist backend and project_id only if explicitly provided
-                if backend_explicit:
-                    set_active_backend(backend)
-                if project_id_explicit:
-                    set_bigquery_project_id(project_id)
-                success("Claude Desktop configuration completed!")
-        except subprocess.CalledProcessError as e:
-            error(f"Claude Desktop setup failed with exit code {e.returncode}")
-            raise typer.Exit(code=e.returncode)
-        except FileNotFoundError:
-            error("Python interpreter not found. Please ensure Python is installed.")
-            raise typer.Exit(code=1)
-
-        # Install skills if requested (Claude-only for backwards compatibility)
+        success("Claude Desktop configuration completed!")
         if skills:
-            from m4.skills import AI_TOOLS, install_skills
+            skill_result = install_config_skills_service(["claude"])
+            if isinstance(skill_result, CommandError):
+                warning(f"Skills installation failed: {skill_result.message}")
+            else:
+                for item in skill_result.data["installed"]:
+                    success(f"Installed skill: {item['skill']} -> {item['path']}")
+        return
 
-            try:
-                results = install_skills(tools=["claude"])
-                for tool_name, paths in results.items():
-                    tool = AI_TOOLS[tool_name]
-                    for skill_path in paths:
-                        success(f"Installed skill: {skill_path.name} → {skill_path}")
-            except Exception as e:
-                warning(f"Skills installation failed: {e}")
+    data = result.data
+    for line in summarize_generated_config(data["config"], data["backend"]):
+        typer.echo(line)
 
+    if data["output"]:
+        typer.echo(f"\nConfiguration saved to: {data['output']}")
     else:
-        # Run the dynamic config generator
-        script_path = script_dir / "dynamic_mcp_config.py"
+        typer.echo("\nMCP Configuration (copy and paste this into your MCP client):")
+        typer.echo("=" * 70)
+        typer.echo(data["config_json"])
+        typer.echo("=" * 70)
 
-        if not script_path.exists():
-            error(f"Dynamic config script not found at {script_path}")
-            raise typer.Exit(code=1)
+    if quick:
+        success("Configuration generated successfully!")
 
-        # Build command arguments
-        cmd = [sys.executable, str(script_path)]
-
-        if quick:
-            cmd.append("--quick")
-
-        if backend != "duckdb":
-            cmd.extend(["--backend", backend])
-
-        if server_name != "m4":
-            cmd.extend(["--server-name", server_name])
-
-        if python_path:
-            cmd.extend(["--python-path", python_path])
-
-        if working_directory:
-            cmd.extend(["--working-directory", working_directory])
-
-        if backend == "duckdb" and db_path:
-            cmd.extend(["--db-path", db_path])
-        elif backend == "bigquery" and project_id:
-            cmd.extend(["--project-id", project_id])
-
-        if output:
-            cmd.extend(["--output", output])
-
-        if quick:
-            info("Generating M4 MCP configuration...")
+    if skills:
+        selected_tools = _prompt_select_tools()
+        console.print()
+        info(f"Installing skills for: {', '.join(selected_tools)}")
+        skill_result = install_config_skills_service(selected_tools)
+        if isinstance(skill_result, CommandError):
+            warning(f"Skills installation failed: {skill_result.message}")
         else:
-            info("Starting interactive M4 MCP configuration...")
-
-        try:
-            result = subprocess.run(cmd, check=True, capture_output=False)
-            if result.returncode == 0:
-                # Persist backend and project_id only if explicitly provided
-                if backend_explicit:
-                    set_active_backend(backend)
-                if project_id_explicit:
-                    set_bigquery_project_id(project_id)
-                if quick:
-                    success("Configuration generated successfully!")
-        except subprocess.CalledProcessError as e:
-            error(f"Configuration generation failed with exit code {e.returncode}")
-            raise typer.Exit(code=e.returncode)
-        except FileNotFoundError:
-            error("Python interpreter not found. Please ensure Python is installed.")
-            raise typer.Exit(code=1)
-
-        # Install skills if requested (interactive tool selection)
-        if skills:
-            from m4.skills import AI_TOOLS, install_skills
-
-            selected_tools = _prompt_select_tools()
-            console.print()
-            info(f"Installing skills for: {', '.join(selected_tools)}")
-
-            try:
-                results = install_skills(tools=selected_tools)
-                for tool_name, paths in results.items():
-                    tool = AI_TOOLS[tool_name]
-                    for skill_path in paths:
-                        success(
-                            f"Installed skill: {skill_path.name} → {tool.display_name}"
-                        )
-            except Exception as e:
-                warning(f"Skills installation failed: {e}")
+            for item in skill_result.data["installed"]:
+                success(
+                    f"Installed skill: {item['skill']} -> {item['tool_display_name']}"
+                )
 
 
 if __name__ == "__main__":

--- a/src/m4/core/tools/notes.py
+++ b/src/m4/core/tools/notes.py
@@ -34,6 +34,42 @@ class NoteType(str, Enum):
     ALL = "all"
 
 
+MAX_NOTE_QUERY_LIMIT = 100
+MAX_SNIPPET_LENGTH = 10_000
+MAX_NOTE_LENGTH = 200_000
+KNOWN_NOTE_TYPES = {item.value for item in NoteType}
+
+
+def quote_sql_literal(value: str) -> str:
+    """Return a single-quoted SQL string literal with quotes escaped."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def validate_positive_int(value: int, *, name: str, maximum: int) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise QueryError(f"{name} must be an integer.")
+    if value <= 0:
+        raise QueryError(f"{name} must be positive.")
+    if value > maximum:
+        raise QueryError(f"{name} must be less than or equal to {maximum}.")
+    return value
+
+
+def validate_note_type(note_type: str) -> str:
+    normalized = note_type.lower().strip() if isinstance(note_type, str) else ""
+    if normalized not in KNOWN_NOTE_TYPES:
+        raise QueryError(
+            f"Invalid note_type '{note_type}'. Use 'discharge', 'radiology', or 'all'."
+        )
+    return normalized
+
+
+def validate_non_empty_text(value: str, *, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise QueryError(f"{name} must be a non-empty string.")
+    return value.strip()
+
+
 # Input models
 @dataclass
 class SearchNotesInput(ToolInput):
@@ -102,19 +138,24 @@ class SearchNotesTool:
             QueryError: If note_type is invalid
         """
         backend = context.backend if context else get_backend()
+        query = validate_non_empty_text(params.query, name="query")
+        note_type = validate_note_type(params.note_type)
+        limit = validate_positive_int(
+            params.limit, name="limit", maximum=MAX_NOTE_QUERY_LIMIT
+        )
+        snippet_length = validate_positive_int(
+            params.snippet_length,
+            name="snippet_length",
+            maximum=MAX_SNIPPET_LENGTH,
+        )
 
         # Determine which tables to search
-        tables_to_search = self._get_tables_for_type(params.note_type)
-
-        if not tables_to_search:
-            raise QueryError(
-                f"Invalid note_type '{params.note_type}'. "
-                "Use 'discharge', 'radiology', or 'all'."
-            )
+        tables_to_search = self._get_tables_for_type(note_type)
 
         results: dict[str, pd.DataFrame] = {}
         errors: list[str] = []
-        search_term = params.query.replace("'", "''")  # Escape single quotes
+        search_literal = quote_sql_literal(query)
+        search_like_literal = quote_sql_literal(f"%{query.lower()}%")
 
         for table in tables_to_search:
             # Build search query with snippet extraction
@@ -124,18 +165,18 @@ class SearchNotesTool:
                     note_id,
                     subject_id,
                     CASE
-                        WHEN STRPOS(LOWER(text), LOWER('{search_term}')) > 0 THEN
+                        WHEN STRPOS(LOWER(text), LOWER({search_literal})) > 0 THEN
                             SUBSTRING(
                                 text,
-                                GREATEST(1, STRPOS(LOWER(text), LOWER('{search_term}')) - {params.snippet_length // 2}),
-                                {params.snippet_length}
+                                GREATEST(1, STRPOS(LOWER(text), LOWER({search_literal})) - {snippet_length // 2}),
+                                {snippet_length}
                             )
-                        ELSE LEFT(text, {params.snippet_length})
+                        ELSE LEFT(text, {snippet_length})
                     END as snippet,
                     LENGTH(text) as note_length
                 FROM {table}
-                WHERE LOWER(text) LIKE '%{search_term.lower()}%'
-                LIMIT {params.limit}
+                WHERE LOWER(text) LIKE {search_like_literal}
+                LIMIT {limit}
             """
 
             result = (
@@ -154,8 +195,8 @@ class SearchNotesTool:
                 if context
                 else backend.get_backend_info(dataset)
             ),
-            "query": params.query,
-            "snippet_length": params.snippet_length,
+            "query": query,
+            "snippet_length": snippet_length,
             "results": results,
         }
         if errors:
@@ -223,9 +264,16 @@ class GetNoteTool:
             QueryError: If note not found
         """
         backend = context.backend if context else get_backend()
+        note_id = validate_non_empty_text(params.note_id, name="note_id")
+        max_length = params.max_length
+        if max_length is not None:
+            max_length = validate_positive_int(
+                max_length,
+                name="max_length",
+                maximum=MAX_NOTE_LENGTH,
+            )
 
-        # Note IDs contain the note type (e.g., "10000032_DS-1" for discharge)
-        note_id = params.note_id.replace("'", "''")
+        note_id_literal = quote_sql_literal(note_id)
 
         # Try both tables since we may not know which one contains the note
         errors: list[str] = []
@@ -237,7 +285,7 @@ class GetNoteTool:
                     text,
                     LENGTH(text) as note_length
                 FROM {table}
-                WHERE note_id = '{note_id}'
+                WHERE note_id = {note_id_literal}
                 LIMIT 1
             """
 
@@ -260,8 +308,8 @@ class GetNoteTool:
                 truncated = False
 
                 # Optionally truncate if max_length specified
-                if params.max_length and len(text) > params.max_length:
-                    text = text[: params.max_length]
+                if max_length and len(text) > max_length:
+                    text = text[:max_length]
                     truncated = True
 
                 return {
@@ -277,7 +325,7 @@ class GetNoteTool:
                     "truncated": truncated,
                 }
 
-        error_msg = f"Note '{params.note_id}' not found."
+        error_msg = f"Note '{note_id}' not found."
         if errors:
             error_msg += " Backend errors: " + "; ".join(errors)
         error_msg += (
@@ -334,14 +382,15 @@ class ListPatientNotesTool:
             QueryError: If note_type is invalid
         """
         backend = context.backend if context else get_backend()
+        note_type = validate_note_type(params.note_type)
+        limit = validate_positive_int(
+            params.limit, name="limit", maximum=MAX_NOTE_QUERY_LIMIT
+        )
+        subject_id = validate_positive_int(
+            params.subject_id, name="subject_id", maximum=9_999_999_999
+        )
 
-        tables_to_query = self._get_tables_for_type(params.note_type)
-
-        if not tables_to_query:
-            raise QueryError(
-                f"Invalid note_type '{params.note_type}'. "
-                "Use 'discharge', 'radiology', or 'all'."
-            )
+        tables_to_query = self._get_tables_for_type(note_type)
 
         notes: dict[str, pd.DataFrame] = {}
         errors: list[str] = []
@@ -356,8 +405,8 @@ class ListPatientNotesTool:
                     LENGTH(text) as note_length,
                     LEFT(text, 100) as preview
                 FROM {table}
-                WHERE subject_id = {params.subject_id}
-                LIMIT {params.limit}
+                WHERE subject_id = {subject_id}
+                LIMIT {limit}
             """
 
             result = (
@@ -376,7 +425,7 @@ class ListPatientNotesTool:
                 if context
                 else backend.get_backend_info(dataset)
             ),
-            "subject_id": params.subject_id,
+            "subject_id": subject_id,
             "notes": notes,
         }
         if errors:

--- a/src/m4/services/agent_env.py
+++ b/src/m4/services/agent_env.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+from m4.config import resolve_runtime_context
+from m4.core.datasets import DatasetRegistry
+from m4.services.results import CommandError
+
+
+@dataclass(frozen=True)
+class AgentEnvResult:
+    command: str
+    data: dict[str, Any]
+    context: dict[str, Any]
+    warnings: list[str]
+
+
+def build_agent_env_service(
+    *,
+    mode: str = "local",
+    dataset: str | None = None,
+    backend: str | None = None,
+    project_id: str | None = None,
+    include_paths: bool = False,
+) -> AgentEnvResult | CommandError:
+    if mode not in {"local", "protected"}:
+        return CommandError(
+            command="agent-env",
+            code="invalid_mode",
+            message=f"Unsupported mode '{mode}'.",
+            hint="Use --mode local or --mode protected.",
+        )
+
+    ctx = resolve_runtime_context(
+        dataset=dataset, backend=backend, path_disclosure=include_paths
+    )
+    env = {
+        "M4_HOME": str(ctx.home),
+        "M4_DATASET": ctx.dataset,
+        "M4_BACKEND": ctx.backend,
+        "M4_STUDY_ID": ctx.study_id,
+        "M4_SESSION_ID": ctx.session_id,
+        "M4_ACTOR": ctx.actor,
+        "M4_TELEMETRY_DIR": str(ctx.telemetry_dir),
+    }
+    if project_id or ctx.project_id:
+        env["M4_PROJECT_ID"] = project_id or ctx.project_id
+    if mode == "local":
+        env["M4_DATA_DIR"] = str(ctx.data_dir)
+
+    warnings: list[str] = []
+    if ctx.dataset and not DatasetRegistry.get(ctx.dataset):
+        warnings.append(f"Dataset '{ctx.dataset}' is not registered.")
+    if ctx.backend == "bigquery" and ctx.dataset:
+        ds = DatasetRegistry.get(ctx.dataset)
+        if ds and not ds.bigquery_dataset_ids:
+            warnings.append(
+                f"Dataset '{ctx.dataset}' is not available on the BigQuery backend."
+            )
+    if mode == "protected":
+        warnings.append(
+            "Protected mode omits M4_DATA_DIR; expose only an M4 service, socket, MCP server, or gateway to agents."
+        )
+
+    data = {
+        "mode": mode,
+        "environment": {key: value for key, value in env.items() if value is not None},
+        "path_recommendations": {
+            "python": sys.executable,
+            "cli": "m4",
+        },
+        "defaults": {
+            "dataset": ctx.dataset,
+            "backend": ctx.backend,
+        },
+        "telemetry_destination": str(ctx.telemetry_dir),
+        "raw_paths_hidden": not include_paths,
+        "recommended_commands": [
+            "m4 status --json --no-interactive",
+            "m4 list-datasets --json --no-interactive",
+            "m4 schema --dataset <dataset> --backend <backend> --json --no-interactive",
+            "m4 describe-table <table> --dataset <dataset> --backend <backend> --json --no-interactive",
+            "m4 query --dataset <dataset> --backend <backend> --sql <sql> --json --no-interactive",
+        ],
+    }
+
+    return AgentEnvResult(
+        command="agent-env",
+        data=data,
+        context=ctx.public_context(),
+        warnings=warnings,
+    )

--- a/src/m4/services/config.py
+++ b/src/m4/services/config.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from m4.config import (
+    get_active_backend,
+    get_bigquery_project_id,
+    set_active_backend,
+    set_bigquery_project_id,
+)
+from m4.mcp_client_configs.dynamic_mcp_config import MCPConfigGenerator
+from m4.mcp_client_configs.setup_claude_desktop import setup_claude_desktop
+from m4.services.results import CommandError, CommandResult
+
+
+@dataclass(frozen=True)
+class MCPConfigRequest:
+    client: str | None = None
+    backend: str | None = None
+    db_path: str | None = None
+    project_id: str | None = None
+    python_path: str | None = None
+    working_directory: str | None = None
+    server_name: str = "m4"
+    output: str | None = None
+    quick: bool = False
+
+
+def _resolve_backend_and_project(
+    request: MCPConfigRequest,
+) -> tuple[str, str | None, bool, bool, CommandError | None]:
+    backend_explicit = request.backend is not None
+    project_id_explicit = request.project_id is not None
+    backend = request.backend or get_active_backend()
+    project_id = request.project_id
+
+    if backend not in {"duckdb", "bigquery"}:
+        return (
+            backend,
+            project_id,
+            backend_explicit,
+            project_id_explicit,
+            CommandError(
+                command="config",
+                code="invalid_backend",
+                message="Unsupported backend. Use duckdb or bigquery.",
+            ),
+        )
+
+    if backend == "bigquery" and not project_id:
+        project_id = get_bigquery_project_id()
+
+    if backend_explicit:
+        if backend == "duckdb" and project_id:
+            return (
+                backend,
+                project_id,
+                backend_explicit,
+                project_id_explicit,
+                CommandError(
+                    command="config",
+                    code="invalid_option",
+                    message="--project-id can only be used with --backend bigquery",
+                ),
+            )
+        if backend == "bigquery" and request.db_path:
+            return (
+                backend,
+                project_id,
+                backend_explicit,
+                project_id_explicit,
+                CommandError(
+                    command="config",
+                    code="invalid_option",
+                    message="--db-path can only be used with --backend duckdb",
+                ),
+            )
+        if backend == "bigquery" and not project_id:
+            return (
+                backend,
+                project_id,
+                backend_explicit,
+                project_id_explicit,
+                CommandError(
+                    command="config",
+                    code="invalid_option",
+                    message="--project-id is required when using --backend bigquery",
+                ),
+            )
+
+    if backend == "bigquery" and not project_id:
+        return (
+            backend,
+            project_id,
+            backend_explicit,
+            project_id_explicit,
+            CommandError(
+                command="config",
+                code="project_id_required",
+                message=(
+                    "BigQuery backend requires a project ID. "
+                    "Set it with: m4 backend bigquery --project-id <ID>"
+                ),
+            ),
+        )
+
+    return backend, project_id, backend_explicit, project_id_explicit, None
+
+
+def _persist_explicit_config(
+    *,
+    backend: str,
+    project_id: str | None,
+    backend_explicit: bool,
+    project_id_explicit: bool,
+) -> None:
+    if backend_explicit:
+        set_active_backend(backend)
+    if project_id_explicit and project_id:
+        set_bigquery_project_id(project_id)
+
+
+def _install_skills_for_tools(tool_names: list[str]) -> list[dict[str, str]]:
+    from m4.skills import AI_TOOLS, install_skills
+
+    installed: list[dict[str, str]] = []
+    results = install_skills(tools=tool_names)
+    for tool_name, paths in results.items():
+        tool = AI_TOOLS[tool_name]
+        for skill_path in paths:
+            installed.append(
+                {
+                    "tool": tool_name,
+                    "tool_display_name": tool.display_name,
+                    "skill": skill_path.name,
+                    "path": str(skill_path),
+                }
+            )
+    return installed
+
+
+def install_config_skills_service(
+    tool_names: list[str],
+) -> CommandResult | CommandError:
+    try:
+        installed = _install_skills_for_tools(tool_names)
+    except Exception as exc:
+        return CommandError(
+            command="config skills",
+            code="skills_install_failed",
+            message=str(exc),
+        )
+    return CommandResult(command="config skills", data={"installed": installed})
+
+
+def configure_mcp_service(
+    request: MCPConfigRequest,
+) -> CommandResult | CommandError:
+    backend, project_id, backend_explicit, project_id_explicit, validation_error = (
+        _resolve_backend_and_project(request)
+    )
+    if validation_error:
+        return validation_error
+
+    if request.client == "claude":
+        db_path = None
+        if backend == "duckdb" and request.db_path:
+            db_path = str(Path(request.db_path).expanduser().resolve())
+
+        try:
+            configured = setup_claude_desktop(
+                backend=backend,
+                db_path=db_path,
+                project_id=project_id if backend == "bigquery" else None,
+            )
+        except Exception as exc:
+            return CommandError(
+                command="config",
+                code="claude_setup_failed",
+                message=str(exc),
+            )
+
+        if not configured:
+            return CommandError(
+                command="config",
+                code="claude_setup_failed",
+                message="Claude Desktop setup failed.",
+            )
+
+        _persist_explicit_config(
+            backend=backend,
+            project_id=project_id,
+            backend_explicit=backend_explicit,
+            project_id_explicit=project_id_explicit,
+        )
+        return CommandResult(
+            command="config",
+            data={
+                "client": "claude",
+                "backend": backend,
+                "project_id": project_id,
+                "status": "completed",
+            },
+        )
+
+    generator = MCPConfigGenerator()
+    try:
+        if request.quick:
+            config = generator.generate_config(
+                server_name=request.server_name,
+                python_path=request.python_path,
+                working_directory=request.working_directory,
+                backend=backend,
+                db_path=request.db_path if backend == "duckdb" else None,
+                project_id=project_id if backend == "bigquery" else None,
+                module_name="m4.mcp_server",
+            )
+        else:
+            config = generator.interactive_config()
+    except Exception as exc:
+        return CommandError(
+            command="config",
+            code="config_generation_failed",
+            message=str(exc),
+        )
+
+    json_output = json.dumps(config, indent=2)
+    output_path = None
+    if request.output:
+        output_path = str(Path(request.output).expanduser().resolve())
+        Path(output_path).write_text(json_output)
+
+    _persist_explicit_config(
+        backend=backend,
+        project_id=project_id,
+        backend_explicit=backend_explicit,
+        project_id_explicit=project_id_explicit,
+    )
+    return CommandResult(
+        command="config",
+        data={
+            "client": request.client or "generic",
+            "backend": backend,
+            "project_id": project_id,
+            "status": "completed",
+            "config": config,
+            "config_json": json_output,
+            "output": output_path,
+            "quick": request.quick,
+        },
+    )
+
+
+def summarize_generated_config(config: dict[str, Any], backend: str) -> list[str]:
+    server_name = next(iter(config["mcpServers"].keys()))
+    server_config = config["mcpServers"][server_name]
+    lines = [
+        "Configuration Summary:",
+        f"Server name: {server_name}",
+        f"Python path: {server_config['command']}",
+        f"Working directory: {server_config['cwd']}",
+        f"Backend: {backend} (from m4_data/config.json)",
+    ]
+    env = server_config["env"]
+    if "M4_DB_PATH" in env:
+        lines.append(f"Database path: {env['M4_DB_PATH']}")
+    if "M4_PROJECT_ID" in env:
+        lines.append(f"Project ID: {env['M4_PROJECT_ID']}")
+    return lines

--- a/src/m4/services/init_derived.py
+++ b/src/m4/services/init_derived.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from m4.config import get_active_backend, get_default_database_path, logger
+from m4.core.datasets import DatasetRegistry
+from m4.core.derived.builtins import list_builtins
+from m4.core.derived.materializer import (
+    get_derived_table_count,
+    materialize_all,
+)
+from m4.services.events import EventReporter
+from m4.services.results import CommandError, CommandResult
+
+
+def init_derived_service(
+    dataset_name: str,
+    *,
+    list_only: bool = False,
+    force: bool = False,
+    event_reporter: EventReporter | None = None,
+) -> CommandResult | CommandError:
+    dataset_key = dataset_name.lower()
+    ds = DatasetRegistry.get(dataset_key)
+
+    if not ds:
+        supported = ", ".join(d.name for d in DatasetRegistry.list_all())
+        return CommandError(
+            command="init-derived",
+            code="dataset_not_found",
+            message=f"Dataset '{dataset_name}' is not supported or not configured.",
+            hint=f"Supported datasets: {supported}",
+        )
+
+    if dataset_key in ("mimic-iv-demo",):
+        return CommandError(
+            command="init-derived",
+            code="derived_not_supported",
+            message=f"Derived tables are not supported for '{dataset_key}'.",
+            hint=(
+                "The demo dataset has only 100 patients; many derived concepts "
+                "produce empty or unreliable results. Use the full mimic-iv dataset."
+            ),
+        )
+
+    if get_active_backend() == "bigquery":
+        return CommandResult(
+            command="init-derived",
+            data={
+                "dataset": dataset_key,
+                "status": "skipped",
+                "reason": "bigquery_derived_tables_available",
+                "created_tables": [],
+                "table_count": 0,
+            },
+        )
+
+    if list_only:
+        try:
+            names = list_builtins(dataset_key)
+        except ValueError as exc:
+            return CommandError(
+                command="init-derived",
+                code="derived_not_supported",
+                message=str(exc),
+            )
+        return CommandResult(
+            command="init-derived",
+            data={
+                "dataset": dataset_key,
+                "status": "listed",
+                "tables": names,
+                "table_count": len(names),
+            },
+        )
+
+    db_path = get_default_database_path(dataset_key)
+    if not db_path or not db_path.exists():
+        return CommandError(
+            command="init-derived",
+            code="database_not_found",
+            message=f"No DuckDB database found for '{dataset_key}'.",
+            hint=f"Initialize first: m4 init {dataset_key}",
+        )
+
+    existing_count = get_derived_table_count(db_path)
+    if existing_count > 0 and not force:
+        return CommandResult(
+            command="init-derived",
+            data={
+                "dataset": dataset_key,
+                "status": "skipped",
+                "reason": "already_materialized",
+                "database": str(db_path),
+                "existing_table_count": existing_count,
+                "created_tables": [],
+                "table_count": 0,
+            },
+        )
+
+    try:
+        created = materialize_all(dataset_key, db_path, event_reporter=event_reporter)
+    except ValueError as exc:
+        return CommandError(
+            command="init-derived",
+            code="derived_not_supported",
+            message=str(exc),
+        )
+    except RuntimeError as exc:
+        return CommandError(
+            command="init-derived",
+            code="derived_materialization_failed",
+            message=str(exc),
+            hint=(
+                "If the database is locked, stop MCP servers or notebooks using it."
+                if "locked by another process" in str(exc)
+                else None
+            ),
+        )
+    except Exception as exc:
+        logger.error("Derived table materialization error: %s", exc, exc_info=True)
+        return CommandError(
+            command="init-derived",
+            code="derived_materialization_failed",
+            message=f"Materialization failed: {exc}",
+        )
+
+    return CommandResult(
+        command="init-derived",
+        data={
+            "dataset": dataset_key,
+            "status": "completed",
+            "database": str(db_path),
+            "created_tables": created,
+            "table_count": len(created),
+        },
+    )

--- a/tests/core/derived/test_cli.py
+++ b/tests/core/derived/test_cli.py
@@ -31,7 +31,7 @@ def inject_version(monkeypatch):
 class TestInitDerivedList:
     """Tests for m4 init-derived --list."""
 
-    @patch("m4.cli.get_active_backend", return_value="duckdb")
+    @patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
     def test_list_mimic_iv_shows_tables(self, mock_backend):
         result = runner.invoke(app, ["init-derived", "mimic-iv", "--list"])
         assert result.exit_code == 0
@@ -39,13 +39,13 @@ class TestInitDerivedList:
         assert "sepsis3" in result.stdout
         assert "age" in result.stdout
 
-    @patch("m4.cli.get_active_backend", return_value="duckdb")
+    @patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
     def test_list_mimic_iv_shows_count(self, mock_backend):
         result = runner.invoke(app, ["init-derived", "mimic-iv", "--list"])
         assert result.exit_code == 0
         assert "tables" in result.stdout
 
-    @patch("m4.cli.get_active_backend", return_value="duckdb")
+    @patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
     def test_list_json_outputs_tables(self, mock_backend):
         result = runner.invoke(app, ["init-derived", "mimic-iv", "--list", "--json"])
         assert result.exit_code == 0
@@ -71,21 +71,21 @@ class TestInitDerivedErrors:
             "Not Supported" in result.stdout or "not supported" in result.stdout.lower()
         )
 
-    @patch("m4.cli.get_active_backend", return_value="bigquery")
+    @patch("m4.services.init_derived.get_active_backend", return_value="bigquery")
     def test_bigquery_backend_skips(self, mock_backend):
         result = runner.invoke(app, ["init-derived", "mimic-iv"])
         assert result.exit_code == 0
         assert "BigQuery" in result.stdout
         assert "already available" in result.stdout
 
-    @patch("m4.cli.get_active_backend", return_value="duckdb")
-    @patch("m4.cli.get_default_database_path", return_value=None)
+    @patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
+    @patch("m4.services.init_derived.get_default_database_path", return_value=None)
     def test_missing_database_fails(self, mock_db_path, mock_backend):
         result = runner.invoke(app, ["init-derived", "mimic-iv"])
         assert result.exit_code == 1
         assert "Not Found" in result.stdout or "not found" in result.stdout.lower()
 
-    @patch("m4.cli.get_active_backend", return_value="duckdb")
+    @patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
     def test_eicu_not_supported(self, mock_backend):
         result = runner.invoke(app, ["init-derived", "eicu"])
         assert result.exit_code == 1
@@ -94,10 +94,10 @@ class TestInitDerivedErrors:
 class TestInitDerivedSkipForce:
     """Tests for skip/force behavior when derived tables already exist."""
 
-    @patch("m4.cli.get_active_backend", return_value="duckdb")
-    @patch("m4.cli.get_derived_table_count", return_value=42)
-    @patch("m4.cli.materialize_all")
-    @patch("m4.cli.get_default_database_path")
+    @patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
+    @patch("m4.services.init_derived.get_derived_table_count", return_value=42)
+    @patch("m4.services.init_derived.materialize_all")
+    @patch("m4.services.init_derived.get_default_database_path")
     def test_skips_when_derived_exist(
         self, mock_db_path, mock_materialize, mock_count, mock_backend, tmp_path
     ):
@@ -111,10 +111,10 @@ class TestInitDerivedSkipForce:
         assert "42 tables" in result.stdout
         mock_materialize.assert_not_called()
 
-    @patch("m4.cli.get_active_backend", return_value="duckdb")
-    @patch("m4.cli.get_derived_table_count", return_value=42)
-    @patch("m4.cli.materialize_all")
-    @patch("m4.cli.get_default_database_path")
+    @patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
+    @patch("m4.services.init_derived.get_derived_table_count", return_value=42)
+    @patch("m4.services.init_derived.materialize_all")
+    @patch("m4.services.init_derived.get_default_database_path")
     def test_force_rematerializes(
         self, mock_db_path, mock_materialize, mock_count, mock_backend, tmp_path
     ):
@@ -125,12 +125,14 @@ class TestInitDerivedSkipForce:
 
         result = runner.invoke(app, ["init-derived", "mimic-iv", "--force"])
         assert result.exit_code == 0
-        mock_materialize.assert_called_once_with("mimic-iv", db_file)
+        mock_materialize.assert_called_once_with(
+            "mimic-iv", db_file, event_reporter=None
+        )
 
-    @patch("m4.cli.get_active_backend", return_value="duckdb")
-    @patch("m4.cli.get_derived_table_count", return_value=0)
-    @patch("m4.cli.materialize_all")
-    @patch("m4.cli.get_default_database_path")
+    @patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
+    @patch("m4.services.init_derived.get_derived_table_count", return_value=0)
+    @patch("m4.services.init_derived.materialize_all")
+    @patch("m4.services.init_derived.get_default_database_path")
     def test_no_skip_when_no_derived(
         self, mock_db_path, mock_materialize, mock_count, mock_backend, tmp_path
     ):
@@ -141,16 +143,18 @@ class TestInitDerivedSkipForce:
 
         result = runner.invoke(app, ["init-derived", "mimic-iv"])
         assert result.exit_code == 0
-        mock_materialize.assert_called_once_with("mimic-iv", db_file)
+        mock_materialize.assert_called_once_with(
+            "mimic-iv", db_file, event_reporter=None
+        )
 
 
 class TestInitDerivedMaterialize:
     """Tests for successful materialization (mocked)."""
 
-    @patch("m4.cli.get_active_backend", return_value="duckdb")
-    @patch("m4.cli.get_derived_table_count", return_value=0)
-    @patch("m4.cli.materialize_all")
-    @patch("m4.cli.get_default_database_path")
+    @patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
+    @patch("m4.services.init_derived.get_derived_table_count", return_value=0)
+    @patch("m4.services.init_derived.materialize_all")
+    @patch("m4.services.init_derived.get_default_database_path")
     def test_successful_materialization(
         self, mock_db_path, mock_materialize, mock_count, mock_backend, tmp_path
     ):
@@ -161,12 +165,14 @@ class TestInitDerivedMaterialize:
 
         result = runner.invoke(app, ["init-derived", "mimic-iv"])
         assert result.exit_code == 0
-        mock_materialize.assert_called_once_with("mimic-iv", db_file)
+        mock_materialize.assert_called_once_with(
+            "mimic-iv", db_file, event_reporter=None
+        )
 
-    @patch("m4.cli.get_active_backend", return_value="duckdb")
-    @patch("m4.cli.get_derived_table_count", return_value=0)
-    @patch("m4.cli.materialize_all")
-    @patch("m4.cli.get_default_database_path")
+    @patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
+    @patch("m4.services.init_derived.get_derived_table_count", return_value=0)
+    @patch("m4.services.init_derived.materialize_all")
+    @patch("m4.services.init_derived.get_default_database_path")
     def test_ndjson_wraps_materialization_result(
         self, mock_db_path, mock_materialize, mock_count, mock_backend, tmp_path
     ):
@@ -192,12 +198,13 @@ class TestInitDerivedMaterialize:
             "mimic-iv", db_file, event_reporter=ANY
         )
 
-    @patch("m4.cli.get_active_backend", return_value="duckdb")
-    @patch("m4.cli.get_derived_table_count", return_value=0)
+    @patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
+    @patch("m4.services.init_derived.get_derived_table_count", return_value=0)
     @patch(
-        "m4.cli.materialize_all", side_effect=ValueError("No built-in derived tables")
+        "m4.services.init_derived.materialize_all",
+        side_effect=ValueError("No built-in derived tables"),
     )
-    @patch("m4.cli.get_default_database_path")
+    @patch("m4.services.init_derived.get_default_database_path")
     def test_value_error_handled(
         self, mock_db_path, mock_materialize, mock_count, mock_backend, tmp_path
     ):
@@ -208,10 +215,13 @@ class TestInitDerivedMaterialize:
         result = runner.invoke(app, ["init-derived", "mimic-iv"])
         assert result.exit_code == 1
 
-    @patch("m4.cli.get_active_backend", return_value="duckdb")
-    @patch("m4.cli.get_derived_table_count", return_value=0)
-    @patch("m4.cli.materialize_all", side_effect=RuntimeError("SQL failed"))
-    @patch("m4.cli.get_default_database_path")
+    @patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
+    @patch("m4.services.init_derived.get_derived_table_count", return_value=0)
+    @patch(
+        "m4.services.init_derived.materialize_all",
+        side_effect=RuntimeError("SQL failed"),
+    )
+    @patch("m4.services.init_derived.get_default_database_path")
     def test_runtime_error_handled(
         self, mock_db_path, mock_materialize, mock_count, mock_backend, tmp_path
     ):

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -13,24 +13,24 @@ class TestIsSafeQuery:
 
     def test_simple_select(self):
         """Simple SELECT queries should be safe."""
-        is_safe, msg = is_safe_query("SELECT * FROM patients LIMIT 10")
+        is_safe, _msg = is_safe_query("SELECT * FROM patients LIMIT 10")
         assert is_safe is True
 
     def test_select_with_where(self):
         """SELECT with WHERE clause should be safe."""
-        is_safe, msg = is_safe_query("SELECT * FROM patients WHERE subject_id = 12345")
+        is_safe, _msg = is_safe_query("SELECT * FROM patients WHERE subject_id = 12345")
         assert is_safe is True
 
     def test_select_with_join(self):
         """SELECT with JOIN should be safe."""
-        is_safe, msg = is_safe_query(
+        is_safe, _msg = is_safe_query(
             "SELECT p.*, a.* FROM patients p JOIN admissions a ON p.subject_id = a.subject_id"
         )
         assert is_safe is True
 
     def test_pragma_allowed(self):
         """PRAGMA statements should be allowed."""
-        is_safe, msg = is_safe_query("PRAGMA table_info(patients)")
+        is_safe, _msg = is_safe_query("PRAGMA table_info(patients)")
         assert is_safe is True
 
     def test_empty_query(self):
@@ -41,7 +41,7 @@ class TestIsSafeQuery:
 
     def test_whitespace_only(self):
         """Whitespace-only queries should fail."""
-        is_safe, msg = is_safe_query("   ")
+        is_safe, _msg = is_safe_query("   ")
         assert is_safe is False
 
     def test_multiple_statements(self):
@@ -52,22 +52,22 @@ class TestIsSafeQuery:
 
     def test_insert_blocked(self):
         """INSERT statements should be blocked."""
-        is_safe, msg = is_safe_query("INSERT INTO patients VALUES (1)")
+        is_safe, _msg = is_safe_query("INSERT INTO patients VALUES (1)")
         assert is_safe is False
 
     def test_update_blocked(self):
         """UPDATE statements should be blocked."""
-        is_safe, msg = is_safe_query("UPDATE patients SET name = 'test'")
+        is_safe, _msg = is_safe_query("UPDATE patients SET name = 'test'")
         assert is_safe is False
 
     def test_delete_blocked(self):
         """DELETE statements should be blocked."""
-        is_safe, msg = is_safe_query("DELETE FROM patients")
+        is_safe, _msg = is_safe_query("DELETE FROM patients")
         assert is_safe is False
 
     def test_drop_blocked(self):
         """DROP statements should be blocked."""
-        is_safe, msg = is_safe_query("DROP TABLE patients")
+        is_safe, _msg = is_safe_query("DROP TABLE patients")
         assert is_safe is False
 
     def test_injection_1_equals_1(self):
@@ -78,7 +78,7 @@ class TestIsSafeQuery:
 
     def test_injection_or_1_1(self):
         """OR 1=1 injection should be blocked."""
-        is_safe, msg = is_safe_query(
+        is_safe, _msg = is_safe_query(
             "SELECT * FROM patients WHERE subject_id = 1 OR 1=1"
         )
         assert is_safe is False
@@ -98,7 +98,7 @@ class TestIsSafeQuery:
     def test_suspicious_admin_standalone(self):
         """Queries with standalone ADMIN keyword should be blocked."""
         # Standalone ADMIN is blocked (word boundary match)
-        is_safe, msg = is_safe_query("SELECT * FROM ADMIN")
+        is_safe, _msg = is_safe_query("SELECT * FROM ADMIN")
         assert is_safe is False
 
     def test_admin_in_compound_name_allowed(self):
@@ -107,12 +107,12 @@ class TestIsSafeQuery:
         Word boundary matching allows 'admin_users' but blocks standalone 'ADMIN'.
         This prevents false positives on legitimate medical database columns.
         """
-        is_safe, msg = is_safe_query("SELECT * FROM admin_users")
+        is_safe, _msg = is_safe_query("SELECT * FROM admin_users")
         assert is_safe is True  # admin_users is a valid table name
 
     def test_case_insensitive_blocking(self):
         """Injection patterns should be case-insensitive."""
-        is_safe, msg = is_safe_query("SELECT * FROM patients WHERE 1=1")
+        is_safe, _msg = is_safe_query("SELECT * FROM patients WHERE 1=1")
         assert is_safe is False
 
 
@@ -131,7 +131,7 @@ class TestIsSafeQueryAdvancedInjection:
         for medical data security.
         """
         # Comments alone don't make a query unsafe
-        is_safe, msg = is_safe_query(
+        is_safe, _msg = is_safe_query(
             "SELECT * FROM patients WHERE id = 100 -- comment here"
         )
         assert is_safe is True  # This is valid SQL with a comment
@@ -147,7 +147,7 @@ class TestIsSafeQueryAdvancedInjection:
 
     def test_union_injection_information_schema(self):
         """Test UNION injection targeting system tables."""
-        is_safe, msg = is_safe_query(
+        is_safe, _msg = is_safe_query(
             "SELECT * FROM patients UNION SELECT * FROM information_schema.tables"
         )
         # This is valid SQL for schema introspection, but union with patients is odd
@@ -160,7 +160,7 @@ class TestIsSafeQueryAdvancedInjection:
         Word boundary matching allows 'admin_users' and 'user_id' since
         they are compound names, not standalone suspicious keywords.
         """
-        is_safe, msg = is_safe_query(
+        is_safe, _msg = is_safe_query(
             "SELECT * FROM patients WHERE id IN (SELECT user_id FROM admin_users)"
         )
         # Compound names like admin_users and user_id are allowed
@@ -177,7 +177,7 @@ class TestIsSafeQueryAdvancedInjection:
     def test_hex_encoded_attack(self):
         """Test hex-encoded injection patterns."""
         # Hex encoding of 'DROP' is 0x44524F50
-        is_safe, msg = is_safe_query("SELECT * FROM patients WHERE name = 0x44524F50")
+        is_safe, _msg = is_safe_query("SELECT * FROM patients WHERE name = 0x44524F50")
         # This is valid SQL, just selecting by hex value
         assert is_safe is True
 
@@ -255,7 +255,7 @@ class TestIsSafeQueryAdvancedInjection:
             "SELECT session_cookie FROM tokens",  # session_cookie is compound
         ]
         for query in allowed_columns:
-            is_safe, msg = is_safe_query(query)
+            is_safe, _msg = is_safe_query(query)
             assert is_safe is True, f"Compound name query should be allowed: {query}"
 
     def test_standalone_credential_names_blocked(self):
@@ -267,7 +267,7 @@ class TestIsSafeQueryAdvancedInjection:
             "SELECT AUTH FROM tokens",  # AUTH standalone
         ]
         for query in blocked_queries:
-            is_safe, msg = is_safe_query(query)
+            is_safe, _msg = is_safe_query(query)
             assert is_safe is False, f"Standalone keyword should be blocked: {query}"
 
     def test_case_variations_bypass(self):
@@ -283,7 +283,7 @@ class TestIsSafeQueryAdvancedInjection:
             "select * from patients where 1=1",
         ]
         for query in blocked_variations:
-            is_safe, msg = is_safe_query(query)
+            is_safe, _msg = is_safe_query(query)
             assert is_safe is False, f"Case variation should be blocked: {query}"
 
         # Note: '1 = 1' with spaces may not be caught by current regex
@@ -292,14 +292,14 @@ class TestIsSafeQueryAdvancedInjection:
     def test_valid_medical_query_with_numbers(self):
         """Test that legitimate medical queries with numbers pass."""
         # Legitimate query comparing lab values
-        is_safe, msg = is_safe_query(
+        is_safe, _msg = is_safe_query(
             "SELECT * FROM labevents WHERE valuenum > 100 AND valuenum < 200"
         )
         assert is_safe is True
 
     def test_valid_join_query(self):
         """Test that legitimate JOIN queries pass."""
-        is_safe, msg = is_safe_query(
+        is_safe, _msg = is_safe_query(
             """
             SELECT p.subject_id, a.hadm_id, l.value
             FROM patients p
@@ -313,7 +313,7 @@ class TestIsSafeQueryAdvancedInjection:
 
     def test_valid_aggregate_query(self):
         """Test that legitimate aggregate queries pass."""
-        is_safe, msg = is_safe_query(
+        is_safe, _msg = is_safe_query(
             """
             SELECT race, COUNT(*) as count, AVG(anchor_age) as avg_age
             FROM hosp_admissions
@@ -323,6 +323,36 @@ class TestIsSafeQueryAdvancedInjection:
             """
         )
         assert is_safe is True
+
+    def test_common_clinical_derived_table_query_allowed(self):
+        """Joins against derived concept tables should stay allowed."""
+        is_safe, msg = is_safe_query(
+            """
+            SELECT s.stay_id, s.sofa_24hours, k.aki_stage
+            FROM mimiciv_derived.sofa s
+            JOIN mimiciv_derived.kdigo_stages k USING (stay_id)
+            WHERE s.sofa_24hours >= 2
+            ORDER BY s.sofa_24hours DESC
+            LIMIT 25
+            """
+        )
+        assert is_safe is True, msg
+
+    def test_common_clinical_time_window_query_allowed(self):
+        """Clinical queries often filter by relative chart times."""
+        is_safe, msg = is_safe_query(
+            """
+            SELECT ce.subject_id, ce.stay_id, AVG(ce.valuenum) AS mean_hr
+            FROM mimiciv_icu.chartevents ce
+            WHERE ce.itemid = 220045
+              AND ce.charttime >= TIMESTAMP '2160-01-01 00:00:00'
+              AND ce.charttime < TIMESTAMP '2160-01-02 00:00:00'
+            GROUP BY ce.subject_id, ce.stay_id
+            HAVING AVG(ce.valuenum) > 100
+            LIMIT 100
+            """
+        )
+        assert is_safe is True, msg
 
 
 class TestFormatErrorWithGuidance:
@@ -456,7 +486,7 @@ class TestIsSafeQueryRobustness:
 
     def test_cte_queries_allowed(self):
         """Common Table Expressions (WITH ... AS) are safe."""
-        is_safe, msg = is_safe_query(
+        is_safe, _msg = is_safe_query(
             "WITH cohort AS (SELECT subject_id FROM patients) "
             "SELECT * FROM cohort LIMIT 10"
         )
@@ -464,7 +494,7 @@ class TestIsSafeQueryRobustness:
 
     def test_window_functions_allowed(self):
         """Window functions are legitimate clinical analysis SQL."""
-        is_safe, msg = is_safe_query(
+        is_safe, _msg = is_safe_query(
             "SELECT subject_id, ROW_NUMBER() OVER (PARTITION BY subject_id ORDER BY charttime) "
             "FROM labevents LIMIT 10"
         )
@@ -472,7 +502,7 @@ class TestIsSafeQueryRobustness:
 
     def test_subquery_in_select_allowed(self):
         """Subqueries in SELECT list are legitimate."""
-        is_safe, msg = is_safe_query(
+        is_safe, _msg = is_safe_query(
             "SELECT subject_id, "
             "(SELECT COUNT(*) FROM admissions a WHERE a.subject_id = p.subject_id) "
             "FROM patients p LIMIT 10"

--- a/tests/core/tools/test_notes.py
+++ b/tests/core/tools/test_notes.py
@@ -26,6 +26,8 @@ from m4.core.tools.notes import (
     ListPatientNotesTool,
     SearchNotesInput,
     SearchNotesTool,
+    quote_sql_literal,
+    validate_positive_int,
 )
 
 
@@ -227,6 +229,43 @@ class TestSearchNotesTool:
 
             sql_arg = mock_backend.execute_query.call_args[0][0]
             assert "patient''s condition" in sql_arg
+
+    def test_invoke_empty_query_raises(self, notes_dataset, mock_backend):
+        with patch(
+            "m4.core.tools.notes.get_backend",
+            return_value=mock_backend,
+        ):
+            tool = SearchNotesTool()
+            params = SearchNotesInput(query="")
+
+            with pytest.raises(QueryError, match="query must be a non-empty string"):
+                tool.invoke(notes_dataset, params)
+
+    @pytest.mark.parametrize("limit", [0, -1, 101])
+    def test_invoke_rejects_bad_limit(self, notes_dataset, mock_backend, limit):
+        with patch(
+            "m4.core.tools.notes.get_backend",
+            return_value=mock_backend,
+        ):
+            tool = SearchNotesTool()
+            params = SearchNotesInput(query="sepsis", limit=limit)
+
+            with pytest.raises(QueryError, match="limit"):
+                tool.invoke(notes_dataset, params)
+
+    @pytest.mark.parametrize("snippet_length", [0, -10, 10001])
+    def test_invoke_rejects_bad_snippet_length(
+        self, notes_dataset, mock_backend, snippet_length
+    ):
+        with patch(
+            "m4.core.tools.notes.get_backend",
+            return_value=mock_backend,
+        ):
+            tool = SearchNotesTool()
+            params = SearchNotesInput(query="sepsis", snippet_length=snippet_length)
+
+            with pytest.raises(QueryError, match="snippet_length"):
+                tool.invoke(notes_dataset, params)
 
     def test_invoke_sql_contains_search_term_and_limit(
         self, notes_dataset, mock_backend
@@ -516,6 +555,31 @@ class TestGetNoteTool:
             sql_arg = mock_backend.execute_query.call_args[0][0]
             assert "10000032_DS-1''; DROP TABLE--" in sql_arg
 
+    def test_invoke_empty_note_id_raises(self, notes_dataset, mock_backend):
+        with patch(
+            "m4.core.tools.notes.get_backend",
+            return_value=mock_backend,
+        ):
+            tool = GetNoteTool()
+            params = GetNoteInput(note_id="")
+
+            with pytest.raises(QueryError, match="note_id must be a non-empty string"):
+                tool.invoke(notes_dataset, params)
+
+    @pytest.mark.parametrize("max_length", [0, -1, 200001])
+    def test_invoke_rejects_bad_max_length(
+        self, notes_dataset, mock_backend, max_length
+    ):
+        with patch(
+            "m4.core.tools.notes.get_backend",
+            return_value=mock_backend,
+        ):
+            tool = GetNoteTool()
+            params = GetNoteInput(note_id="10001_DS-1", max_length=max_length)
+
+            with pytest.raises(QueryError, match="max_length"):
+                tool.invoke(notes_dataset, params)
+
     def test_compatibility(self, notes_dataset, tabular_only_dataset):
         """Test compatibility with NOTES and TABULAR-only datasets."""
         tool = GetNoteTool()
@@ -619,6 +683,18 @@ class TestListPatientNotesTool:
             params = ListPatientNotesInput(subject_id=10001, note_type="invalid")
 
             with pytest.raises(QueryError, match="Invalid note_type"):
+                tool.invoke(notes_dataset, params)
+
+    @pytest.mark.parametrize("limit", [0, -1, 101])
+    def test_invoke_rejects_bad_limit(self, notes_dataset, mock_backend, limit):
+        with patch(
+            "m4.core.tools.notes.get_backend",
+            return_value=mock_backend,
+        ):
+            tool = ListPatientNotesTool()
+            params = ListPatientNotesInput(subject_id=10001, limit=limit)
+
+            with pytest.raises(QueryError, match="limit"):
                 tool.invoke(notes_dataset, params)
 
     def test_invoke_empty_results(self, notes_dataset, mock_backend):
@@ -775,3 +851,14 @@ class TestNoteToolProtocolConformance:
 
         for tool in tools:
             assert Modality.NOTES in tool.required_modalities
+
+
+class TestSqlHelpers:
+    def test_quote_sql_literal_escapes_single_quotes(self):
+        assert quote_sql_literal("patient's") == "'patient''s'"
+
+    def test_validate_positive_int_rejects_bool_and_bounds(self):
+        with pytest.raises(QueryError):
+            validate_positive_int(True, name="limit", maximum=10)
+        with pytest.raises(QueryError):
+            validate_positive_int(11, name="limit", maximum=10)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,4 @@
 import json
-import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -220,7 +219,7 @@ def test_config_validation_bigquery_with_db_path():
     assert "db-path can only be used with --backend duckdb" in result.output
 
 
-@patch("m4.cli.get_bigquery_project_id", return_value=None)
+@patch("m4.services.config.get_bigquery_project_id", return_value=None)
 def test_config_validation_bigquery_requires_project_id(mock_get_project):
     """Test that bigquery backend requires project-id parameter."""
     result = runner.invoke(app, ["config", "claude", "--backend", "bigquery"])
@@ -240,86 +239,64 @@ def test_config_validation_duckdb_with_project_id():
     assert "project-id can only be used with --backend bigquery" in result.output
 
 
-@patch("subprocess.run")
-@patch("m4.cli.get_active_backend", return_value="duckdb")
-def test_config_claude_success(mock_backend, mock_subprocess):
+@patch("m4.services.config.setup_claude_desktop", return_value=True)
+@patch("m4.services.config.get_active_backend", return_value="duckdb")
+def test_config_claude_success(mock_backend, mock_setup):
     """Test successful Claude Desktop configuration."""
-    mock_subprocess.return_value = MagicMock(returncode=0)
-
     result = runner.invoke(app, ["config", "claude"])
     assert result.exit_code == 0
     assert "Claude Desktop configuration completed" in result.stdout
 
-    mock_subprocess.assert_called_once()
-    call_args = mock_subprocess.call_args[0][0]
-    # correct script should be invoked
-    assert "setup_claude_desktop.py" in call_args[1]
+    mock_setup.assert_called_once_with(backend="duckdb", db_path=None, project_id=None)
 
 
-@patch("subprocess.run")
-@patch("m4.cli.get_active_backend", return_value="duckdb")
-def test_config_universal_quick_mode(mock_backend, mock_subprocess):
+@patch("m4.services.config.MCPConfigGenerator")
+@patch("m4.services.config.get_active_backend", return_value="duckdb")
+def test_config_universal_quick_mode(mock_backend, mock_generator_cls):
     """Test universal config generator in quick mode."""
-    mock_subprocess.return_value = MagicMock(returncode=0)
+    mock_generator = mock_generator_cls.return_value
+    mock_generator.generate_config.return_value = {
+        "mcpServers": {
+            "m4": {
+                "command": "python",
+                "args": ["-m", "m4.mcp_server"],
+                "cwd": ".",
+                "env": {},
+            }
+        }
+    }
 
     result = runner.invoke(app, ["config", "--quick"])
     assert result.exit_code == 0
     assert "Generating M4 MCP configuration" in result.stdout
 
-    mock_subprocess.assert_called_once()
-    call_args = mock_subprocess.call_args[0][0]
-    assert "dynamic_mcp_config.py" in call_args[1]
-    assert "--quick" in call_args
+    mock_generator.generate_config.assert_called_once()
 
 
-@patch("subprocess.run")
-@patch("m4.cli.get_active_backend", return_value="duckdb")
-def test_config_script_failure(mock_backend, mock_subprocess):
+@patch("m4.services.config.setup_claude_desktop", return_value=False)
+@patch("m4.services.config.get_active_backend", return_value="duckdb")
+def test_config_script_failure(mock_backend, mock_setup):
     """Test error handling when config script fails."""
-    mock_subprocess.side_effect = subprocess.CalledProcessError(1, "cmd")
-
     result = runner.invoke(app, ["config", "claude"])
-    # command should return failure exit code when subprocess fails
     assert result.exit_code == 1
-    # Just verify that the command failed with the right exit code
-    # The specific error message may vary
 
 
-@patch("subprocess.run")
-@patch("m4.cli.get_active_backend", return_value="duckdb")
-@patch("m4.cli.get_default_database_path")
-@patch("m4.cli.get_active_dataset")
-def test_config_claude_infers_db_path_demo(
-    mock_active, mock_get_default, mock_backend, mock_subprocess
-):
-    mock_active.return_value = None  # unset -> default to demo
-    mock_get_default.return_value = Path("/tmp/inferred-demo.duckdb")
-    mock_subprocess.return_value = MagicMock(returncode=0)
-
+@patch("m4.services.config.setup_claude_desktop", return_value=True)
+@patch("m4.services.config.get_active_backend", return_value="duckdb")
+def test_config_claude_infers_db_path_demo(mock_backend, mock_setup):
     result = runner.invoke(app, ["config", "claude"])
     assert result.exit_code == 0
 
-    # subprocess run should NOT be called with inferred --db-path (dynamic resolution)
-    call_args = mock_subprocess.call_args[0][0]
-    assert "--db-path" not in call_args
+    mock_setup.assert_called_once_with(backend="duckdb", db_path=None, project_id=None)
 
 
-@patch("subprocess.run")
-@patch("m4.cli.get_active_backend", return_value="duckdb")
-@patch("m4.cli.get_default_database_path")
-@patch("m4.cli.get_active_dataset")
-def test_config_claude_infers_db_path_full(
-    mock_active, mock_get_default, mock_backend, mock_subprocess
-):
-    mock_active.return_value = "mimic-iv"
-    mock_get_default.return_value = Path("/tmp/inferred-full.duckdb")
-    mock_subprocess.return_value = MagicMock(returncode=0)
-
+@patch("m4.services.config.setup_claude_desktop", return_value=True)
+@patch("m4.services.config.get_active_backend", return_value="duckdb")
+def test_config_claude_infers_db_path_full(mock_backend, mock_setup):
     result = runner.invoke(app, ["config", "claude"])
     assert result.exit_code == 0
 
-    call_args = mock_subprocess.call_args[0][0]
-    assert "--db-path" not in call_args
+    mock_setup.assert_called_once_with(backend="duckdb", db_path=None, project_id=None)
 
 
 @patch("m4.services.use.set_active_dataset")
@@ -1140,15 +1117,13 @@ def test_backend_bigquery_without_flag_uses_config_project_id(
 # ----------------------------------------------------------------
 
 
-@patch("subprocess.run")
-@patch("m4.cli.set_bigquery_project_id")
-@patch("m4.cli.set_active_backend")
+@patch("m4.services.config.setup_claude_desktop", return_value=True)
+@patch("m4.services.config.set_bigquery_project_id")
+@patch("m4.services.config.set_active_backend")
 def test_config_claude_bigquery_persists_to_config(
-    mock_set_backend, mock_set_project, mock_subprocess
+    mock_set_backend, mock_set_project, mock_setup
 ):
     """Test that m4 config claude --backend bigquery persists backend and project_id."""
-    mock_subprocess.return_value = MagicMock(returncode=0)
-
     result = runner.invoke(
         app,
         ["config", "claude", "--backend", "bigquery", "--project-id", "my-project"],
@@ -1159,16 +1134,14 @@ def test_config_claude_bigquery_persists_to_config(
     mock_set_project.assert_called_once_with("my-project")
 
 
-@patch("subprocess.run")
-@patch("m4.cli.get_active_backend", return_value="duckdb")
-@patch("m4.cli.set_bigquery_project_id")
-@patch("m4.cli.set_active_backend")
+@patch("m4.services.config.setup_claude_desktop", return_value=True)
+@patch("m4.services.config.get_active_backend", return_value="duckdb")
+@patch("m4.services.config.set_bigquery_project_id")
+@patch("m4.services.config.set_active_backend")
 def test_config_claude_without_backend_flag_does_not_overwrite(
-    mock_set_backend, mock_set_project, mock_get_backend, mock_subprocess
+    mock_set_backend, mock_set_project, mock_get_backend, mock_setup
 ):
     """Test that m4 config claude without --backend does not overwrite the active backend."""
-    mock_subprocess.return_value = MagicMock(returncode=0)
-
     result = runner.invoke(app, ["config", "claude"])
 
     assert result.exit_code == 0
@@ -1176,28 +1149,23 @@ def test_config_claude_without_backend_flag_does_not_overwrite(
     mock_set_project.assert_not_called()
 
 
-@patch("subprocess.run")
-@patch("m4.cli.get_bigquery_project_id", return_value="inferred-project")
-@patch("m4.cli.get_active_backend", return_value="bigquery")
+@patch("m4.services.config.setup_claude_desktop", return_value=True)
+@patch("m4.services.config.get_bigquery_project_id", return_value="inferred-project")
+@patch("m4.services.config.get_active_backend", return_value="bigquery")
 def test_config_claude_infers_bigquery_project_from_config(
-    mock_backend, mock_get_project, mock_subprocess
+    mock_backend, mock_get_project, mock_setup
 ):
     """Test that m4 config claude infers project-id from config.json when backend is bigquery."""
-    mock_subprocess.return_value = MagicMock(returncode=0)
-
     result = runner.invoke(app, ["config", "claude"])
 
     assert result.exit_code == 0
-    # Verify the setup script was called with --backend bigquery and --project-id
-    call_args = mock_subprocess.call_args[0][0]
-    assert "--backend" in call_args
-    assert "bigquery" in call_args
-    assert "--project-id" in call_args
-    assert "inferred-project" in call_args
+    mock_setup.assert_called_once_with(
+        backend="bigquery", db_path=None, project_id="inferred-project"
+    )
 
 
-@patch("m4.cli.get_bigquery_project_id", return_value=None)
-@patch("m4.cli.get_active_backend", return_value="bigquery")
+@patch("m4.services.config.get_bigquery_project_id", return_value=None)
+@patch("m4.services.config.get_active_backend", return_value="bigquery")
 def test_config_claude_errors_when_bigquery_no_project_in_config(
     mock_backend, mock_get_project
 ):
@@ -1208,14 +1176,24 @@ def test_config_claude_errors_when_bigquery_no_project_in_config(
     assert "BigQuery backend requires a project ID" in result.output
 
 
-@patch("subprocess.run")
-@patch("m4.cli.set_bigquery_project_id")
-@patch("m4.cli.set_active_backend")
+@patch("m4.services.config.MCPConfigGenerator")
+@patch("m4.services.config.set_bigquery_project_id")
+@patch("m4.services.config.set_active_backend")
 def test_config_universal_bigquery_persists_to_config(
-    mock_set_backend, mock_set_project, mock_subprocess
+    mock_set_backend, mock_set_project, mock_generator_cls
 ):
     """Test that m4 config --quick --backend bigquery persists to config.json."""
-    mock_subprocess.return_value = MagicMock(returncode=0)
+    mock_generator = mock_generator_cls.return_value
+    mock_generator.generate_config.return_value = {
+        "mcpServers": {
+            "m4": {
+                "command": "python",
+                "args": ["-m", "m4.mcp_server"],
+                "cwd": ".",
+                "env": {"M4_PROJECT_ID": "my-project"},
+            }
+        }
+    }
 
     result = runner.invoke(
         app,

--- a/tests/test_docs_freshness.py
+++ b/tests/test_docs_freshness.py
@@ -1,0 +1,49 @@
+import importlib.util
+import re
+from pathlib import Path
+
+from m4.core.derived.builtins import get_tables_by_category
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "update_derived_docs", ROOT / "scripts" / "update_derived_docs.py"
+)
+assert SPEC and SPEC.loader
+update_derived_docs = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(update_derived_docs)
+START = update_derived_docs.START
+END = update_derived_docs.END
+generated_block = update_derived_docs.generated_block
+
+
+def test_derived_docs_block_matches_builtins():
+    tools = ROOT / "docs" / "TOOLS.md"
+    text = tools.read_text()
+    start = text.index(START)
+    end = text.index(END) + len(END)
+
+    assert text[start:end] == generated_block()
+
+
+def test_derived_docs_include_current_category_tables():
+    block = generated_block()
+    categories = get_tables_by_category("mimic-iv")
+
+    for tables in categories.values():
+        for table in tables:
+            assert f"`{table}`" in block
+
+
+def test_stale_derived_count_absent_from_docs():
+    for path in [ROOT / "docs" / "TOOLS.md", ROOT / "docs" / "DEVELOPMENT.md"]:
+        text = path.read_text()
+        assert '"total": 42' not in text
+        assert '"materialized": 42' not in text
+
+
+def test_package_urls_use_canonical_github_repo():
+    pyproject = (ROOT / "pyproject.toml").read_text()
+    urls = re.findall(r'https://github.com/[^\s"]+', pyproject)
+
+    assert urls
+    assert all(url.startswith("https://github.com/hannesill/m4") for url in urls)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -88,7 +88,7 @@ class TestEndToEnd:
 
     def test_execute_query_full_stack(self, integration_env):
         """ExecuteQueryTool returns correct DataFrame through the full stack."""
-        dataset, backend, db_path = integration_env
+        dataset, backend, _db_path = integration_env
 
         tool = ExecuteQueryTool()
         with patch("m4.core.tools.tabular.get_backend", return_value=backend):
@@ -105,7 +105,7 @@ class TestEndToEnd:
 
     def test_get_database_schema_full_stack(self, integration_env):
         """GetDatabaseSchemaTool lists schema-qualified tables."""
-        dataset, backend, db_path = integration_env
+        dataset, backend, _db_path = integration_env
 
         tool = GetDatabaseSchemaTool()
         with patch("m4.core.tools.tabular.get_backend", return_value=backend):
@@ -119,7 +119,7 @@ class TestEndToEnd:
 
     def test_get_table_info_full_stack(self, integration_env):
         """GetTableInfoTool returns schema and sample data for a real table."""
-        dataset, backend, db_path = integration_env
+        dataset, backend, _db_path = integration_env
 
         tool = GetTableInfoTool()
         with patch("m4.core.tools.tabular.get_backend", return_value=backend):
@@ -144,7 +144,7 @@ class TestEndToEnd:
 
     def test_execute_query_error_full_stack(self, integration_env):
         """ExecuteQueryTool raises QueryError for a nonexistent table."""
-        dataset, backend, db_path = integration_env
+        dataset, backend, _db_path = integration_env
 
         tool = ExecuteQueryTool()
         with patch("m4.core.tools.tabular.get_backend", return_value=backend):
@@ -160,7 +160,7 @@ class TestEndToEnd:
 
     def test_invalid_sql_full_stack(self, integration_env):
         """ExecuteQueryTool raises SecurityError for dangerous SQL."""
-        dataset, backend, db_path = integration_env
+        dataset, backend, _db_path = integration_env
 
         tool = ExecuteQueryTool()
         with patch("m4.core.tools.tabular.get_backend", return_value=backend):
@@ -172,7 +172,7 @@ class TestEndToEnd:
 
     def test_execute_query_with_join(self, integration_env):
         """ExecuteQueryTool handles JOIN queries across schemas."""
-        dataset, backend, db_path = integration_env
+        dataset, backend, _db_path = integration_env
 
         tool = ExecuteQueryTool()
         sql = """
@@ -193,7 +193,7 @@ class TestEndToEnd:
 
     def test_execute_query_with_aggregation(self, integration_env):
         """ExecuteQueryTool handles GROUP BY aggregation queries."""
-        dataset, backend, db_path = integration_env
+        dataset, backend, _db_path = integration_env
 
         tool = ExecuteQueryTool()
         sql = (
@@ -212,7 +212,7 @@ class TestEndToEnd:
 
     def test_execute_query_empty_result(self, integration_env):
         """ExecuteQueryTool returns empty DataFrame for no-match queries."""
-        dataset, backend, db_path = integration_env
+        dataset, backend, _db_path = integration_env
 
         tool = ExecuteQueryTool()
         sql = "SELECT * FROM mimiciv_hosp.patients WHERE subject_id = -1"

--- a/tests/test_services_agent_env_config.py
+++ b/tests/test_services_agent_env_config.py
@@ -1,0 +1,94 @@
+from unittest.mock import patch
+
+from m4.services.agent_env import build_agent_env_service
+from m4.services.config import MCPConfigRequest, configure_mcp_service
+
+
+def test_agent_env_local_includes_data_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("M4_DATA_DIR", str(tmp_path / "m4_data"))
+
+    result = build_agent_env_service(
+        mode="local", dataset="mimic-iv-demo", backend="duckdb"
+    )
+
+    assert result.command == "agent-env"
+    assert result.data["environment"]["M4_DATASET"] == "mimic-iv-demo"
+    assert result.data["environment"]["M4_BACKEND"] == "duckdb"
+    assert "M4_DATA_DIR" in result.data["environment"]
+    assert result.data["raw_paths_hidden"] is True
+
+
+def test_agent_env_protected_omits_data_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("M4_DATA_DIR", str(tmp_path / "m4_data"))
+
+    result = build_agent_env_service(mode="protected")
+
+    assert "M4_DATA_DIR" not in result.data["environment"]
+    assert result.warnings
+
+
+def test_agent_env_invalid_mode_returns_command_error():
+    result = build_agent_env_service(mode="bad")
+
+    assert result.ok is False
+    assert result.code == "invalid_mode"
+
+
+@patch("m4.services.config.setup_claude_desktop", return_value=True)
+@patch("m4.services.config.set_bigquery_project_id")
+@patch("m4.services.config.set_active_backend")
+def test_config_claude_persists_explicit_backend(
+    mock_set_backend, mock_set_project, mock_setup
+):
+    result = configure_mcp_service(
+        MCPConfigRequest(
+            client="claude",
+            backend="bigquery",
+            project_id="billing-project",
+        )
+    )
+
+    assert result.ok is True
+    mock_setup.assert_called_once_with(
+        backend="bigquery", db_path=None, project_id="billing-project"
+    )
+    mock_set_backend.assert_called_once_with("bigquery")
+    mock_set_project.assert_called_once_with("billing-project")
+
+
+@patch("m4.services.config.get_active_backend", return_value="bigquery")
+@patch("m4.services.config.get_bigquery_project_id", return_value=None)
+def test_config_bigquery_without_project_returns_command_error(
+    mock_get_project, mock_get_backend
+):
+    result = configure_mcp_service(MCPConfigRequest(client="claude"))
+
+    assert result.ok is False
+    assert result.code == "project_id_required"
+
+
+@patch("m4.services.config.MCPConfigGenerator")
+@patch("m4.services.config.get_active_backend", return_value="duckdb")
+def test_config_quick_generates_config_without_subprocess(
+    mock_get_backend, mock_generator_cls
+):
+    mock_generator = mock_generator_cls.return_value
+    mock_generator.generate_config.return_value = {
+        "mcpServers": {
+            "m4": {
+                "command": "python",
+                "args": ["-m", "m4.mcp_server"],
+                "cwd": ".",
+                "env": {},
+            }
+        }
+    }
+
+    result = configure_mcp_service(MCPConfigRequest(quick=True))
+
+    assert result.ok is True
+    assert result.data["config"]["mcpServers"]["m4"]["args"] == [
+        "-m",
+        "m4.mcp_server",
+    ]
+    mock_generator.generate_config.assert_called_once()

--- a/tests/test_services_init_derived.py
+++ b/tests/test_services_init_derived.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from m4.services.init_derived import init_derived_service
+
+
+def test_init_derived_list_returns_tables():
+    result = init_derived_service("mimic-iv", list_only=True)
+
+    assert result.ok is True
+    assert result.command == "init-derived"
+    assert result.data["status"] == "listed"
+    assert "sofa" in result.data["tables"]
+    assert result.data["table_count"] == len(result.data["tables"])
+
+
+def test_init_derived_unknown_dataset_returns_command_error():
+    result = init_derived_service("missing")
+
+    assert result.ok is False
+    assert result.code == "dataset_not_found"
+
+
+@patch("m4.services.init_derived.get_active_backend", return_value="bigquery")
+def test_init_derived_bigquery_skips_materialization(mock_backend):
+    result = init_derived_service("mimic-iv")
+
+    assert result.ok is True
+    assert result.data["status"] == "skipped"
+    assert result.data["reason"] == "bigquery_derived_tables_available"
+
+
+@patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
+@patch("m4.services.init_derived.get_default_database_path", return_value=None)
+def test_init_derived_missing_duckdb_returns_error(mock_db_path, mock_backend):
+    result = init_derived_service("mimic-iv")
+
+    assert result.ok is False
+    assert result.code == "database_not_found"
+
+
+@patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
+@patch("m4.services.init_derived.get_derived_table_count", return_value=2)
+@patch("m4.services.init_derived.materialize_all")
+@patch("m4.services.init_derived.get_default_database_path")
+def test_init_derived_existing_tables_skip_without_force(
+    mock_db_path, mock_materialize, mock_count, mock_backend, tmp_path
+):
+    db_path = tmp_path / "mimic.duckdb"
+    db_path.touch()
+    mock_db_path.return_value = db_path
+
+    result = init_derived_service("mimic-iv")
+
+    assert result.ok is True
+    assert result.data["reason"] == "already_materialized"
+    mock_materialize.assert_not_called()
+
+
+@patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
+@patch("m4.services.init_derived.get_derived_table_count", return_value=0)
+@patch("m4.services.init_derived.materialize_all", return_value=["sofa"])
+@patch("m4.services.init_derived.get_default_database_path")
+def test_init_derived_materializes_with_event_reporter(
+    mock_db_path, mock_materialize, mock_count, mock_backend, tmp_path
+):
+    db_path = tmp_path / "mimic.duckdb"
+    db_path.touch()
+    mock_db_path.return_value = db_path
+    reporter = Mock()
+
+    result = init_derived_service("mimic-iv", event_reporter=reporter)
+
+    assert result.ok is True
+    assert result.data["status"] == "completed"
+    mock_materialize.assert_called_once_with(
+        "mimic-iv", Path(db_path), event_reporter=reporter
+    )


### PR DESCRIPTION
## Summary
- Refactor CLI orchestration for config, agent env, and derived-table initialization into service modules
- Add docs freshness and cohort-builder bundle checks
- Harden notes tool input validation and SQL literal handling
- Fix the existing Ruff RUF059 integration-test lint issue
- Bump package version to 0.5.2

## Validation
- uv run pytest
- uv run ruff check
- uv run python scripts/update_derived_docs.py --check
- uv run python scripts/check_cohort_builder_bundle.py
- CLI smoke checks for capabilities, status, list-datasets, init-derived, agent-env, config, download, and doctor

## Implications
- No migration required
- CLI behavior should remain compatible while service boundaries improve testability
- Package metadata now reports version 0.5.2