### PR TITLE
Remove global active dataset routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ Copy the generated JSON into your client's MCP settings, restart, and start aski
 For complex analysis that goes beyond simple queries, M4 provides a Python API that returns Python data types instead of formatted strings (e.g. pd.DataFrame for SQL queries). This transforms M4 from a query tool into a complete clinical data analysis environment.
 
 ```python
-from m4 import set_dataset, execute_query, get_schema
+from m4 import execute_query, get_schema
 
-set_dataset("mimic-iv")
+dataset = "mimic-iv"
 
 # Get schema as a dict
-schema = get_schema()
+schema = get_schema(dataset=dataset)
 print(schema['tables'])  # ['mimiciv_hosp.admissions', 'mimiciv_hosp.diagnoses_icd', ...]
 
 # Query returns a pandas DataFrame
@@ -111,7 +111,7 @@ df = execute_query("""
     GROUP BY icd_code
     ORDER BY n DESC
     LIMIT 10
-""")
+""", dataset=dataset)
 
 # Use full pandas power: filter, join, compute statistics
 df[df['n'] > 100].plot(kind='bar')
@@ -209,19 +209,18 @@ Once connected, try asking:
 
 These datasets are supported out of the box. However, it is possible to add any other custom dataset by following [these instructions](docs/CUSTOM_DATASETS.md).
 
-Switch datasets or backends anytime:
+Choose datasets explicitly at each call site and switch the saved backend anytime:
 ```bash
-m4 use mimic-iv     # Switch to full MIMIC-IV
 m4 backend bigquery # Switch to BigQuery (or duckdb)
 m4 capabilities     # Show available interfaces, datasets, tools, and policies
 m4 doctor           # Diagnose local, BigQuery, and MCP setup
-m4 status           # Show active dataset and backend
+m4 status --dataset mimic-iv # Show dataset and backend status
 m4 status --all     # List all available datasets
-m4 status --derived # Show per-table derived materialization status
+m4 status --dataset mimic-iv --derived # Show per-table derived materialization status
 ```
 
 For automation and external agents, M4 also provides non-interactive JSON
-commands that do not mutate active configuration unless explicitly documented:
+commands that use request-scoped dataset and backend options:
 
 ```bash
 m4 agent-env --dataset mimic-iv --backend duckdb --json
@@ -315,13 +314,13 @@ This converts the CSV files to Parquet format and creates a local DuckDB databas
 
 ## Available Tools
 
-M4 exposes these tools to your AI client. Tools are filtered based on the active dataset's modality.
+M4 exposes these tools to your AI client. Data tools are checked against the explicit dataset selected for that call.
 
 **Dataset Management:**
 | Tool | Description |
 |------|-------------|
 | `list_datasets` | List available datasets and their status |
-| `set_dataset` | Switch the active dataset |
+| `set_dataset` | Removed migration aid; pass `dataset` to data tools |
 
 **Tabular Data Tools** (mimic-iv, mimic-iv-demo, eicu):
 | Tool | Description |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,9 +76,11 @@ AI Client → MCP Protocol → M4 Tools → Backend → Dataset
 For complex analysis: multi-step workflows, statistical computations, survival analysis.
 
 ```python
-from m4 import set_dataset, execute_query
-set_dataset("mimic-iv")
-df = execute_query("SELECT * FROM mimiciv_hosp.patients")  # Returns DataFrame
+from m4 import execute_query
+df = execute_query(
+    "SELECT * FROM mimiciv_hosp.patients",
+    dataset="mimic-iv",
+)  # Returns DataFrame
 ```
 
 **3. Agent Skills (Knowledge)**
@@ -110,7 +112,7 @@ class SearchNotesTool:
     required_modalities = frozenset({Modality.NOTES})
 ```
 
-When you switch datasets, M4 automatically shows only compatible tools. Query a tabular dataset? You get SQL tools. Switch to MIMIC-IV-Note? You get notes search tools.
+When a request selects a dataset, M4 checks which tools are compatible with that dataset. Query a tabular dataset? SQL tools are available. Query MIMIC-IV-Note? Notes search tools are available.
 
 ### 2. Backend Abstraction
 
@@ -144,7 +146,7 @@ M4's skills and concept mappings handle these translations, enabling external va
 FastMCP server exposing tools via Model Context Protocol. Thin adapter over core functionality.
 
 **Tools exposed:**
-- Dataset management: `list_datasets`, `set_dataset`
+- Dataset management: `list_datasets`; `set_dataset` remains only as a migration-error helper
 - Tabular: `get_database_schema`, `get_table_info`, `execute_query`
 - Notes: `search_notes`, `get_note`, `list_patient_notes`
 
@@ -154,10 +156,10 @@ Direct programmatic access returning native Python types:
 
 | Function | Returns |
 |----------|---------|
-| `execute_query(sql)` | `pd.DataFrame` |
-| `get_schema()` | `dict` |
-| `get_table_info(table)` | `dict` with DataFrame values |
-| `search_notes(query)` | `dict` with DataFrame values |
+| `execute_query(sql, dataset=...)` | `pd.DataFrame` |
+| `get_schema(dataset=...)` | `dict` |
+| `get_table_info(table, dataset=...)` | `dict` with DataFrame values |
+| `search_notes(query, dataset=...)` | `dict` with DataFrame values |
 
 ### Tool System (`core/tools/`)
 
@@ -173,7 +175,7 @@ class Tool(Protocol):
     def is_compatible(self, dataset) -> bool: ...
 ```
 
-The `ToolSelector` filters tools based on active dataset modalities.
+The `ToolSelector` filters tools based on explicit dataset modalities.
 
 ### Derived Table System (`core/derived/`)
 
@@ -250,9 +252,7 @@ Implementations handle database-specific details (DuckDB views, BigQuery schemas
 
 ```python
 # Claude Code with M4 skills generates:
-from m4 import set_dataset, execute_query
-
-set_dataset("mimic-iv")
+from m4 import execute_query
 
 # KDIGO AKI staging (validated)
 aki_cohort = execute_query("""
@@ -263,7 +263,7 @@ aki_cohort = execute_query("""
     FROM mimiciv_derived.kdigo_stages k
     JOIN admissions a ON k.hadm_id = a.hadm_id
     WHERE k.aki_stage >= 1
-""")
+""", dataset="mimic-iv")
 
 mortality_rate = aki_cohort['hospital_expire_flag'].mean()
 ```

--- a/docs/BIGQUERY.md
+++ b/docs/BIGQUERY.md
@@ -49,10 +49,10 @@ m4 setup-agent --backend bigquery --project-id YOUR_PROJECT_ID --format dotenv
 m4 doctor --json
 ```
 
-### 4. Set the dataset
+### 4. Query with an explicit dataset
 
 ```bash
-m4 use mimic-iv    # or eicu
+m4 status --dataset mimic-iv --backend bigquery
 ```
 
 ### 5. Restart your MCP client
@@ -84,12 +84,11 @@ The `mimiciv_derived` schema is accessible alongside the standard `mimiciv_hosp`
 
 ## Environment Variables
 
-You can also override the backend and dataset via environment variables. These
+You can also override the backend and project via environment variables. These
 take priority over saved CLI configuration for the current process:
 
 ```bash
 export M4_BACKEND=bigquery
-export M4_DATASET=mimic-iv
 export M4_PROJECT_ID=your-project-id
 ```
 

--- a/docs/CODE_EXECUTION.md
+++ b/docs/CODE_EXECUTION.md
@@ -17,22 +17,21 @@ The Python API makes all of this natural. Same underlying tools, but with DataFr
 ## Quick Start
 
 ```python
-from m4 import set_dataset, execute_query, get_schema, get_table_info
+from m4 import execute_query, get_schema, get_table_info
 
-# 1. Select your dataset
-set_dataset("mimic-iv")
+dataset = "mimic-iv"
 
-# 2. Explore what's available
-schema = get_schema()
+# 1. Explore what's available
+schema = get_schema(dataset=dataset)
 print(schema['tables'])  # List of table names
 
-# 3. Inspect a table
-info = get_table_info("mimiciv_hosp.patients")
+# 2. Inspect a table
+info = get_table_info("mimiciv_hosp.patients", dataset=dataset)
 print(info['schema'])  # DataFrame: column names, types, descriptions
 print(info['sample'])  # DataFrame: sample rows
 
-# 4. Run queries
-df = execute_query("SELECT * FROM mimiciv_hosp.patients LIMIT 1000")
+# 3. Run queries
+df = execute_query("SELECT * FROM mimiciv_hosp.patients LIMIT 1000", dataset=dataset)
 print(df.head())
 print(df.describe())
 ```
@@ -45,35 +44,36 @@ print(df.describe())
 | Function | Returns | Description |
 |----------|---------|-------------|
 | `list_datasets()` | `list[str]` | Available dataset names |
-| `set_dataset(name)` | `str` | Set active dataset (required before queries) |
-| `get_active_dataset()` | `str` | Current dataset name |
+| `M4Client(dataset=...)` | `M4Client` | Preferred explicit client for one dataset |
 
 ```python
-from m4 import list_datasets, set_dataset, get_active_dataset
+from m4 import M4Client, list_datasets
 
 print(list_datasets())  # ['mimic-iv', 'mimic-iv-note', 'eicu', ...]
-set_dataset("mimic-iv")
-print(get_active_dataset())  # 'mimic-iv'
+client = M4Client(dataset="mimic-iv")
+print(client.dataset.name)  # 'mimic-iv'
 ```
 
 ### Tabular Data
 
 | Function | Returns | Description |
 |----------|---------|-------------|
-| `get_schema()` | `dict` | Tables list and backend info |
-| `get_table_info(table, show_sample=True)` | `dict` | Schema DataFrame and optional sample |
-| `execute_query(sql)` | `DataFrame` | Query results |
+| `get_schema(dataset=...)` | `dict` | Tables list and backend info |
+| `get_table_info(table, dataset=..., show_sample=True)` | `dict` | Schema DataFrame and optional sample |
+| `execute_query(sql, dataset=...)` | `DataFrame` | Query results |
 
 ```python
 from m4 import execute_query, get_schema, get_table_info
 
+dataset = "mimic-iv"
+
 # Schema exploration
-schema = get_schema()
-print(schema['backend_info'])  # Backend and active dataset summary
+schema = get_schema(dataset=dataset)
+print(schema['backend_info'])  # Backend and dataset summary
 print(schema['tables'])        # ['mimiciv_hosp.admissions', 'mimiciv_hosp.diagnoses_icd', ...]
 
 # Table details
-info = get_table_info("mimiciv_hosp.admissions")
+info = get_table_info("mimiciv_hosp.admissions", dataset=dataset)
 print(info['schema'])  # DataFrame with column_name, data_type, description
 print(info['sample'])  # DataFrame with sample rows
 
@@ -82,7 +82,7 @@ df = execute_query("""
     SELECT gender, COUNT(*) as count
     FROM mimiciv_hosp.patients
     GROUP BY gender
-""")
+""", dataset=dataset)
 print(df)
 #   gender  count
 # 0      M    185
@@ -102,22 +102,22 @@ print(df)
 | `list_patient_notes(subject_id, note_type, limit)` | `dict` | Note metadata for a patient |
 
 ```python
-from m4 import set_dataset, search_notes, get_note, list_patient_notes
+from m4 import search_notes, get_note, list_patient_notes
 
-set_dataset("mimic-iv-note")  # Dataset with NOTES modality
+dataset = "mimic-iv-note"  # Dataset with NOTES modality
 
 # Search across notes
-results = search_notes("pneumonia", note_type="discharge", limit=10)
+results = search_notes("pneumonia", note_type="discharge", limit=10, dataset=dataset)
 for note_type, df in results['results'].items():
     print(f"{note_type}: {len(df)} matches")
     print(df[['note_id', 'snippet']].head())
 
 # Get full note
-note = get_note("10000032_DS-1")
+note = get_note("10000032_DS-1", dataset=dataset)
 print(note['text'][:500])
 
 # List patient's notes
-notes = list_patient_notes(10000032)
+notes = list_patient_notes(10000032, dataset=dataset)
 for note_type, df in notes['notes'].items():
     print(f"{note_type}: {len(df)} notes")
 ```
@@ -135,20 +135,19 @@ M4Error (base)
 ```
 
 ```python
-from m4 import execute_query, set_dataset, DatasetError, QueryError, ModalityError
+from m4 import execute_query, DatasetError, QueryError, ModalityError
 
 try:
-    df = execute_query("SELECT * FROM mimiciv_hosp.patients")
+    df = execute_query("SELECT * FROM mimiciv_hosp.patients", dataset="mimic-iv")
 except DatasetError:
-    # No dataset selected
-    set_dataset("mimic-iv")
-    df = execute_query("SELECT * FROM mimiciv_hosp.patients")
+    # Dataset not found or not initialized
+    print("Run `m4 status --dataset mimic-iv` to inspect setup.")
 except QueryError as e:
     # Bad SQL or missing table
     print(f"Query failed: {e}")
 except ModalityError:
     # Tried notes function on tabular-only dataset
-    set_dataset("mimic-iv-note")
+    print("Pass dataset='mimic-iv-note' to notes functions.")
 ```
 
 
@@ -157,10 +156,10 @@ except ModalityError:
 Here's how the Python API enables a complete analysis workflow:
 
 ```python
-from m4 import set_dataset, execute_query
+from m4 import execute_query
 import pandas as pd
 
-set_dataset("mimic-iv")
+dataset = "mimic-iv"
 
 # Step 1: Get ICU stays with outcomes
 icu_stays = execute_query("""
@@ -174,7 +173,7 @@ icu_stays = execute_query("""
     FROM mimiciv_icu.icustays i
     JOIN mimiciv_hosp.admissions a ON i.hadm_id = a.hadm_id
     JOIN mimiciv_hosp.patients p ON i.subject_id = p.subject_id
-""")
+""", dataset=dataset)
 
 # Step 2: Analyze with pandas
 print(f"Total ICU stays: {len(icu_stays)}")

--- a/docs/CODE_EXECUTION.md
+++ b/docs/CODE_EXECUTION.md
@@ -45,6 +45,8 @@ print(df.describe())
 |----------|---------|-------------|
 | `list_datasets()` | `list[str]` | Available dataset names |
 | `M4Client(dataset=...)` | `M4Client` | Preferred explicit client for one dataset |
+| `client.with_dataset(name)` | `M4Client` | New client with the same session context and a different dataset |
+| `client.switch_dataset(name)` | `M4Client` | Mutate a client to another dataset for notebook-style sessions |
 
 ```python
 from m4 import M4Client, list_datasets
@@ -52,6 +54,9 @@ from m4 import M4Client, list_datasets
 print(list_datasets())  # ['mimic-iv', 'mimic-iv-note', 'eicu', ...]
 client = M4Client(dataset="mimic-iv")
 print(client.dataset.name)  # 'mimic-iv'
+
+eicu_client = client.with_dataset("eicu")  # original client still targets mimic-iv
+client.switch_dataset("mimic-iv-note")    # mutates client and its execution context
 ```
 
 ### Tabular Data
@@ -92,6 +97,8 @@ print(df)
 > **Table naming convention:** Tables use canonical `schema.table` names (e.g., `mimiciv_hosp.patients`, `mimiciv_icu.icustays`) that work on both DuckDB and BigQuery backends. Use `get_schema()` to see all available tables.
 
 > **Path disclosure:** DuckDB backend metadata hides raw local database paths by default. Set `M4_PATH_DISCLOSURE=1` only when code is allowed to receive local filesystem paths.
+
+> **Dataset switching:** Prefer `client.with_dataset(...)` for concurrent or reproducible workflows. Use `client.switch_dataset(...)` only when a single long-lived interactive client should move to a different dataset.
 
 ### Clinical Notes
 

--- a/docs/CUSTOM_DATASETS.md
+++ b/docs/CUSTOM_DATASETS.md
@@ -34,7 +34,7 @@ m4 init mimic-iv-ed --src /path/to/your/csv/files
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `name` | Yes | Unique identifier (used in `m4 use <name>`) |
+| `name` | Yes | Unique identifier passed as `--dataset <name>` or `dataset="<name>"` |
 | `description` | Yes | Human-readable description |
 | `file_listing_url` | No | PhysioNet URL for auto-download (demo datasets only) |
 | `subdirectories_to_scan` | No | Subdirs containing CSV files (e.g., `["hosp", "icu"]`) |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,17 +36,14 @@ uv run m4 init-derived mimic-iv
 # List available derived tables without materializing
 uv run m4 init-derived mimic-iv --list
 
-# Switch active dataset
-uv run m4 use mimic-iv
-
-# Show active dataset status (detailed view)
-uv run m4 status
+# Show dataset status (detailed view)
+uv run m4 status --dataset mimic-iv
 
 # List all datasets (compact table)
 uv run m4 status --all
 
 # Show per-table derived materialization status
-uv run m4 status --derived
+uv run m4 status --dataset mimic-iv --derived
 ```
 
 ### CLI JSON Output
@@ -60,13 +57,13 @@ non-zero.
 ```json
 {
   "version": 1,
-  "active_dataset": "mimic-iv",
+  "selected_dataset": "mimic-iv",
   "backend": "duckdb",
   "bigquery_project_id": "my-project",
   "datasets": [
     {
       "name": "mimic-iv",
-      "active": true,
+      "selected": true,
       "raw_present": true,
       "parquet_present": true,
       "db_present": true,
@@ -98,17 +95,15 @@ status warnings:
 - `parquet_path_mismatch`: row-count verification could not read the Parquet
   path referenced by the local DuckDB views.
 
-`m4 use TARGET --json` and `m4 backend BACKEND --json` wrap command results in
-an `ok` envelope:
+`m4 backend BACKEND --json` wraps command results in an `ok` envelope:
 
 ```json
 {
   "version": 1,
   "ok": true,
-  "command": "use",
-  "active_dataset": "mimic-iv",
+  "command": "backend",
   "backend": "duckdb",
-  "warnings": ["local_db_missing"]
+  "warnings": []
 }
 ```
 
@@ -128,8 +123,8 @@ Command errors use the same envelope with `ok: false`:
 ```
 
 Stable command error codes are `dataset_not_found`, `backend_incompatible`,
-`invalid_backend`, `invalid_option`, `project_id_required`, and
-`dataset_incompatible`. Dataset setup can also return `missing_credentials`,
+`invalid_backend`, `invalid_option`, `project_id_required`,
+`dataset_incompatible`, and `active_dataset_removed`. Dataset setup can also return `missing_credentials`,
 `physionet_auth_failed`, `physionet_access_forbidden`,
 `download_network_failed`, `download_filesystem_failed`,
 `download_interrupted`, `raw_files_missing`, `conversion_failed`,
@@ -200,7 +195,7 @@ m4 provenance export --json
 ```
 
 These commands accept `--dataset` and `--backend` to resolve context without
-changing saved active configuration. `agent-env --mode protected` omits
+changing saved backend configuration. `agent-env --mode protected` omits
 `M4_DATA_DIR` so a caller can expose only a service, socket, MCP server, or
 gateway to agents.
 
@@ -212,7 +207,6 @@ Durable environment controls:
 |----------|---------|
 | `M4_DATA_DIR` | Exact M4 data directory containing `databases/`, `parquet/`, `datasets/`, and `raw_files/`. |
 | `M4_HOME` | Runtime home for config and default telemetry when separate from the data directory. |
-| `M4_DATASET` | Active dataset override. |
 | `M4_BACKEND` | Active backend override, such as `duckdb` or `bigquery`. |
 | `M4_PROJECT_ID` | BigQuery billing/project override. |
 | `M4_TELEMETRY_DIR` | Directory for telemetry JSONL when `M4_EVENT_LOG` is not set. |
@@ -276,8 +270,8 @@ Point your MCP client to your local development environment:
 
 For normal local development, configure the active backend with
 `m4 backend duckdb` or `m4 backend bigquery`. For isolated agents or MCP
-servers, `M4_BACKEND` and `M4_DATASET` may be supplied in the environment to
-override saved configuration for that process.
+servers, `M4_BACKEND` may be supplied in the environment to override saved
+backend configuration for that process. Datasets are selected per request.
 
 ## Architecture Overview
 
@@ -312,7 +306,7 @@ class ExecuteQueryTool:
     required_modalities = frozenset({Modality.TABULAR})
 ```
 
-The `ToolSelector` automatically filters tools based on the active dataset's modalities. If a dataset lacks a required modality, the tool returns a helpful error message instead of failing silently.
+The `ToolSelector` filters tools based on the request's explicit dataset. If a dataset lacks a required modality, the tool returns a helpful error message instead of failing silently.
 
 ### Backend Abstraction
 
@@ -389,7 +383,9 @@ def init_tools():
 @mcp.tool()
 @require_oauth2
 def my_new_tool(param1: str, limit: int = 10) -> str:
-    dataset = DatasetRegistry.get_active()
+    dataset = DatasetRegistry.get("mimic-iv")
+    if dataset is None:
+        return "Dataset 'mimic-iv' is not registered."
     result = _tool_selector.check_compatibility("my_new_tool", dataset)
     if not result.compatible:
         return result.error_message

--- a/docs/M4_APPS.md
+++ b/docs/M4_APPS.md
@@ -86,7 +86,7 @@ M4 Apps use the MCP Apps protocol to serve interactive UIs alongside tool respon
 
 M4 Apps require:
 - **Host support**: A client that implements the MCP Apps protocol (Claude Desktop 1.x+)
-- **M4 initialized**: An active dataset (`m4 init mimic-iv-demo`)
+- **M4 initialized**: A dataset initialized locally (`m4 init mimic-iv-demo`)
 - **MCP connection**: M4 configured in your client (`m4 config claude --quick`)
 
 Apps gracefully degrade in hosts without MCP Apps support—you'll get text-based results instead of the interactive UI.

--- a/docs/OAUTH2_AUTHENTICATION.md
+++ b/docs/OAUTH2_AUTHENTICATION.md
@@ -33,8 +33,9 @@ For manual MCP client configuration with OAuth2 enabled:
 ```
 
 > **Note:** For normal use, configure the active backend with `m4 backend duckdb`
-> or `m4 backend bigquery`. Use `M4_BACKEND` and `M4_DATASET` in MCP env blocks
-> only when that server process should override saved configuration.
+> or `m4 backend bigquery`. Use `M4_BACKEND` in MCP env blocks only when that
+> server process should override saved backend configuration. Datasets are
+> selected per tool call.
 
 ## Environment Variables
 

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -8,7 +8,7 @@ For the canonical list of bundled skills, see `src/m4/skills/SKILLS_INDEX.md`.
 
 Without skills, an AI assistant might guess at APIs or make assumptions about clinical concepts. With M4 skills installed:
 
-- **m4-api**: Claude knows to call `set_dataset()` before queries, returns proper DataFrames, handles errors correctly
+- **m4-api**: Claude knows to pass `dataset=...` or use `M4Client(dataset=...)`, returns proper DataFrames, handles errors correctly
 - **Clinical skills**: Claude understands SOFA scoring, Sepsis-3 criteria, KDIGO AKI staging, and other validated clinical concepts
 
 Skills activate automatically when relevant. Ask Claude to "calculate SOFA scores for my cohort" and it will use the validated SQL from MIT-LCP without you needing to look up the implementation.
@@ -57,7 +57,7 @@ Skills are installed to `.claude/skills/` (or equivalent for other tools). AI as
 
 | Skill | Triggers On | Description |
 |-------|-------------|-------------|
-| **m4-api** | "M4 API", "query MIMIC with Python", "clinical data analysis" | Complete Python API usage including `set_dataset()`, DataFrame handling, error handling |
+| **m4-api** | "M4 API", "query MIMIC with Python", "clinical data analysis" | Complete Python API usage including explicit dataset selection, DataFrame handling, error handling |
 | **clinical-research-session** | "research workflow", "clinical study", "protocol" | Structured clinical research workflow and protocol drafting |
 | **m4-setup** | "M4 setup", "fix M4", "dataset missing", "skills missing", "vitrine broken" | Diagnose and repair M4 environment, dataset, skill installation, backend, and vitrine issues |
 | **vitrine-api** | "vitrine", "show results", "forms", "visualization", "approval" | Display results, collect structured input, manage study cards, and export research trails |
@@ -190,15 +190,14 @@ When identifying cardiac surgery patients in MIMIC-IV:
 ## Standard Query
 
 \`\`\`python
-from m4 import set_dataset, execute_query
+from m4 import execute_query
 
-set_dataset("mimic-iv")
 cardiac_cohort = execute_query("""
     SELECT DISTINCT p.subject_id, p.hadm_id
     FROM procedures_icd p
     WHERE p.icd_code LIKE '02%'
       AND p.icd_version = 10
-""")
+""", dataset="mimic-iv")
 \`\`\`
 ```
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-M4 exposes these tools to AI clients via the Model Context Protocol. Tools are filtered based on the active dataset's modality.
+M4 exposes these tools to AI clients via the Model Context Protocol. Data tools take an explicit `dataset` parameter and are checked against that dataset's modality.
 
 ## Dataset Management
 
@@ -12,22 +12,14 @@ List all available datasets and their status.
 **Example response:**
 ```
 Available datasets:
-- mimic-iv-demo (active) - MIMIC-IV Clinical Database Demo [TABULAR]
+- mimic-iv-demo - MIMIC-IV Clinical Database Demo [TABULAR]
 - mimic-iv - MIMIC-IV Clinical Database [TABULAR]
 - mimic-iv-note - MIMIC-IV Clinical Notes [NOTES]
 - eicu - eICU Collaborative Research Database [TABULAR]
 ```
 
 ### `set_dataset`
-Switch the active dataset.
-
-**Parameters:**
-- `dataset_name` (string, required): Name of the dataset to activate
-
-**Example:**
-```
-set_dataset("mimic-iv-note")
-```
+Removed. The compatibility tool returns migration guidance; pass `dataset` to the data tool call instead.
 
 ---
 
@@ -38,9 +30,10 @@ These tools are available for datasets with the `TABULAR` modality (mimic-iv, mi
 **Derived tables:** For MIMIC-IV, after materializing derived tables with `m4 init-derived mimic-iv`, the `execute_query` tool can query pre-computed clinical concept tables in the `mimiciv_derived.*` schema. These tables provide validated severity scores, sepsis cohorts, organ failure staging, and more -- eliminating the need to write complex clinical SQL from scratch. See [Derived Table Categories](#derived-table-categories) below for the full list.
 
 ### `get_database_schema`
-List all tables in the current dataset.
+List all tables in a dataset.
 
-**Parameters:** None
+**Parameters:**
+- `dataset` (string, required): Dataset name
 
 **Returns:** Table names with row counts
 
@@ -49,6 +42,7 @@ Get detailed information about a specific table.
 
 **Parameters:**
 - `table_name` (string, required): Name of the table
+- `dataset` (string, required): Dataset name
 - `sample_rows` (int, optional): Number of sample rows to return (default: 5)
 
 **Returns:** Column names, types, and sample data
@@ -58,6 +52,7 @@ Execute a read-only SQL SELECT query.
 
 **Parameters:**
 - `query` (string, required): SQL SELECT statement
+- `dataset` (string, required): Dataset name
 - `limit` (int, optional): Maximum rows to return (default: 100)
 
 **Security:**
@@ -84,6 +79,7 @@ Full-text search across clinical notes. Returns snippets around matches.
 
 **Parameters:**
 - `query` (string, required): Search term
+- `dataset` (string, required): Dataset name
 - `note_type` (string, optional): Filter by type - `"discharge"`, `"radiology"`, or `"all"` (default: `"all"`)
 - `limit` (int, optional): Maximum results (default: 5)
 - `snippet_length` (int, optional): Characters around match (default: 300)
@@ -102,6 +98,7 @@ Retrieve the full text of a single clinical note by ID.
 
 **Parameters:**
 - `note_id` (string, required): The note identifier (e.g., `"10000032_DS-1"`)
+- `dataset` (string, required): Dataset name
 - `max_length` (int, optional): Truncate output to this length
 
 **Returns:** Full note text (or truncated if `max_length` specified)
@@ -119,6 +116,7 @@ List available notes for a patient. Returns metadata only (IDs, types, lengths) 
 
 **Parameters:**
 - `subject_id` (int, required): Patient identifier
+- `dataset` (string, required): Dataset name
 - `note_type` (string, optional): Filter by type - `"discharge"`, `"radiology"`, or `"all"` (default: `"all"`)
 - `limit` (int, optional): Maximum results (default: 20)
 
@@ -147,7 +145,7 @@ Tools declare required modalities. Only datasets with matching modalities expose
 | `get_note` | NOTES | No | No | Yes | No |
 | `list_patient_notes` | NOTES | No | No | Yes | No |
 | `list_datasets` | (always) | Yes | Yes | Yes | Yes |
-| `set_dataset` | (always) | Yes | Yes | Yes | Yes |
+| `set_dataset` | Removed migration aid | Yes | Yes | Yes | Yes |
 
 ---
 
@@ -157,14 +155,15 @@ MIMIC-IV and MIMIC-IV-Note are separate datasets that can be linked via `subject
 
 ```
 # 1. Find patients of interest in MIMIC-IV (tabular)
-set_dataset("mimic-iv")
-execute_query("SELECT subject_id FROM mimiciv_hosp.patients WHERE anchor_age > 80 LIMIT 5")
+execute_query(
+    "SELECT subject_id FROM mimiciv_hosp.patients WHERE anchor_age > 80 LIMIT 5",
+    dataset="mimic-iv",
+)
 
-# 2. Switch to notes and explore their clinical narratives
-set_dataset("mimic-iv-note")
-list_patient_notes(10000032)
-search_notes("heart failure", note_type="discharge")
-get_note("10000032_DS-1")
+# 2. Query notes explicitly
+list_patient_notes(10000032, dataset="mimic-iv-note")
+search_notes("heart failure", note_type="discharge", dataset="mimic-iv-note")
+get_note("10000032_DS-1", dataset="mimic-iv-note")
 ```
 
 ---
@@ -180,7 +179,7 @@ This tool requires the NOTES modality, but 'mimic-iv' only has: TABULAR
 
 Suggestions:
    - Use `list_datasets()` to see all available datasets
-   - Use `set_dataset('mimic-iv-note')` to switch to a notes dataset
+   - Pass `dataset='mimic-iv-note'` to use a notes dataset
 ```
 
 ---
@@ -230,10 +229,12 @@ For complex analysis beyond simple queries, M4 provides a Python API that return
 - Building reproducible analysis notebooks
 
 ```python
-from m4 import set_dataset, execute_query
+from m4 import execute_query
 
-set_dataset("mimic-iv")
-df = execute_query("SELECT * FROM mimiciv_hosp.patients")  # Returns pandas DataFrame
+df = execute_query(
+    "SELECT * FROM mimiciv_hosp.patients",
+    dataset="mimic-iv",
+)  # Returns pandas DataFrame
 ```
 
 See [Code Execution Guide](CODE_EXECUTION.md) for the full API reference.

--- a/src/m4/__init__.py
+++ b/src/m4/__init__.py
@@ -4,11 +4,13 @@ M4 provides rigorous, auditable infrastructure for AI-assisted clinical research
 offering a safe interface for LLMs and autonomous agents to interact with EHR data.
 
 Quick Start:
-    from m4 import execute_query, set_dataset, get_schema
+    from m4 import execute_query, get_schema
 
-    set_dataset("mimic-iv")
-    print(get_schema())
-    result = execute_query("SELECT COUNT(*) FROM mimiciv_hosp.patients")
+    print(get_schema(dataset="mimic-iv"))
+    result = execute_query(
+        "SELECT COUNT(*) FROM mimiciv_hosp.patients",
+        dataset="mimic-iv",
+    )
 
 For MCP server usage, run: m4 serve
 """

--- a/src/m4/api.py
+++ b/src/m4/api.py
@@ -11,19 +11,21 @@ Unlike the MCP server, this API returns native Python types:
 - etc.
 
 Example:
-    from m4 import execute_query, set_dataset, get_schema
+    from m4 import M4Client, execute_query, get_schema
     import pandas as pd
 
-    set_dataset("mimic-iv")
-    schema = get_schema()  # Returns dict with 'tables' list
+    client = M4Client(dataset="mimic-iv")
+    schema = client.schema()  # Returns dict with 'tables' list
     print(schema['tables'])
 
-    df = execute_query("SELECT COUNT(*) FROM mimiciv_hosp.patients")
+    df = execute_query(
+        "SELECT COUNT(*) FROM mimiciv_hosp.patients",
+        dataset="mimic-iv",
+    )
     print(df)  # DataFrame
 
 All queries use canonical schema.table names (e.g., mimiciv_hosp.patients)
-that work on both DuckDB and BigQuery backends. Use set_dataset()
-to switch between datasets.
+that work on both DuckDB and BigQuery backends.
 """
 
 import os
@@ -33,20 +35,15 @@ from typing import Any
 import pandas as pd
 
 from m4.client import M4Client
-from m4.config import _ensure_custom_datasets_loaded
-from m4.config import get_active_dataset as _get_active_dataset
-from m4.config import set_active_dataset as _set_active_dataset
+from m4.config import _ensure_custom_datasets_loaded, get_bigquery_project_id
 from m4.core.datasets import DatasetRegistry
 from m4.core.exceptions import DatasetError, M4Error, ModalityError, QueryError
 from m4.core.telemetry import set_interface
-from m4.core.tools import ToolSelector, init_tools
+from m4.core.tools import init_tools
 
 # Initialize tools on module import
 init_tools()
 set_interface("python_api")
-
-# Tool selector for compatibility checking
-_tool_selector = ToolSelector()
 
 # Re-export exceptions for convenience
 __all__ = [
@@ -78,7 +75,7 @@ def list_datasets() -> list[str]:
     """List all available datasets.
 
     Returns:
-        List of dataset names that can be used with set_dataset().
+        List of dataset names that can be used with M4Client(dataset=...).
 
     Example:
         >>> list_datasets()
@@ -89,53 +86,49 @@ def list_datasets() -> list[str]:
 
 
 def set_dataset(name: str) -> str:
-    """Set the active dataset for subsequent queries.
-
-    Args:
-        name: Dataset name (e.g., 'mimic-iv', 'eicu')
-
-    Returns:
-        Confirmation message with dataset info.
-
-    Raises:
-        DatasetError: If dataset doesn't exist.
-
-    Example:
-        >>> set_dataset("mimic-iv")
-        'Active dataset: mimic-iv (modalities: TABULAR)'
-    """
-    try:
-        _set_active_dataset(name)
-        dataset = DatasetRegistry.get(name)
-        if not dataset:
-            raise ValueError(f"Dataset '{name}' not found")
-        modalities = ", ".join(m.name for m in dataset.modalities)
-        return f"Active dataset: {name} (modalities: {modalities})"
-    except ValueError as e:
-        available = ", ".join(list_datasets())
-        raise DatasetError(f"{e}. Available datasets: {available}") from e
+    """Deprecated compatibility shim for removed global dataset state."""
+    raise DatasetError(
+        f"set_dataset({name!r}) is no longer supported because M4 no longer keeps "
+        "a global active dataset. Use M4Client(dataset='mimic-iv') or pass "
+        "dataset='mimic-iv' to convenience functions such as execute_query(...)."
+    )
 
 
 def get_active_dataset() -> str:
-    """Get the name of the currently active dataset.
-
-    Returns:
-        Name of the active dataset.
-
-    Raises:
-        DatasetError: If no dataset is active.
-    """
-    try:
-        return _get_active_dataset()
-    except ValueError as e:
-        raise DatasetError(str(e)) from e
+    """Deprecated compatibility shim for removed global dataset state."""
+    raise DatasetError(
+        "get_active_dataset() is no longer supported because M4 no longer keeps "
+        "a global active dataset. Pass dataset explicitly, for example "
+        "M4Client(dataset='mimic-iv') or execute_query(sql, dataset='mimic-iv')."
+    )
 
 
 def get_capabilities() -> dict[str, Any]:
     """Return the stable M4 capability manifest."""
-    return M4Client.from_active(
-        interface="python_api", allow_missing_dataset=True
-    ).capabilities()
+    from m4.services.capabilities import build_capabilities_manifest
+
+    return build_capabilities_manifest()
+
+
+def _client(dataset: str, backend: str | None = None) -> M4Client:
+    path_disclosure = os.getenv("M4_PATH_DISCLOSURE", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+        "paths",
+    }
+    return M4Client(
+        dataset=dataset,
+        backend=backend,
+        interface="python_api",
+        study_id=os.getenv("M4_STUDY_ID"),
+        session_id=os.getenv("M4_SESSION_ID"),
+        actor=os.getenv("M4_ACTOR"),
+        project_id=get_bigquery_project_id(),
+        db_path=os.getenv("M4_DB_PATH"),
+        path_disclosure=path_disclosure,
+    )
 
 
 # =============================================================================
@@ -143,8 +136,8 @@ def get_capabilities() -> dict[str, Any]:
 # =============================================================================
 
 
-def get_schema() -> dict[str, Any]:
-    """Get database schema information for the active dataset.
+def get_schema(dataset: str, backend: str | None = None) -> dict[str, Any]:
+    """Get database schema information for a dataset.
 
     Returns:
         dict with:
@@ -152,15 +145,20 @@ def get_schema() -> dict[str, Any]:
             - tables: list[str] - List of table names
 
     Example:
-        >>> set_dataset("mimic-iv")
-        >>> schema = get_schema()
+        >>> schema = get_schema(dataset="mimic-iv")
         >>> print(schema['tables'])
         ['admissions', 'diagnoses_icd', 'patients', ...]
     """
-    return M4Client.from_active(interface="python_api").schema()
+    return _client(dataset, backend).schema()
 
 
-def get_table_info(table_name: str, show_sample: bool = True) -> dict[str, Any]:
+def get_table_info(
+    table_name: str,
+    *,
+    dataset: str,
+    backend: str | None = None,
+    show_sample: bool = True,
+) -> dict[str, Any]:
     """Get column information and sample data for a table.
 
     Args:
@@ -182,13 +180,16 @@ def get_table_info(table_name: str, show_sample: bool = True) -> dict[str, Any]:
         >>> print(info['schema'])  # DataFrame with column info
         >>> print(info['sample'])  # DataFrame with sample rows
     """
-    return M4Client.from_active(interface="python_api").table_info(
-        table_name, show_sample=show_sample
-    )
+    return _client(dataset, backend).table_info(table_name, show_sample=show_sample)
 
 
-def execute_query(sql: str) -> pd.DataFrame:
-    """Execute a SQL SELECT query against the active dataset.
+def execute_query(
+    sql: str,
+    *,
+    dataset: str,
+    backend: str | None = None,
+) -> pd.DataFrame:
+    """Execute a SQL SELECT query against a dataset.
 
     Args:
         sql: SQL SELECT query string.
@@ -207,7 +208,7 @@ def execute_query(sql: str) -> pd.DataFrame:
         0       M            55
         1       F            45
     """
-    return M4Client.from_active(interface="python_api").query(sql)
+    return _client(dataset, backend).query(sql)
 
 
 # =============================================================================
@@ -215,20 +216,11 @@ def execute_query(sql: str) -> pd.DataFrame:
 # =============================================================================
 
 
-def _check_notes_compatibility(tool_name: str) -> None:
-    """Check that active dataset supports notes tools."""
-    dataset = DatasetRegistry.get_active()
-    result = _tool_selector.check_compatibility(tool_name, dataset)
-    if not result.compatible:
-        raise ModalityError(
-            f"Dataset '{dataset.name}' does not support clinical notes. "
-            f"Available modalities: {', '.join(m.name for m in dataset.modalities)}. "
-            f"Use a dataset with NOTES modality (e.g., 'mimic-iv-note')."
-        )
-
-
 def search_notes(
     query: str,
+    *,
+    dataset: str,
+    backend: str | None = None,
     note_type: str = "all",
     limit: int = 5,
     snippet_length: int = 300,
@@ -249,18 +241,15 @@ def search_notes(
             - results: dict[str, pd.DataFrame] - Results by note type
 
     Raises:
-        ModalityError: If active dataset doesn't support notes.
+        ModalityError: If dataset doesn't support notes.
         QueryError: If note_type is invalid.
 
     Example:
-        >>> set_dataset("mimic-iv-note")
-        >>> results = search_notes("pneumonia", limit=3)
+        >>> results = search_notes("pneumonia", dataset="mimic-iv-note", limit=3)
         >>> for note_type, df in results['results'].items():
         ...     print(f"{note_type}: {len(df)} matches")
     """
-    _check_notes_compatibility("search_notes")
-
-    return M4Client.from_active(interface="python_api").search_notes(
+    return _client(dataset, backend).search_notes(
         query=query,
         note_type=note_type,
         limit=limit,
@@ -268,7 +257,13 @@ def search_notes(
     )
 
 
-def get_note(note_id: str, max_length: int | None = None) -> dict[str, Any]:
+def get_note(
+    note_id: str,
+    *,
+    dataset: str,
+    backend: str | None = None,
+    max_length: int | None = None,
+) -> dict[str, Any]:
     """Retrieve full text of a clinical note by ID.
 
     Args:
@@ -285,22 +280,21 @@ def get_note(note_id: str, max_length: int | None = None) -> dict[str, Any]:
             - truncated: bool - Whether text was truncated
 
     Raises:
-        ModalityError: If active dataset doesn't support notes.
+        ModalityError: If dataset doesn't support notes.
         QueryError: If note not found.
 
     Example:
         >>> note = get_note("10000032_DS-1")
         >>> print(note['text'][:500])
     """
-    _check_notes_compatibility("get_note")
-
-    return M4Client.from_active(interface="python_api").get_note(
-        note_id=note_id, max_length=max_length
-    )
+    return _client(dataset, backend).get_note(note_id=note_id, max_length=max_length)
 
 
 def list_patient_notes(
     subject_id: int,
+    *,
+    dataset: str,
+    backend: str | None = None,
     note_type: str = "all",
     limit: int = 20,
 ) -> dict[str, Any]:
@@ -318,7 +312,7 @@ def list_patient_notes(
             - notes: dict[str, pd.DataFrame] - Note metadata by type
 
     Raises:
-        ModalityError: If active dataset doesn't support notes.
+        ModalityError: If dataset doesn't support notes.
         QueryError: If note_type is invalid.
 
     Example:
@@ -326,9 +320,7 @@ def list_patient_notes(
         >>> for note_type, df in notes['notes'].items():
         ...     print(f"{note_type}: {len(df)} notes")
     """
-    _check_notes_compatibility("list_patient_notes")
-
-    return M4Client.from_active(interface="python_api").list_patient_notes(
+    return _client(dataset, backend).list_patient_notes(
         subject_id=subject_id,
         note_type=note_type,
         limit=limit,

--- a/src/m4/apps/cohort_builder/tool.py
+++ b/src/m4/apps/cohort_builder/tool.py
@@ -69,7 +69,7 @@ class CohortBuilderTool:
         is handled by the MCP Apps protocol via _meta.ui.resourceUri.
 
         Args:
-            dataset: The active dataset
+            dataset: The selected dataset
             params: Tool parameters (empty for this tool)
 
         Returns:
@@ -131,7 +131,7 @@ class QueryCohortTool:
         """Execute cohort query and return results.
 
         Args:
-            dataset: The active dataset
+            dataset: The selected dataset
             params: Cohort filtering criteria
 
         Returns:

--- a/src/m4/cli.py
+++ b/src/m4/cli.py
@@ -14,13 +14,13 @@ import typer
 from m4.client import M4Client
 from m4.config import (
     get_active_backend,
-    get_active_dataset,
+    get_active_dataset,  # noqa: F401 - retained for compatibility patch targets
     get_dataset_parquet_root,
     get_default_database_path,
     get_telemetry_dir,
     logger,
     resolve_runtime_context,
-    set_active_dataset,
+    set_active_dataset,  # noqa: F401 - retained for compatibility patch targets
 )
 from m4.console import (
     console,
@@ -49,7 +49,7 @@ from m4.core.derived.materializer import (
     list_materialized_tables,
     materialize_all,
 )
-from m4.core.exceptions import DatasetError, M4Error
+from m4.core.exceptions import M4Error
 from m4.core.tools import init_tools
 from m4.data_io import (
     PhysioNetCredentials,
@@ -294,12 +294,9 @@ def _is_missing_value(value: Any) -> bool:
 @contextmanager
 def _runtime_env_override(*, dataset: str | None = None, backend: str | None = None):
     previous: dict[str, str | None] = {
-        "M4_DATASET": os.environ.get("M4_DATASET"),
         "M4_BACKEND": os.environ.get("M4_BACKEND"),
     }
     try:
-        if dataset:
-            os.environ["M4_DATASET"] = dataset
         if backend:
             os.environ["M4_BACKEND"] = backend
         yield
@@ -316,13 +313,12 @@ def _resolve_agent_dataset(
 ):
     from m4.core.datasets import DatasetRegistry
 
-    try:
-        effective = dataset_name or get_active_dataset()
-    except DatasetError:
+    effective = dataset_name.lower() if dataset_name else None
+    if not effective:
         _emit_agent_error(
             command,
             "dataset_required",
-            "No dataset was provided and no active dataset is configured.",
+            "No dataset was provided.",
             hint=f"Use: m4 {command} --dataset <dataset> --json",
             context=context,
         )
@@ -383,9 +379,9 @@ def capabilities_cmd(
     ] = False,
 ):
     """Show M4 interfaces, commands, tools, datasets, limits, and policies."""
-    manifest = M4Client.from_active(
-        interface="cli", allow_missing_dataset=True
-    ).capabilities()
+    from m4.services.capabilities import build_capabilities_manifest
+
+    manifest = build_capabilities_manifest()
     if json_output:
         _emit_json(manifest)
         return
@@ -1015,9 +1011,6 @@ def dataset_init_cmd(
             )
             error(f"Verification failed: {e}")
 
-    # Set active dataset to match init target
-    set_active_dataset(dataset_key)
-
     # Offer to materialize derived tables for supported datasets
     if has_derived_support(dataset_key) and get_active_backend() == "duckdb":
         existing_derived = get_derived_table_count(final_db_path)
@@ -1207,9 +1200,7 @@ def init_derived_cmd(
 def use_cmd(
     target: Annotated[
         str,
-        typer.Argument(
-            help="Select active dataset: name (e.g., mimic-iv-full)", metavar="TARGET"
-        ),
+        typer.Argument(help="Deprecated global dataset selector.", metavar="TARGET"),
     ],
     json_output: Annotated[
         bool,
@@ -1219,47 +1210,16 @@ def use_cmd(
         ),
     ] = False,
 ):
-    """Set the active dataset selection for the project."""
+    """Deprecated: global active dataset selection has been removed."""
     with _silence_m4_logging() if json_output else nullcontext():
         result = set_active_dataset_service(target)
 
-    if isinstance(result, CommandError):
-        if json_output:
-            _emit_command_json(result)
-            raise typer.Exit(code=1)
-
-        title = {
-            "dataset_not_found": "Dataset Not Found",
-            "backend_incompatible": "Backend Incompatible",
-        }.get(result.code, "Command Failed")
-        print_error_panel(title, result.message, hint=result.hint)
-        raise typer.Exit(code=1)
-
     if json_output:
         _emit_command_json(result)
-        return
+        raise typer.Exit(code=1)
 
-    target = result.data["active_dataset"]
-    dataset = result.data["dataset"]
-    success(f"Active dataset set to '{target}'")
-
-    if not dataset["parquet_present"]:
-        warning(f"Local Parquet files not found at {dataset['parquet_root']}")
-        console.print(
-            "  [muted]This is fine if you are using the BigQuery backend.[/muted]"
-        )
-        console.print(
-            "  [muted]For DuckDB (local), run:[/muted] [command]m4 init[/command]"
-        )
-    else:
-        info("Local: Available", prefix="status")
-
-    if dataset["bigquery_available"]:
-        ds_def = DatasetRegistry.get(target)
-        info(
-            f"BigQuery: Available (Project: {ds_def.bigquery_project_id if ds_def else None})",
-            prefix="status",
-        )
+    print_error_panel("Active Dataset Removed", result.message, hint=result.hint)
+    raise typer.Exit(code=1)
 
 
 @app.command("backend")
@@ -1378,7 +1338,7 @@ def status_cmd(
         ),
     ] = False,
 ):
-    """Show active dataset status. Use --all for all supported datasets."""
+    """Show dataset status. Use --dataset for one dataset or --all for all."""
     if show_derived and json_output:
         _json_error(
             "status",
@@ -1393,28 +1353,28 @@ def status_cmd(
             _runtime_env_override(dataset=dataset_name, backend=backend_name),
         ):
             snapshot = collect_status_snapshot(
-                show_all=show_all, include_paths=include_paths
+                show_all=show_all,
+                include_paths=include_paths,
+                selected_dataset=dataset_name,
+                backend=backend_name,
             )
         _emit_json(snapshot)
         return
 
     # --derived: detailed per-table view (early return)
     if show_derived:
-        try:
-            active = get_active_dataset()
-        except DatasetError:
-            active = None
-        if not active:
-            console.print("[warning]No active dataset set.[/warning]")
+        selected = dataset_name.lower() if dataset_name else None
+        if not selected:
+            console.print("[warning]--dataset is required for --derived.[/warning]")
             raise typer.Exit()
 
-        if not has_derived_support(active):
+        if not has_derived_support(selected):
             console.print(
-                f"[muted]Derived tables are not available for '{active}'.[/muted]"
+                f"[muted]Derived tables are not available for '{selected}'.[/muted]"
             )
             raise typer.Exit()
 
-        backend = get_active_backend()
+        backend = (backend_name or get_active_backend()).lower()
         if backend == "bigquery":
             info(
                 "BigQuery backend active — derived tables are available "
@@ -1422,19 +1382,19 @@ def status_cmd(
             )
             raise typer.Exit()
 
-        db_path = get_default_database_path(active)
+        db_path = get_default_database_path(selected)
         if not db_path or not db_path.exists():
             console.print(
-                f"[warning]No DuckDB database found for '{active}'.[/warning]"
+                f"[warning]No DuckDB database found for '{selected}'.[/warning]"
             )
             console.print(
-                f"  [muted]Initialize with:[/muted] [command]m4 init {active}[/command]"
+                f"  [muted]Initialize with:[/muted] [command]m4 init {selected}[/command]"
             )
             raise typer.Exit()
 
-        categories = get_tables_by_category(active)
+        categories = get_tables_by_category(selected)
         materialized = list_materialized_tables(db_path)
-        print_derived_detail(active, categories, materialized)
+        print_derived_detail(selected, categories, materialized)
         return
 
     print_logo(show_tagline=False, show_version=True)
@@ -1442,9 +1402,12 @@ def status_cmd(
 
     with _runtime_env_override(dataset=dataset_name, backend=backend_name):
         snapshot = collect_status_snapshot(
-            show_all=show_all, include_paths=include_paths
+            show_all=show_all,
+            include_paths=include_paths,
+            selected_dataset=dataset_name,
+            backend=backend_name,
         )
-    active = snapshot["active_dataset"]
+    selected = snapshot["selected_dataset"]
     datasets = snapshot["datasets"]
 
     if show_all:
@@ -1467,22 +1430,21 @@ def status_cmd(
             for dataset in datasets
         ]
 
-        print_datasets_table(datasets_info, active_dataset=active)
+        print_datasets_table(datasets_info, selected_dataset=selected)
         return
 
-    # Default: show only active dataset with full detail
-    if not active:
-        console.print("[warning]No active dataset set.[/warning]")
+    if not selected:
+        console.print("[warning]No dataset selected.[/warning]")
         console.print()
         console.print(
-            "[muted]Set one with:[/muted] [command]m4 use <dataset>[/command]"
+            "[muted]Use:[/muted] [command]m4 status --dataset <dataset>[/command]"
         )
         console.print(
             "[muted]List all with:[/muted] [command]m4 status --all[/command]"
         )
         return
 
-    console.print(f"[bold]Active dataset:[/bold] [success]{active}[/success]")
+    console.print(f"[bold]Dataset:[/bold] [success]{selected}[/success]")
 
     backend = snapshot["backend"]
     backend_label = backend
@@ -1490,24 +1452,24 @@ def status_cmd(
         backend_label = f"{backend} ({snapshot['bigquery_project_id']})"
     console.print(f"[bold]Backend:[/bold] [success]{backend_label}[/success]")
 
-    # Get info for active dataset
+    # Get info for selected dataset
     dataset = datasets[0] if datasets else None
     if not dataset:
         console.print()
-        warning(f"Dataset '{active}' is set but not found locally.")
+        warning(f"Dataset '{selected}' was not found locally.")
         console.print(
-            f"  [muted]Initialize with:[/muted] [command]m4 init {active}[/command]"
+            f"  [muted]Initialize with:[/muted] [command]m4 init {selected}[/command]"
         )
         return
 
     if "parquet_path_mismatch" in dataset["warnings"]:
         warning("Database views may point to wrong parquet location")
         console.print(
-            f"  [muted]Try:[/muted] [command]m4 init {active} --force[/command]"
+            f"  [muted]Try:[/muted] [command]m4 init {selected} --force[/command]"
         )
 
     print_dataset_status(
-        name=active,
+        name=selected,
         parquet_present=dataset["parquet_present"],
         db_present=dataset["db_present"],
         parquet_root=dataset.get("parquet_root") or "",
@@ -1515,7 +1477,7 @@ def status_cmd(
         parquet_size_gb=dataset["parquet_size_gb"],
         bigquery_available=dataset["bigquery_available"],
         row_count=dataset["row_count"],
-        is_active=True,
+        is_selected=True,
         derived_materialized=dataset["derived"]["materialized"],
         derived_total=dataset["derived"]["total"],
         derived_has_support=dataset["derived"]["supported"],
@@ -1555,7 +1517,10 @@ def list_datasets_cmd(
                 path_disclosure=include_paths,
             )
             snapshot = collect_status_snapshot(
-                show_all=True, include_paths=include_paths
+                show_all=True,
+                include_paths=include_paths,
+                selected_dataset=dataset_name,
+                backend=backend_name,
             )
 
     if json_output:
@@ -1563,7 +1528,7 @@ def list_datasets_cmd(
             _agent_success_payload(
                 "list-datasets",
                 {
-                    "active_dataset": snapshot["active_dataset"],
+                    "selected_dataset": snapshot["selected_dataset"],
                     "backend": snapshot["backend"],
                     "datasets": snapshot["datasets"],
                     "raw_paths_hidden": not include_paths,
@@ -1585,7 +1550,7 @@ def list_datasets_cmd(
         }
         for dataset in snapshot["datasets"]
     ]
-    print_datasets_table(datasets_info, active_dataset=snapshot["active_dataset"])
+    print_datasets_table(datasets_info, selected_dataset=snapshot["selected_dataset"])
 
 
 @app.command("schema")

--- a/src/m4/client.py
+++ b/src/m4/client.py
@@ -92,6 +92,34 @@ class M4Client:
         """Execute a read-only SQL query."""
         return self._invoke("execute_query", ExecuteQueryInput(sql_query=sql))
 
+    def with_dataset(self, dataset: str | DatasetDefinition) -> "M4Client":
+        """Return a new client with the same context but a different dataset.
+
+        This keeps dataset transitions explicit while preserving session
+        attribution, backend selection, project settings, and path disclosure.
+        """
+        return M4Client(
+            dataset=dataset,
+            backend=self.backend if self.backend is not None else self.backend_name,
+            study_id=self.context.study_id,
+            session_id=self.context.session_id,
+            actor=self.context.actor,
+            interface=self.context.interface,
+            project_id=self.context.project_id,
+            db_path=self.context.db_path,
+            path_disclosure=self.context.path_disclosure,
+        )
+
+    def switch_dataset(self, dataset: str | DatasetDefinition) -> "M4Client":
+        """Switch this client to another dataset and return itself.
+
+        Prefer ``with_dataset()`` for concurrent or reproducible workflows. This
+        mutating helper is intended for notebook-style, single-session use.
+        """
+        self.dataset = self._resolve_dataset(dataset)
+        self.context = replace(self.context, dataset=self.dataset)
+        return self
+
     def list_datasets(self) -> list[str]:
         """Return registered dataset names."""
         _ensure_custom_datasets_loaded()

--- a/src/m4/client.py
+++ b/src/m4/client.py
@@ -1,6 +1,5 @@
 """First-class Python client for M4 data access."""
 
-import os
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -10,7 +9,6 @@ import pandas as pd
 from m4.config import (
     _ensure_custom_datasets_loaded,
     get_active_backend,
-    get_bigquery_project_id,
 )
 from m4.core.backends import Backend, get_backend
 from m4.core.context import M4ExecutionContext
@@ -36,7 +34,7 @@ class M4Client:
 
     def __init__(
         self,
-        dataset: str | DatasetDefinition | None = None,
+        dataset: str | DatasetDefinition | None,
         backend: str | Backend | None = None,
         study_id: str | None = None,
         session_id: str | None = None,
@@ -72,23 +70,11 @@ class M4Client:
     def from_active(
         cls, interface: str = "python_api", allow_missing_dataset: bool = False
     ) -> "M4Client":
-        """Create a client from active runtime configuration and environment."""
-        path_disclosure = os.getenv("M4_PATH_DISCLOSURE", "").lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-            "paths",
-        }
-        return cls(
-            interface=interface,
-            study_id=os.getenv("M4_STUDY_ID"),
-            session_id=os.getenv("M4_SESSION_ID"),
-            actor=os.getenv("M4_ACTOR"),
-            project_id=get_bigquery_project_id(),
-            db_path=os.getenv("M4_DB_PATH"),
-            path_disclosure=path_disclosure,
-            allow_missing_dataset=allow_missing_dataset,
+        """Deprecated compatibility shim for removed global dataset state."""
+        raise DatasetError(
+            "M4Client.from_active() has been removed because M4 no longer keeps "
+            "a global active dataset. Use M4Client(dataset='mimic-iv', ...) "
+            "instead."
         )
 
     def schema(self) -> dict[str, Any]:
@@ -200,12 +186,12 @@ class M4Client:
             return dataset
 
         if dataset is None:
-            try:
-                return DatasetRegistry.get_active()
-            except DatasetError:
-                if allow_missing_dataset:
-                    return DatasetRegistry.list_all()[0]
-                raise
+            if allow_missing_dataset:
+                return DatasetRegistry.list_all()[0]
+            raise DatasetError(
+                "A dataset is required. Use M4Client(dataset='mimic-iv') or pass "
+                "dataset='mimic-iv' to a top-level convenience function."
+            )
 
         resolved = DatasetRegistry.get(dataset.lower())
         if resolved is None:

--- a/src/m4/config.py
+++ b/src/m4/config.py
@@ -181,13 +181,8 @@ def resolve_runtime_context(
     backend: str | None = None,
     path_disclosure: bool | None = None,
 ) -> M4Context:
-    """Resolve runtime context with CLI flag > env > config/default precedence."""
+    """Resolve runtime context for explicit command/client settings."""
     resolved_dataset = dataset
-    if resolved_dataset is None:
-        try:
-            resolved_dataset = get_active_dataset()
-        except DatasetError:
-            resolved_dataset = None
 
     resolved_backend = (backend or get_active_backend()).lower()
     env_home = os.getenv("M4_HOME")
@@ -254,7 +249,7 @@ def get_dataset_parquet_root(dataset_name: str) -> Path | None:
 
 
 # -----------------------------
-# Runtime config (active dataset)
+# Runtime config
 # -----------------------------
 def _ensure_data_dirs():
     _DEFAULT_DATABASES_DIR.mkdir(parents=True, exist_ok=True)
@@ -268,7 +263,6 @@ def _get_default_runtime_config() -> dict:
     # We initialize with empty overrides.
     # Paths are derived dynamically from registry unless overridden here.
     return {
-        "active_dataset": None,
         "duckdb_paths": {},  # Map dataset_name -> path
         "parquet_roots": {},  # Map dataset_name -> path
         "bigquery_project_id": None,
@@ -280,7 +274,9 @@ def load_runtime_config() -> dict:
     _ensure_data_dirs()
     if _RUNTIME_CONFIG_PATH.exists():
         try:
-            return json.loads(_RUNTIME_CONFIG_PATH.read_text())
+            cfg = json.loads(_RUNTIME_CONFIG_PATH.read_text())
+            cfg.pop("active_dataset", None)
+            return {**_get_default_runtime_config(), **cfg}
         except Exception:
             logger.warning("Could not parse runtime config; using defaults")
     # defaults
@@ -336,50 +332,20 @@ def detect_available_local_datasets() -> dict[str, dict[str, Any]]:
 
 
 def get_active_dataset() -> str:
-    """Get the active dataset name.
-
-    Raises:
-        DatasetError: If no dataset is configured and none can be auto-detected.
-    """
-    # Ensure custom datasets are loaded so they can be found in the registry
-    _ensure_custom_datasets_loaded()
-
-    # Priority 1: Environment variable
-    env_dataset = os.getenv("M4_DATASET")
-    if env_dataset:
-        return env_dataset
-
-    # Priority 2: Config file
-    cfg = load_runtime_config()
-    active = cfg.get("active_dataset")
-
-    # Else, raise an error that no active dataset is configured.
-    if not active:
-        raise DatasetError(
-            "No active dataset configured. Please rerun 'm4 init' to configure a dataset."
-        )
-
-    return active
+    """Deprecated compatibility shim for removed global dataset state."""
+    raise DatasetError(
+        "Global active dataset state has been removed. Pass the dataset explicitly: "
+        "M4Client(dataset='mimic-iv') or execute_query(sql, dataset='mimic-iv')."
+    )
 
 
 def set_active_dataset(choice: str) -> None:
-    """Set the active dataset.
-
-    Args:
-        choice: Dataset name to set as active
-
-    Raises:
-        ValueError: If the dataset is not registered
-    """
-    _ensure_custom_datasets_loaded()
-    valid_names = {ds.name for ds in DatasetRegistry.list_all()}
-
-    if choice not in valid_names:
-        raise ValueError(f"active_dataset must be a registered dataset. Got: {choice}")
-
-    cfg = load_runtime_config()
-    cfg["active_dataset"] = choice
-    save_runtime_config(cfg)
+    """Deprecated compatibility shim for removed global dataset state."""
+    raise DatasetError(
+        f"Cannot set active dataset to '{choice}'. Global active dataset state has "
+        "been removed. Use M4Client(dataset=...) or pass dataset=... to the "
+        "top-level convenience functions."
+    )
 
 
 VALID_BACKENDS = {"duckdb", "bigquery"}

--- a/src/m4/console.py
+++ b/src/m4/console.py
@@ -289,15 +289,15 @@ def print_dataset_status(
     parquet_size_gb: float | None = None,
     bigquery_available: bool = False,
     row_count: int | None = None,
-    is_active: bool = False,
+    is_selected: bool = False,
     derived_materialized: int | None = None,
     derived_total: int | None = None,
     derived_has_support: bool = False,
     derived_is_bigquery: bool = False,
 ) -> None:
     """Print formatted dataset status information."""
-    # Header with active indicator
-    status_indicator = "[success] (active)[/success]" if is_active else ""
+    # Header with selected indicator
+    status_indicator = "[success] (selected)[/success]" if is_selected else ""
     console.print(f"\n[brand]{name.upper()}[/brand]{status_indicator}")
 
     # Status icons
@@ -359,7 +359,7 @@ def print_error_panel(title: str, message: str, hint: str | None = None) -> None
 
 def print_datasets_table(
     datasets: list[dict],
-    active_dataset: str | None = None,
+    selected_dataset: str | None = None,
 ) -> None:
     """
     Print a compact table of all datasets.
@@ -367,7 +367,7 @@ def print_datasets_table(
     Args:
         datasets: List of dicts with keys: name, parquet_present, db_present,
                   bigquery_available, parquet_size_gb (optional)
-        active_dataset: Name of the currently active dataset
+        selected_dataset: Name of the dataset selected for this status view
     """
     table = Table(
         show_header=True,
@@ -377,7 +377,7 @@ def print_datasets_table(
     )
 
     table.add_column("Dataset", style="bold")
-    table.add_column("Active", justify="center")
+    table.add_column("Selected", justify="center")
     table.add_column("Local", justify="center")
     table.add_column("BigQuery", justify="center")
     table.add_column("Derived", justify="center")
@@ -385,10 +385,10 @@ def print_datasets_table(
 
     for ds in datasets:
         name = ds["name"]
-        is_active = name == active_dataset
+        is_selected = name == selected_dataset
 
-        # Active indicator
-        active_str = "[success]*[/success]" if is_active else "[muted]-[/muted]"
+        # Selected indicator
+        selected_str = "[success]*[/success]" if is_selected else "[muted]-[/muted]"
 
         # Local status (combine parquet + duckdb)
         pq = ds.get("parquet_present", False)
@@ -421,6 +421,6 @@ def print_datasets_table(
         else:
             size_str = "[muted]-[/muted]"
 
-        table.add_row(name, active_str, local_str, bq_str, derived_str, size_str)
+        table.add_row(name, selected_str, local_str, bq_str, derived_str, size_str)
 
     console.print(table)

--- a/src/m4/core/backends/base.py
+++ b/src/m4/core/backends/base.py
@@ -234,7 +234,7 @@ class Backend(Protocol):
         """Get human-readable information about the current backend.
 
         Args:
-            dataset: The active dataset definition
+            dataset: The dataset definition
 
         Returns:
             Formatted string with backend details (type, connection info, etc.)

--- a/src/m4/core/backends/bigquery.py
+++ b/src/m4/core/backends/bigquery.py
@@ -185,7 +185,7 @@ class BigQueryBackend:
                 error=(
                     f"Dataset '{dataset.name}' is not available in BigQuery. "
                     f"Use 'm4 backend duckdb' to switch to local database, "
-                    f"or 'm4 use <dataset>' to choose a BigQuery-enabled dataset."
+                    f"or pass a BigQuery-enabled dataset explicitly."
                 ),
             )
 
@@ -348,7 +348,7 @@ class BigQueryBackend:
                 error=(
                     f"Dataset '{dataset.name}' is not available in BigQuery. "
                     f"Use 'm4 backend duckdb' to switch to local database, "
-                    f"or 'm4 use <dataset>' to choose a BigQuery-enabled dataset."
+                    f"or pass a BigQuery-enabled dataset explicitly."
                 ),
             )
 
@@ -444,7 +444,7 @@ class BigQueryBackend:
                 error=(
                     f"Dataset '{dataset.name}' is not available in BigQuery. "
                     f"Use 'm4 backend duckdb' to switch to local database, "
-                    f"or 'm4 use <dataset>' to choose a BigQuery-enabled dataset."
+                    f"or pass a BigQuery-enabled dataset explicitly."
                 ),
             )
 
@@ -475,7 +475,7 @@ class BigQueryBackend:
         """Get human-readable information about the current backend.
 
         Args:
-            dataset: The active dataset definition
+            dataset: The dataset definition
 
         Returns:
             Formatted string with backend details
@@ -489,7 +489,7 @@ class BigQueryBackend:
 
         return (
             f"**Current Backend:** BigQuery (cloud database)\n"
-            f"**Active Dataset:** {dataset.name}\n"
+            f"**Dataset:** {dataset.name}\n"
             f"**Project ID:** {project_id}\n"
             f"**Dataset IDs:** {dataset_ids}"
         )

--- a/src/m4/core/backends/duckdb.py
+++ b/src/m4/core/backends/duckdb.py
@@ -349,14 +349,13 @@ class DuckDBBackend:
         """Get human-readable information about the current backend.
 
         Args:
-            dataset: The active dataset definition
+            dataset: The dataset definition
 
         Returns:
             Formatted string with backend details
         """
         info = (
-            f"**Current Backend:** DuckDB (local database)\n"
-            f"**Active Dataset:** {dataset.name}"
+            f"**Current Backend:** DuckDB (local database)\n**Dataset:** {dataset.name}"
         )
         disclose = (
             context.path_disclosure

--- a/src/m4/core/datasets.py
+++ b/src/m4/core/datasets.py
@@ -146,35 +146,12 @@ class DatasetRegistry:
 
     @classmethod
     def get_active(cls) -> DatasetDefinition:
-        """Get the currently active dataset definition.
-
-        This method retrieves the active dataset from config and returns
-        its definition. Raises an error if no active dataset is configured.
-
-        Returns:
-            DatasetDefinition for the active dataset
-
-        Raises:
-            DatasetError: If no active dataset is configured or dataset not found
-        """
-        # Import here to avoid circular dependency
-        from m4.config import get_active_dataset
-
-        active_ds_name = get_active_dataset()
-        if not active_ds_name:
-            raise DatasetError(
-                "No active dataset configured. "
-                "Use `set_dataset('dataset-name')` to select a dataset."
-            )
-
-        ds_def = cls.get(active_ds_name)
-        if not ds_def:
-            raise DatasetError(
-                f"Active dataset '{active_ds_name}' not found in registry. "
-                f"Available datasets: {', '.join(d.name for d in cls.list_all())}"
-            )
-
-        return ds_def
+        """Deprecated compatibility shim for removed global dataset state."""
+        raise DatasetError(
+            "DatasetRegistry.get_active() is no longer supported because M4 no "
+            "longer keeps a global active dataset. Resolve datasets explicitly "
+            "with DatasetRegistry.get(name) or M4Client(dataset=name)."
+        )
 
     @classmethod
     def reset(cls):

--- a/src/m4/core/telemetry.py
+++ b/src/m4/core/telemetry.py
@@ -84,7 +84,7 @@ class ToolCallRecord:
             captured. Groups tool calls by terminal session — all processes
             spawned from the same terminal share this value. None on
             platforms without os.getsid (Windows).
-        dataset_name: Active dataset at call time (e.g., 'mimic-iv')
+        dataset_name: Dataset selected for the call (e.g., 'mimic-iv')
         timestamp: ISO 8601 UTC timestamp of call start
         duration_ms: Wall-clock time in milliseconds
         success: True if tool returned without exception

--- a/src/m4/core/tools/__init__.py
+++ b/src/m4/core/tools/__init__.py
@@ -13,7 +13,6 @@ import threading
 from m4.core.tools.base import Tool, ToolInput, ToolOutput
 from m4.core.tools.management import (
     ListDatasetsTool,
-    SetDatasetTool,
 )
 from m4.core.tools.notes import (
     GetNoteTool,
@@ -58,7 +57,6 @@ def init_tools() -> None:
 
         # Register management tools (always available)
         ToolRegistry.register(ListDatasetsTool())
-        ToolRegistry.register(SetDatasetTool())
 
         # Register tabular data tools
         ToolRegistry.register(GetDatabaseSchemaTool())
@@ -95,7 +93,6 @@ __all__ = [
     "ListDatasetsTool",
     "ListPatientNotesTool",
     "SearchNotesTool",
-    "SetDatasetTool",
     "Tool",
     "ToolInput",
     "ToolOutput",

--- a/src/m4/core/tools/base.py
+++ b/src/m4/core/tools/base.py
@@ -2,7 +2,7 @@
 
 This module defines the core Tool protocol that all M4 tools must implement.
 Tools declare their required modalities and are automatically filtered based
-on the active dataset's modalities.
+on the selected dataset's modalities.
 
 Architecture Note:
     Tools return native Python types (DataFrame, list, dict, str, None).

--- a/src/m4/core/tools/management.py
+++ b/src/m4/core/tools/management.py
@@ -2,7 +2,7 @@
 
 This module provides tools for switching between datasets and listing
 available datasets. These tools are always available regardless of
-the active dataset.
+the selected request dataset.
 
 All tools use config functions directly - no circular dependencies.
 
@@ -18,8 +18,8 @@ from typing import Any
 from m4.config import (
     detect_available_local_datasets,
     get_active_backend,
-    get_active_dataset,
-    set_active_dataset,
+    get_active_dataset,  # noqa: F401 - retained for compatibility patch targets
+    set_active_dataset,  # noqa: F401 - retained for compatibility patch targets
 )
 from m4.core.context import M4ExecutionContext
 from m4.core.datasets import DatasetDefinition, DatasetRegistry, Modality
@@ -50,7 +50,7 @@ class ListDatasetsTool:
     both locally (DuckDB) and remotely (BigQuery).
 
     Returns:
-        dict with active dataset, backend info, and dataset availability
+        dict with selected dataset, backend info, and dataset availability
     """
 
     name = "list_datasets"
@@ -71,14 +71,14 @@ class ListDatasetsTool:
 
         Returns:
             dict with:
-                - active_dataset: str | None - Currently active dataset
+                - selected_dataset: str | None - Request-scoped dataset, if any
                 - backend: str - Backend type (duckdb or bigquery)
                 - datasets: dict[str, dict] - Dataset availability info
         """
         try:
-            active = get_active_dataset()
+            selected = context.dataset.name if context else None
         except Exception:
-            active = context.dataset.name if context else None
+            selected = None
         availability = detect_available_local_datasets()
         backend_name = context.backend_name if context else get_active_backend()
 
@@ -104,7 +104,8 @@ class ListDatasetsTool:
                 }
 
             datasets_info[label] = {
-                "is_active": label == active,
+                "is_active": label == selected,
+                "selected": label == selected,
                 "parquet_present": info["parquet_present"],
                 "db_present": info["db_present"],
                 "bigquery_support": bool(ds_def and ds_def.bigquery_dataset_ids),
@@ -113,7 +114,8 @@ class ListDatasetsTool:
             }
 
         return {
-            "active_dataset": active,
+            "active_dataset": selected,
+            "selected_dataset": selected,
             "backend": backend_name,
             "datasets": datasets_info,
         }
@@ -124,14 +126,7 @@ class ListDatasetsTool:
 
 
 class SetDatasetTool:
-    """Tool for switching the active dataset.
-
-    Changes which dataset subsequent queries will run against.
-    Automatically handles both DuckDB and BigQuery backends.
-
-    Returns:
-        dict with new dataset info and any warnings
-    """
+    """Deprecated compatibility shim for removed global dataset state."""
 
     name = "set_dataset"
     description = "🔄 Switch to a different dataset"
@@ -147,70 +142,10 @@ class SetDatasetTool:
         params: SetDatasetInput,
         context: M4ExecutionContext | None = None,
     ) -> dict[str, Any]:
-        """Switch to a different dataset.
-
-        Returns:
-            dict with:
-                - dataset_name: str - New active dataset
-                - db_present: bool - Whether local DB exists
-                - bigquery_support: bool - Whether BigQuery is configured
-                - modalities: list[str] - Available modalities
-                - warnings: list[str] - Any warnings
-
-        Raises:
-            DatasetError: If dataset doesn't exist
-        """
-        dataset_name = params.dataset_name.lower()
-        availability = detect_available_local_datasets()
-        backend_name = context.backend_name if context else get_active_backend()
-
-        if dataset_name not in availability:
-            supported = ", ".join(availability.keys())
-            raise DatasetError(
-                f"Dataset '{dataset_name}' not found. Supported datasets: {supported}",
-                dataset_name=dataset_name,
-            )
-
-        # Check backend compatibility before switching
-        info = availability[dataset_name]
-        ds_def = DatasetRegistry.get(dataset_name)
-
-        if ds_def and not ds_def.bigquery_dataset_ids and backend_name == "bigquery":
-            available = [
-                name
-                for name in availability
-                if (ds := DatasetRegistry.get(name)) and ds.bigquery_dataset_ids
-            ]
-            hint = (
-                f" BigQuery-compatible datasets: {', '.join(available)}."
-                if available
-                else ""
-            )
-            raise DatasetError(
-                f"Dataset '{dataset_name}' is not available on the BigQuery backend."
-                f"{hint}"
-                f" Or switch to DuckDB: set the M4_BACKEND environment variable"
-                f" or run `m4 backend duckdb`.",
-                dataset_name=dataset_name,
-            )
-
-        set_active_dataset(dataset_name)
-
-        warnings: list[str] = []
-
-        if not info["db_present"] and backend_name == "duckdb":
-            warnings.append(
-                "Local database not found. "
-                "You may need to run initialization if using DuckDB."
-            )
-
-        return {
-            "dataset_name": dataset_name,
-            "db_present": info["db_present"],
-            "bigquery_support": bool(ds_def and ds_def.bigquery_dataset_ids),
-            "modalities": [m.name for m in ds_def.modalities] if ds_def else [],
-            "warnings": warnings,
-        }
+        raise DatasetError(
+            "set_dataset is no longer supported because M4 no longer keeps a "
+            "global active dataset. Pass dataset explicitly to each tool call."
+        )
 
     def is_compatible(self, dataset: DatasetDefinition) -> bool:
         """Management tools are always compatible."""

--- a/src/m4/core/tools/registry.py
+++ b/src/m4/core/tools/registry.py
@@ -40,7 +40,7 @@ class ToolRegistry:
 
     This class maintains a global registry of all tools that can be
     exposed via the MCP server. Tools are filtered dynamically based
-    on the active dataset's modalities.
+    on the explicitly selected dataset's modalities.
 
     Example:
         # Register tools
@@ -104,7 +104,7 @@ class ToolSelector:
     """Intelligent tool selection based on dataset modalities.
 
     This class provides the core filtering logic that determines which
-    tools should be exposed to the LLM based on the active dataset's
+    tools should be exposed to the LLM based on the selected dataset's
     declared modalities.
 
     Example:
@@ -279,7 +279,7 @@ class ToolSelector:
                 "",
                 "**Suggestions:**",
                 "   - Use `list_datasets()` to see all available datasets",
-                "   - Use `set_dataset('dataset-name')` to switch datasets",
+                "   - Pass `dataset='dataset-name'` explicitly for the tool call",
             ]
         )
 
@@ -320,7 +320,7 @@ class ToolSelector:
         snapshot_parts = [
             "",
             "─" * 40,
-            f"**Active dataset:** {dataset.name}",
+            f"**Dataset:** {dataset.name}",
             f"**Modalities:** {', '.join(modalities) or '(none)'}",
         ]
 

--- a/src/m4/mcp_client_configs/dynamic_mcp_config.py
+++ b/src/m4/mcp_client_configs/dynamic_mcp_config.py
@@ -227,9 +227,7 @@ class MCPConfigGenerator:
                 raise ValueError(_DATABASE_PATH_ERROR_MSG)
             print(f"Default database path: {default_db_path}")
 
-            print(
-                "\nLeaving database path empty allows switching datasets dynamically via 'm4 use'."
-            )
+            print("\nLeaving database path empty uses dataset-specific defaults.")
             db_path = (
                 input(
                     "DuckDB database path (optional, press Enter for dynamic): "

--- a/src/m4/mcp_server.py
+++ b/src/m4/mcp_server.py
@@ -15,7 +15,7 @@ Architecture:
 
 Tool Surface:
     The MCP tool surface is stable - all tools remain registered regardless of
-    the active dataset. Compatibility is enforced per-call via proactive
+    the selected dataset. Compatibility is enforced per-call via proactive
     capability checking before tool invocation.
 """
 
@@ -36,7 +36,8 @@ from m4.core.exceptions import M4Error
 from m4.core.serialization import serialize_for_mcp
 from m4.core.telemetry import set_interface
 from m4.core.tools import ToolSelector, init_tools
-from m4.core.tools.management import SetDatasetInput
+from m4.core.tools.management import ListDatasetsInput, ListDatasetsTool
+from m4.services.capabilities import build_capabilities_manifest
 
 # Create FastMCP server instance
 mcp = FastMCP("m4")
@@ -50,11 +51,10 @@ set_interface("mcp")
 # Tool selector for capability-based filtering
 _tool_selector = ToolSelector()
 
-# MCP-exposed tool names (for filtering in set_dataset snapshot)
+# MCP-exposed tool names (for capability snapshots)
 _MCP_TOOL_NAMES = frozenset(
     {
         "list_datasets",
-        "set_dataset",
         "get_database_schema",
         "get_table_info",
         "execute_query",
@@ -118,21 +118,23 @@ def _serialize_table_info_result(result: dict[str, Any]) -> str:
 
 def _serialize_datasets_result(result: dict[str, Any]) -> str:
     """Serialize list_datasets result to MCP string."""
-    active = result.get("active_dataset") or "(unset)"
+    selected = result.get("selected_dataset")
     backend = result.get("backend", "duckdb")
     datasets = result.get("datasets", {})
 
     if not datasets:
         return "No datasets detected."
 
-    output = [f"Active dataset: {active}\n"]
+    output = []
+    if selected:
+        output.append(f"Selected dataset: {selected}\n")
     output.append(
         f"Backend: {'local (DuckDB)' if backend == 'duckdb' else 'cloud (BigQuery)'}\n"
     )
 
     for label, info in datasets.items():
-        is_active = " (Active)" if info.get("is_active") else ""
-        output.append(f"=== {label.upper()}{is_active} ===")
+        is_selected = " (Selected)" if info.get("selected") else ""
+        output.append(f"=== {label.upper()}{is_selected} ===")
 
         parquet_icon = "✅" if info.get("parquet_present") else "❌"
         db_icon = "✅" if info.get("db_present") else "❌"
@@ -159,19 +161,6 @@ def _serialize_datasets_result(result: dict[str, Any]) -> str:
         output.append("")
 
     return "\n".join(output)
-
-
-def _serialize_set_dataset_result(result: dict[str, Any]) -> str:
-    """Serialize set_dataset result to MCP string."""
-    dataset_name = result.get("dataset_name", "")
-    warnings = result.get("warnings", [])
-
-    status_msg = f"✅ Active dataset switched to '{dataset_name}'."
-
-    for warning in warnings:
-        status_msg += f"\n⚠️ {warning}"
-
-    return status_msg
 
 
 def _serialize_search_notes_result(result: dict[str, Any]) -> str:
@@ -260,18 +249,21 @@ def _serialize_list_patient_notes_result(result: dict[str, Any]) -> str:
 # ==========================================
 
 
+def _client_for_dataset(dataset: str | None) -> M4Client:
+    resolved = dataset if dataset is not None else DatasetRegistry.get_active()
+    return M4Client(dataset=resolved, interface="mcp")
+
+
 @mcp.resource("m4://capabilities", mime_type="application/json")
 def capabilities_resource() -> str:
     """Return the M4 capability manifest as JSON."""
-    client = M4Client.from_active(interface="mcp", allow_missing_dataset=True)
-    return json.dumps(client.capabilities(), indent=2)
+    return json.dumps(build_capabilities_manifest(), indent=2)
 
 
 @mcp.tool()
 def capabilities() -> str:
     """Return the M4 capability manifest as JSON."""
-    client = M4Client.from_active(interface="mcp", allow_missing_dataset=True)
-    return json.dumps(client.capabilities(), indent=2)
+    return json.dumps(build_capabilities_manifest(), indent=2)
 
 
 @mcp.tool()
@@ -279,12 +271,12 @@ def list_datasets() -> str:
     """📋 List all available datasets and their status.
 
     Returns:
-        A formatted string listing available datasets, indicating which one is active,
+        A formatted string listing available datasets, indicating selected status,
         and showing availability of local database and BigQuery support.
     """
     try:
-        client = M4Client.from_active(interface="mcp")
-        result = client.dataset_status()
+        dummy = DatasetRegistry.list_all()[0]
+        result = ListDatasetsTool().invoke(dummy, ListDatasetsInput(), context=None)
         return _serialize_datasets_result(result)
     except M4Error as e:
         return f"**Error:** {e}"
@@ -292,52 +284,33 @@ def list_datasets() -> str:
 
 @mcp.tool()
 def set_dataset(dataset_name: str) -> str:
-    """🔄 Switch the active dataset.
-
-    Args:
-        dataset_name: The name of the dataset to switch to (e.g., 'mimic-iv-demo').
-
-    Returns:
-        Confirmation message with supported tools snapshot, or error if not found.
-    """
-    try:
-        # Check if target dataset exists before switching
-        target_dataset_def = DatasetRegistry.get(dataset_name.lower())
-
-        client = M4Client.from_active(interface="mcp")
-        result = client.invoke_tool(
-            "set_dataset", SetDatasetInput(dataset_name=dataset_name)
-        )
-        output = _serialize_set_dataset_result(result)
-
-        # Append supported tools snapshot if dataset is valid
-        if target_dataset_def is not None:
-            output += _tool_selector.get_supported_tools_snapshot(
-                target_dataset_def, _MCP_TOOL_NAMES
-            )
-
-        return output
-    except M4Error as e:
-        return f"**Error:** {e}"
+    """Deprecated: M4 no longer keeps a global active dataset."""
+    return (
+        "**Error:** set_dataset is no longer supported. M4 tools now require an "
+        "explicit dataset argument, for example dataset='mimic-iv'."
+    )
 
 
 @mcp.tool()
 @require_oauth2
-def get_database_schema() -> str:
+def get_database_schema(dataset: str | None = None) -> str:
     """📚 Discover what data is available in the database.
 
     **When to use:** Start here to understand what tables exist.
+
+    Args:
+        dataset: Dataset name, e.g. 'mimic-iv'.
 
     Returns:
         List of all available tables in the database with current backend info.
     """
     try:
-        client = M4Client.from_active(interface="mcp")
-        dataset = client.dataset
+        client = _client_for_dataset(dataset)
+        dataset_def = client.dataset
 
         # Proactive capability check
         compat_result = _tool_selector.check_compatibility(
-            "get_database_schema", dataset
+            "get_database_schema", dataset_def
         )
         if not compat_result.compatible:
             return compat_result.error_message
@@ -350,12 +323,15 @@ def get_database_schema() -> str:
 
 @mcp.tool()
 @require_oauth2
-def get_table_info(table_name: str, show_sample: bool = True) -> str:
+def get_table_info(
+    table_name: str, show_sample: bool = True, dataset: str | None = None
+) -> str:
     """🔍 Explore a specific table's structure and see sample data.
 
     **When to use:** After identifying relevant tables from get_database_schema().
 
     Args:
+        dataset: Dataset name, e.g. 'mimic-iv'.
         table_name: Exact table name (case-sensitive).
         show_sample: Whether to include sample rows (default: True).
 
@@ -363,11 +339,13 @@ def get_table_info(table_name: str, show_sample: bool = True) -> str:
         Table structure with column names, types, and sample data.
     """
     try:
-        client = M4Client.from_active(interface="mcp")
-        dataset = client.dataset
+        client = _client_for_dataset(dataset)
+        dataset_def = client.dataset
 
         # Proactive capability check
-        compat_result = _tool_selector.check_compatibility("get_table_info", dataset)
+        compat_result = _tool_selector.check_compatibility(
+            "get_table_info", dataset_def
+        )
         if not compat_result.compatible:
             return compat_result.error_message
 
@@ -382,7 +360,7 @@ def get_table_info(table_name: str, show_sample: bool = True) -> str:
 
 @mcp.tool()
 @require_oauth2
-def execute_query(sql_query: str) -> str:
+def execute_query(sql_query: str, dataset: str | None = None) -> str:
     """🚀 Execute SQL queries to analyze data.
 
     **Recommended workflow:**
@@ -391,17 +369,18 @@ def execute_query(sql_query: str) -> str:
     3. Write your SQL query with exact names
 
     Args:
+        dataset: Dataset name, e.g. 'mimic-iv'.
         sql_query: Your SQL SELECT query (SELECT only).
 
     Returns:
         Query results or helpful error messages.
     """
     try:
-        client = M4Client.from_active(interface="mcp")
-        dataset = client.dataset
+        client = _client_for_dataset(dataset)
+        dataset_def = client.dataset
 
         # Proactive capability check
-        compat_result = _tool_selector.check_compatibility("execute_query", dataset)
+        compat_result = _tool_selector.check_compatibility("execute_query", dataset_def)
         if not compat_result.compatible:
             return compat_result.error_message
 
@@ -424,6 +403,7 @@ def search_notes(
     note_type: str = "all",
     limit: int = 5,
     snippet_length: int = 300,
+    dataset: str | None = None,
 ) -> str:
     """🔍 Search clinical notes by keyword.
 
@@ -433,6 +413,7 @@ def search_notes(
     **Note types:** 'discharge' (summaries), 'radiology' (reports), or 'all'
 
     Args:
+        dataset: Dataset name, e.g. 'mimic-iv-note'.
         query: Search term to find in notes.
         note_type: Type of notes to search ('discharge', 'radiology', or 'all').
         limit: Maximum number of results per note type (default: 5).
@@ -442,10 +423,10 @@ def search_notes(
         Matching snippets with note IDs for follow-up retrieval.
     """
     try:
-        client = M4Client.from_active(interface="mcp")
-        dataset = client.dataset
+        client = _client_for_dataset(dataset)
+        dataset_def = client.dataset
 
-        compat_result = _tool_selector.check_compatibility("search_notes", dataset)
+        compat_result = _tool_selector.check_compatibility("search_notes", dataset_def)
         if not compat_result.compatible:
             return compat_result.error_message
 
@@ -462,7 +443,9 @@ def search_notes(
 
 @mcp.tool()
 @require_oauth2
-def get_note(note_id: str, max_length: int | None = None) -> str:
+def get_note(
+    note_id: str, max_length: int | None = None, dataset: str | None = None
+) -> str:
     """📄 Retrieve full text of a specific clinical note.
 
     **Warning:** Clinical notes can be very long. Consider using
@@ -470,6 +453,7 @@ def get_note(note_id: str, max_length: int | None = None) -> str:
     to truncate output.
 
     Args:
+        dataset: Dataset name, e.g. 'mimic-iv-note'.
         note_id: The note ID (e.g., from search_notes or list_patient_notes).
         max_length: Optional maximum characters to return (truncates if exceeded).
 
@@ -477,10 +461,10 @@ def get_note(note_id: str, max_length: int | None = None) -> str:
         Full note text, or truncated version if max_length specified.
     """
     try:
-        client = M4Client.from_active(interface="mcp")
-        dataset = client.dataset
+        client = _client_for_dataset(dataset)
+        dataset_def = client.dataset
 
-        compat_result = _tool_selector.check_compatibility("get_note", dataset)
+        compat_result = _tool_selector.check_compatibility("get_note", dataset_def)
         if not compat_result.compatible:
             return compat_result.error_message
 
@@ -499,6 +483,7 @@ def list_patient_notes(
     subject_id: int,
     note_type: str = "all",
     limit: int = 20,
+    dataset: str | None = None,
 ) -> str:
     """📋 List available clinical notes for a patient.
 
@@ -509,6 +494,7 @@ def list_patient_notes(
     use it here to find related clinical notes.
 
     Args:
+        dataset: Dataset name, e.g. 'mimic-iv-note'.
         subject_id: Patient identifier (same as in MIMIC-IV).
         note_type: Type of notes to list ('discharge', 'radiology', or 'all').
         limit: Maximum notes to return (default: 20).
@@ -517,11 +503,11 @@ def list_patient_notes(
         List of available notes with metadata for the patient.
     """
     try:
-        client = M4Client.from_active(interface="mcp")
-        dataset = client.dataset
+        client = _client_for_dataset(dataset)
+        dataset_def = client.dataset
 
         compat_result = _tool_selector.check_compatibility(
-            "list_patient_notes", dataset
+            "list_patient_notes", dataset_def
         )
         if not compat_result.compatible:
             return compat_result.error_message
@@ -549,7 +535,7 @@ def cohort_builder_ui() -> str:
 
 @mcp.tool()
 @require_oauth2
-def cohort_builder() -> str:
+def cohort_builder(dataset: str | None = None) -> str:
     """Launch the interactive cohort builder.
 
     Opens a visual interface for filtering patients by demographics and
@@ -563,11 +549,13 @@ def cohort_builder() -> str:
         interactive cohort builder interface.
     """
     try:
-        client = M4Client.from_active(interface="mcp")
-        dataset = client.dataset
+        client = _client_for_dataset(dataset)
+        dataset_def = client.dataset
 
         # Proactive capability check
-        compat_result = _tool_selector.check_compatibility("cohort_builder", dataset)
+        compat_result = _tool_selector.check_compatibility(
+            "cohort_builder", dataset_def
+        )
         if not compat_result.compatible:
             return compat_result.error_message
 
@@ -587,6 +575,7 @@ def query_cohort(
     icd_match_all: bool | None = None,
     has_icu_stay: bool | None = None,
     in_hospital_mortality: bool | None = None,
+    dataset: str | None = None,
 ) -> str:
     """Query cohort counts based on filtering criteria.
 
@@ -594,6 +583,7 @@ def query_cohort(
     Can also be called directly to get cohort statistics.
 
     Args:
+        dataset: Dataset name, e.g. 'mimic-iv'.
         age_min: Minimum patient age (0-130, inclusive).
         age_max: Maximum patient age (0-130, inclusive).
         gender: Patient gender ('M' or 'F').
@@ -606,11 +596,11 @@ def query_cohort(
         JSON with patient_count, admission_count, demographics, and SQL.
     """
     try:
-        client = M4Client.from_active(interface="mcp")
-        dataset = client.dataset
+        client = _client_for_dataset(dataset)
+        dataset_def = client.dataset
 
         # Proactive capability check
-        compat_result = _tool_selector.check_compatibility("query_cohort", dataset)
+        compat_result = _tool_selector.check_compatibility("query_cohort", dataset_def)
         if not compat_result.compatible:
             # Return JSON error for UI compatibility
             return json.dumps({"error": compat_result.error_message})

--- a/src/m4/services/agent_env.py
+++ b/src/m4/services/agent_env.py
@@ -38,7 +38,6 @@ def build_agent_env_service(
     )
     env = {
         "M4_HOME": str(ctx.home),
-        "M4_DATASET": ctx.dataset,
         "M4_BACKEND": ctx.backend,
         "M4_STUDY_ID": ctx.study_id,
         "M4_SESSION_ID": ctx.session_id,

--- a/src/m4/services/backend.py
+++ b/src/m4/services/backend.py
@@ -2,28 +2,19 @@ from __future__ import annotations
 
 from m4.config import (
     VALID_BACKENDS,
-    get_active_dataset,
+    get_active_dataset,  # noqa: F401 - retained for compatibility patch targets
     get_bigquery_project_id,
     set_active_backend,
     set_bigquery_project_id,
 )
-from m4.core.datasets import DatasetRegistry
-from m4.core.exceptions import DatasetError
+from m4.core.datasets import DatasetRegistry  # noqa: F401 - compatibility patch target
 from m4.services.results import (
-    ERROR_DATASET_INCOMPATIBLE,
     ERROR_INVALID_BACKEND,
     ERROR_INVALID_OPTION,
     ERROR_PROJECT_ID_REQUIRED,
     CommandError,
     CommandResult,
 )
-
-
-def _get_active_dataset_or_none() -> str | None:
-    try:
-        return get_active_dataset()
-    except DatasetError:
-        return None
 
 
 def set_active_backend_service(
@@ -47,19 +38,6 @@ def set_active_backend_service(
             message="--project-id can only be used with bigquery backend.",
         )
 
-    active_dataset = _get_active_dataset_or_none()
-    if target == "bigquery" and active_dataset:
-        ds_def = DatasetRegistry.get(active_dataset)
-        if ds_def and not ds_def.bigquery_dataset_ids:
-            return CommandError(
-                command="backend",
-                code=ERROR_DATASET_INCOMPATIBLE,
-                message=(
-                    f"Current dataset '{active_dataset}' is not available on BigQuery."
-                ),
-                hint="Switch dataset first: m4 use <dataset>",
-            )
-
     effective_project_id = None
     if target == "bigquery":
         effective_project_id = project_id or get_bigquery_project_id()
@@ -79,7 +57,6 @@ def set_active_backend_service(
         command="backend",
         data={
             "backend": target,
-            "active_dataset": active_dataset,
             "bigquery_project_id": (
                 project_id or effective_project_id or get_bigquery_project_id()
             ),

--- a/src/m4/services/capabilities.py
+++ b/src/m4/services/capabilities.py
@@ -7,7 +7,6 @@ from typing import Any
 from m4.config import (
     ensure_custom_datasets_loaded,
     get_active_backend,
-    get_active_dataset,
     get_bigquery_project_id,
 )
 from m4.core.datasets import DatasetDefinition, DatasetRegistry
@@ -149,10 +148,6 @@ def _derived_inventory() -> dict[str, Any]:
 def build_capabilities_manifest() -> dict[str, Any]:
     """Return the stable M4 capability manifest."""
     ensure_custom_datasets_loaded()
-    try:
-        active_dataset = get_active_dataset()
-    except Exception:
-        active_dataset = None
 
     commands = [
         {"name": "capabilities", "flags": ["--json"], "mutates": False},
@@ -245,9 +240,9 @@ def build_capabilities_manifest() -> dict[str, Any]:
             "output_formats": ["text", "json", "dotenv"],
         },
         "runtime": {
-            "active_dataset": active_dataset,
             "backend": get_active_backend(),
             "bigquery_project_id_configured": bool(get_bigquery_project_id()),
+            "dataset_selection": "explicit",
         },
         "commands": commands,
         "tools": _tool_payloads(),

--- a/src/m4/services/init.py
+++ b/src/m4/services/init.py
@@ -7,7 +7,7 @@ from m4.config import (
     get_active_backend,
     get_dataset_parquet_root,
     get_default_database_path,
-    set_active_dataset,
+    set_active_dataset,  # noqa: F401 - retained for compatibility patch targets
 )
 from m4.console import console
 from m4.core.datasets import DatasetRegistry
@@ -286,8 +286,6 @@ def initialize_dataset_service(
             steps.append(
                 _step("verification", "skipped", "No verification table configured.")
             )
-
-        set_active_dataset(dataset_key)
 
         if has_derived_support(dataset_key) and get_active_backend() == "duckdb":
             try:

--- a/src/m4/services/setup.py
+++ b/src/m4/services/setup.py
@@ -10,11 +10,11 @@ from typing import Any
 from m4.config import (
     ensure_custom_datasets_loaded,
     get_active_backend,
-    get_active_dataset,
+    get_active_dataset,  # noqa: F401 - retained for compatibility patch targets
     get_bigquery_project_id,
     resolve_runtime_context,
     set_active_backend,
-    set_active_dataset,
+    set_active_dataset,  # noqa: F401 - retained for compatibility patch targets
     set_bigquery_project_id,
 )
 from m4.core.datasets import DatasetRegistry
@@ -68,21 +68,6 @@ def doctor_service(*, include_paths: bool = False) -> CommandResult:
         )
     )
 
-    try:
-        active_dataset = get_active_dataset()
-        checks.append(_check("active_dataset", True, active_dataset))
-    except Exception as exc:
-        active_dataset = None
-        checks.append(
-            _check(
-                "active_dataset",
-                False,
-                str(exc),
-                "Run m4 quickstart or m4 use <dataset>.",
-            )
-        )
-        warnings.append("no_active_dataset")
-
     backend = get_active_backend()
     checks.append(
         _check(
@@ -94,20 +79,6 @@ def doctor_service(*, include_paths: bool = False) -> CommandResult:
     )
 
     snapshot = collect_status_snapshot(show_all=True, include_paths=include_paths)
-    if backend == "duckdb" and active_dataset:
-        active_status = next(
-            (ds for ds in snapshot["datasets"] if ds["name"] == active_dataset), None
-        )
-        checks.append(
-            _check(
-                f"duckdb:{active_dataset}",
-                bool(active_status and active_status["db_present"]),
-                "local DuckDB present"
-                if active_status and active_status["db_present"]
-                else "local DuckDB missing",
-                f"Run m4 init {active_dataset}.",
-            )
-        )
 
     for ds in snapshot["datasets"]:
         warnings.extend(ds.get("warnings", []))
@@ -201,8 +172,6 @@ def setup_agent_service(
         )
 
     if apply_config:
-        if dataset:
-            set_active_dataset(dataset)
         if backend:
             set_active_backend(resolved_backend)
         if project_id:
@@ -212,7 +181,6 @@ def setup_agent_service(
     env = {
         "M4_HOME": str(ctx.home),
         "M4_BACKEND": resolved_backend,
-        "M4_DATASET": dataset or ctx.dataset,
         "M4_TELEMETRY_DIR": str(ctx.telemetry_dir),
     }
     if mode == "local":
@@ -306,7 +274,10 @@ def quickstart_service(
                     "command": f"m4 backend bigquery --project-id {project_id or 'YOUR_PROJECT_ID'}",
                     "mutates": True,
                 },
-                {"command": f"m4 use {resolved_dataset}", "mutates": True},
+                {
+                    "command": f"m4 status --dataset {resolved_dataset}",
+                    "mutates": False,
+                },
             ]
         )
 
@@ -314,8 +285,6 @@ def quickstart_service(
         set_active_backend(resolved_backend)
         if project_id:
             set_bigquery_project_id(project_id)
-        if DatasetRegistry.get(resolved_dataset):
-            set_active_dataset(resolved_dataset)
 
     return CommandResult(
         command="quickstart",

--- a/src/m4/services/status.py
+++ b/src/m4/services/status.py
@@ -10,7 +10,6 @@ from m4.config import (
 from m4.core.datasets import DatasetRegistry
 from m4.core.derived.builtins import has_derived_support, list_builtins
 from m4.core.derived.materializer import get_derived_table_count
-from m4.core.exceptions import DatasetError
 from m4.data_io import compute_parquet_dir_size, verify_table_rowcount
 from m4.services.results import WARNING_PARQUET_PATH_MISMATCH
 
@@ -29,7 +28,7 @@ def _is_path_mismatch_error(exc: Exception) -> bool:
 def _collect_dataset_status(
     name: str,
     ds_info: dict[str, Any],
-    active_dataset: str | None,
+    selected_dataset: str | None,
     backend: str,
     *,
     include_row_count: bool,
@@ -104,7 +103,7 @@ def _collect_dataset_status(
 
     result = {
         "name": name,
-        "active": name == active_dataset,
+        "selected": name == selected_dataset,
         "raw_present": raw_present,
         "parquet_present": parquet_present,
         "db_present": db_present,
@@ -132,17 +131,21 @@ def _collect_dataset_status(
 
 
 def collect_status_snapshot(
-    show_all: bool, include_paths: bool = False
+    show_all: bool,
+    include_paths: bool = False,
+    selected_dataset: str | None = None,
+    backend: str | None = None,
 ) -> dict[str, Any]:
-    try:
-        active = get_active_dataset()
-    except DatasetError:
-        active = None
-
-    backend = get_active_backend()
+    selected = selected_dataset.lower() if selected_dataset else None
+    if selected is None:
+        try:
+            selected = get_active_dataset()
+        except Exception:
+            selected = None
+    backend_name = (backend or get_active_backend()).lower()
     availability = detect_available_local_datasets()
 
-    dataset_names = list(availability) if show_all else ([active] if active else [])
+    dataset_names = list(availability) if show_all else ([selected] if selected else [])
     datasets = []
     for name in dataset_names:
         ds_info = availability.get(name)
@@ -152,8 +155,8 @@ def collect_status_snapshot(
             _collect_dataset_status(
                 name,
                 ds_info,
-                active,
-                backend,
+                selected,
+                backend_name,
                 include_row_count=not show_all,
                 include_paths=include_paths,
             )
@@ -161,8 +164,9 @@ def collect_status_snapshot(
 
     return {
         "version": 1,
-        "active_dataset": active,
-        "backend": backend,
+        "active_dataset": selected,
+        "selected_dataset": selected,
+        "backend": backend_name,
         "bigquery_project_id": get_bigquery_project_id(),
         "datasets": datasets,
     }

--- a/src/m4/services/use.py
+++ b/src/m4/services/use.py
@@ -1,76 +1,26 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
-
 from m4.config import (
-    detect_available_local_datasets,
-    get_active_backend,
-    set_active_dataset,
+    detect_available_local_datasets,  # noqa: F401 - compatibility patch target
+    get_active_backend,  # noqa: F401 - compatibility patch target
+    set_active_dataset,  # noqa: F401 - compatibility patch target
 )
-from m4.core.datasets import DatasetRegistry
 from m4.services.results import (
-    ERROR_BACKEND_INCOMPATIBLE,
-    ERROR_DATASET_NOT_FOUND,
-    WARNING_LOCAL_DB_MISSING,
-    WARNING_LOCAL_PARQUET_MISSING,
     CommandError,
-    CommandResult,
 )
 
 
-def _absolute_path_or_none(path_value: str | Path | None) -> str | None:
-    if not path_value:
-        return None
-    return str(Path(path_value).expanduser().resolve())
-
-
-def _supported_datasets_text() -> str:
-    return ", ".join([ds.name for ds in DatasetRegistry.list_all()])
-
-
-def set_active_dataset_service(target: str) -> CommandResult | CommandError:
-    """Set the active dataset and return a machine-readable command result."""
-    target = target.lower()
-
-    availability = detect_available_local_datasets().get(target)
-    if not availability:
-        return CommandError(
-            command="use",
-            code=ERROR_DATASET_NOT_FOUND,
-            message=f"Dataset '{target}' not found or not registered.",
-            hint=f"Supported datasets: {_supported_datasets_text()}",
-        )
-
-    ds_def = DatasetRegistry.get(target)
-    backend_name = get_active_backend()
-
-    if ds_def and not ds_def.bigquery_dataset_ids and backend_name == "bigquery":
-        return CommandError(
-            command="use",
-            code=ERROR_BACKEND_INCOMPATIBLE,
-            message=f"Dataset '{target}' is not available on the BigQuery backend.",
-            hint="Switch to DuckDB first: m4 backend duckdb",
-        )
-
-    set_active_dataset(target)
-
-    warnings = []
-    if not availability["parquet_present"]:
-        warnings.append(WARNING_LOCAL_PARQUET_MISSING)
-    if backend_name == "duckdb" and not availability["db_present"]:
-        warnings.append(WARNING_LOCAL_DB_MISSING)
-
-    data: dict[str, Any] = {
-        "active_dataset": target,
-        "backend": backend_name,
-        "dataset": {
-            "name": target,
-            "parquet_present": bool(availability["parquet_present"]),
-            "db_present": bool(availability["db_present"]),
-            "parquet_root": _absolute_path_or_none(availability.get("parquet_root")),
-            "db_path": _absolute_path_or_none(availability.get("db_path")),
-            "bigquery_available": bool(ds_def and ds_def.bigquery_dataset_ids),
-        },
-    }
-    return CommandResult(command="use", data=data, warnings=warnings)
+def set_active_dataset_service(target: str) -> CommandError:
+    """Return migration guidance for the removed active dataset command."""
+    return CommandError(
+        command="use",
+        code="active_dataset_removed",
+        message=(
+            "Global active dataset state has been removed. Commands and APIs now "
+            "require an explicit dataset."
+        ),
+        hint=(
+            "Use --dataset on CLI commands, M4Client(dataset=...) in Python, or "
+            "dataset=... on MCP tool calls."
+        ),
+    )

--- a/src/m4/skills/clinical/apache-iv-score/SKILL.md
+++ b/src/m4/skills/clinical/apache-iv-score/SKILL.md
@@ -57,7 +57,7 @@ For pre-computed APACHE IV scores:
 - `eicu_crd.apachepredvar` - Demographics and mapped diagnosis categories
 - `eicu_crd.patient` - Patient outcomes and demographics
 
-Call `set_dataset("eicu")` before running these queries.
+Pass `dataset="eicu"` when running these queries through the M4 Python API.
 
 ## Critical Implementation Notes
 

--- a/src/m4/skills/system/clinical-research-session/SKILL.md
+++ b/src/m4/skills/system/clinical-research-session/SKILL.md
@@ -79,7 +79,7 @@ Every analysis step that produces a result shown in vitrine MUST be executed fro
 Interactive exploration (checking schemas, small test queries to understand data shape) is fine — not everything needs a script. But the moment you produce a result you'll show to the researcher, it comes from a stored script.
 
 **Script requirements:**
-- **Self-contained**: imports, `set_dataset()`, SQL strings, analysis code, output writes — everything to run `python scripts/01_cohort_definition.py` from the output directory
+- **Self-contained**: imports, explicit dataset selection, SQL strings, analysis code, output writes — everything to run `python scripts/01_cohort_definition.py` from the output directory
 - **Relative paths**: use `out = Path(__file__).resolve().parent.parent` to locate `data/` and `plots/`
 - **Saves outputs**: `.parquet` to `data/`, `.json` to `plots/` via `fig.write_json()` (never `.html` or `.png`)
 - **Plotly reload**: `plotly.io.from_json(open("plots/fig.json").read())` to reconstruct a `Figure` for `show()`
@@ -91,9 +91,8 @@ Interactive exploration (checking schemas, small test queries to understand data
 (output_dir / "scripts" / "01_cohort_definition.py").write_text('''\
 """01 — Define sepsis cohort from MIMIC-IV."""
 from pathlib import Path
-from m4 import execute_query, set_dataset
+from m4 import execute_query
 
-set_dataset("mimic-iv")
 out = Path(__file__).resolve().parent.parent
 
 sql = """
@@ -104,7 +103,7 @@ INNER JOIN mimiciv_derived.icustay_detail i ON s.stay_id = i.stay_id
 INNER JOIN mimiciv_hosp.admissions a ON s.hadm_id = a.hadm_id
 WHERE i.first_icu_stay = true AND i.admission_age >= 18
 """
-cohort = execute_query(sql)
+cohort = execute_query(sql, dataset="mimic-iv")
 cohort.to_parquet(out / "data" / "cohort.parquet")
 print(f"Cohort: {len(cohort)} patients")
 ''')

--- a/src/m4/skills/system/m4-api/SKILL.md
+++ b/src/m4/skills/system/m4-api/SKILL.md
@@ -59,6 +59,8 @@ df = execute_query(
 |----------|---------|-------------|
 | `list_datasets()` | `list[str]` | Available dataset names |
 | `M4Client(dataset=...)` | `M4Client` | Preferred explicit client for one dataset |
+| `client.with_dataset(name)` | `M4Client` | New client with the same session context and a different dataset |
+| `client.switch_dataset(name)` | `M4Client` | Mutate a client to another dataset for notebook-style sessions |
 
 ### Tabular Data (requires TABULAR modality)
 
@@ -131,15 +133,19 @@ For blocking review (agent waits for researcher approval), use `show(df, wait=Tr
 
 ## Dataset Selection
 
-**Important:** Dataset selection is explicit. Prefer `M4Client(dataset=...)` when several calls target the same dataset, or pass `dataset=...` to each convenience function.
+**Important:** Dataset selection is explicit. Prefer `M4Client(dataset=...)` when several calls target the same dataset, or pass `dataset=...` to each convenience function. For a long-lived session, use `client.with_dataset(...)` to create a new client for another dataset without mutating the current one. Use `client.switch_dataset(...)` only for single-session, notebook-style workflows where mutation is expected.
 
 ```python
 from m4 import M4Client, execute_query
 
 client = M4Client(dataset="mimic-iv")
-df1 = client.execute_query("SELECT COUNT(*) FROM mimiciv_hosp.patients")
+df1 = client.query("SELECT COUNT(*) FROM mimiciv_hosp.patients")
 
-df2 = execute_query("SELECT COUNT(*) FROM patient", dataset="eicu")
+eicu_client = client.with_dataset("eicu")
+df2 = eicu_client.query("SELECT COUNT(*) FROM patient")
+
+client.switch_dataset("mimic-iv-note")  # mutates client and its execution context
+df3 = execute_query("SELECT COUNT(*) FROM patient", dataset="eicu")
 ```
 
 ## MCP Tool Equivalence

--- a/src/m4/skills/system/m4-api/SKILL.md
+++ b/src/m4/skills/system/m4-api/SKILL.md
@@ -25,27 +25,29 @@ The M4 Python API provides programmatic access to clinical datasets for code exe
 
 **You must follow this sequence:**
 
-1. `set_dataset()` - Select which dataset to query (REQUIRED FIRST)
-2. `get_schema()` / `get_table_info()` - Explore available tables
+1. Choose a dataset name and pass it explicitly, or create `M4Client(dataset=...)`
+2. `get_schema(dataset=...)` / `get_table_info(..., dataset=...)` - Explore available tables
 3. `execute_query()` - Run SQL queries
 
 ```python
-from m4 import set_dataset, get_schema, get_table_info, execute_query
+from m4 import get_schema, get_table_info, execute_query
 
-# Step 1: Always set dataset first
-set_dataset("mimic-iv")  # or "mimic-iv-demo", "eicu", "mimic-iv-note"
+dataset = "mimic-iv"  # or "mimic-iv-demo", "eicu", "mimic-iv-note"
 
-# Step 2: Explore schema
-schema = get_schema()
+# Step 1: Explore schema
+schema = get_schema(dataset=dataset)
 print(schema['tables'])  # List of table names
 
-# Step 3: Inspect specific tables before querying
-info = get_table_info("mimiciv_hosp.patients")
+# Step 2: Inspect specific tables before querying
+info = get_table_info("mimiciv_hosp.patients", dataset=dataset)
 print(info['schema'])  # DataFrame with column names, types
 print(info['sample'])  # DataFrame with sample rows
 
-# Step 4: Execute queries
-df = execute_query("SELECT gender, COUNT(*) as n FROM mimiciv_hosp.patients GROUP BY gender")
+# Step 3: Execute queries
+df = execute_query(
+    "SELECT gender, COUNT(*) as n FROM mimiciv_hosp.patients GROUP BY gender",
+    dataset=dataset,
+)
 # Returns pd.DataFrame - use pandas operations freely
 ```
 
@@ -56,27 +58,26 @@ df = execute_query("SELECT gender, COUNT(*) as n FROM mimiciv_hosp.patients GROU
 | Function | Returns | Description |
 |----------|---------|-------------|
 | `list_datasets()` | `list[str]` | Available dataset names |
-| `set_dataset(name)` | `str` | Set active dataset (confirmation message) |
-| `get_active_dataset()` | `str` | Get current dataset name |
+| `M4Client(dataset=...)` | `M4Client` | Preferred explicit client for one dataset |
 
 ### Tabular Data (requires TABULAR modality)
 
 | Function | Returns | Description |
 |----------|---------|-------------|
-| `get_schema()` | `dict` | `{'backend_info': str, 'tables': list[str]}` |
-| `get_table_info(table, show_sample=True)` | `dict` | `{'schema': DataFrame, 'sample': DataFrame}` |
-| `execute_query(sql)` | `DataFrame` | Query results as pandas DataFrame |
+| `get_schema(dataset=...)` | `dict` | `{'backend_info': str, 'tables': list[str]}` |
+| `get_table_info(table, dataset=..., show_sample=True)` | `dict` | `{'schema': DataFrame, 'sample': DataFrame}` |
+| `execute_query(sql, dataset=...)` | `DataFrame` | Query results as pandas DataFrame |
 
-`backend_info` summarizes the backend and active dataset. Local DuckDB paths are
+`backend_info` summarizes the backend and dataset. Local DuckDB paths are
 hidden unless `M4_PATH_DISCLOSURE=1` is set for the process.
 
 ### Clinical Notes (requires NOTES modality)
 
 | Function | Returns | Description |
 |----------|---------|-------------|
-| `search_notes(query, note_type, limit, snippet_length)` | `dict` | `{'results': dict[str, DataFrame]}` |
-| `get_note(note_id, max_length)` | `dict` | `{'text': str, 'subject_id': int, ...}` |
-| `list_patient_notes(subject_id, note_type, limit)` | `dict` | `{'notes': dict[str, DataFrame]}` |
+| `search_notes(query, dataset=..., note_type, limit, snippet_length)` | `dict` | `{'results': dict[str, DataFrame]}` |
+| `get_note(note_id, dataset=..., max_length)` | `dict` | `{'text': str, 'subject_id': int, ...}` |
+| `list_patient_notes(subject_id, dataset=..., note_type, limit)` | `dict` | `{'notes': dict[str, DataFrame]}` |
 
 ## Error Handling
 
@@ -92,23 +93,22 @@ M4Error (base)
 **Recovery patterns:**
 
 ```python
-from m4 import execute_query, set_dataset, DatasetError, QueryError, ModalityError
+from m4 import execute_query, DatasetError, QueryError, ModalityError
 
 try:
-    df = execute_query("SELECT * FROM mimiciv_hosp.patients")
+    df = execute_query("SELECT * FROM mimiciv_hosp.patients", dataset="mimic-iv")
 except DatasetError as e:
-    # No dataset selected, or dataset not found
-    # Recovery: call set_dataset() first, or check list_datasets()
-    set_dataset("mimic-iv")
-    df = execute_query("SELECT * FROM mimiciv_hosp.patients")
+    # Dataset missing, not initialized, or misspelled.
+    # Recovery: check list_datasets() and m4 status --dataset mimic-iv.
+    print(f"Dataset problem: {e}")
 except QueryError as e:
     # SQL error or table not found
     # Recovery: check table name with get_schema(), fix SQL syntax
     print(f"Query failed: {e}")
 except ModalityError as e:
     # Tried notes function on tabular-only dataset
-    # Recovery: switch to dataset with NOTES modality
-    set_dataset("mimic-iv-note")
+    # Recovery: pass dataset="mimic-iv-note" to notes functions
+    print(f"Modality problem: {e}")
 ```
 
 ## Displaying Results
@@ -119,23 +119,27 @@ Use `show()` from the vitrine module to present query results to the researcher 
 from m4 import execute_query
 from vitrine import show
 
-df = execute_query("SELECT gender, COUNT(*) as n FROM mimiciv_hosp.patients GROUP BY gender")
+df = execute_query(
+    "SELECT gender, COUNT(*) as n FROM mimiciv_hosp.patients GROUP BY gender",
+    dataset="mimic-iv",
+)
 df.to_csv("output/demographics.csv", index=False)  # Save for reproducibility
 show(df, title="Demographics", study="my-study")   # Show for review
 ```
 
 For blocking review (agent waits for researcher approval), use `show(df, wait=True, prompt="Proceed?")`. For the full display API, use the `vitrine-api` skill.
 
-## Dataset State
+## Dataset Selection
 
-**Important:** Dataset selection is module-level state that persists across function calls.
+**Important:** Dataset selection is explicit. Prefer `M4Client(dataset=...)` when several calls target the same dataset, or pass `dataset=...` to each convenience function.
 
 ```python
-set_dataset("mimic-iv")
-df1 = execute_query("SELECT COUNT(*) FROM mimiciv_hosp.patients")  # Uses mimic-iv
+from m4 import M4Client, execute_query
 
-set_dataset("eicu")
-df2 = execute_query("SELECT COUNT(*) FROM patient")        # Uses eicu
+client = M4Client(dataset="mimic-iv")
+df1 = client.execute_query("SELECT COUNT(*) FROM mimiciv_hosp.patients")
+
+df2 = execute_query("SELECT COUNT(*) FROM patient", dataset="eicu")
 ```
 
 ## MCP Tool Equivalence

--- a/src/m4/skills/system/m4-setup/SKILL.md
+++ b/src/m4/skills/system/m4-setup/SKILL.md
@@ -24,12 +24,11 @@ Run commands from the M4 repo root unless the user is intentionally working else
 ```bash
 pwd
 uv run python - <<'PY'
-from m4 import list_datasets, get_active_dataset
-print("active:", get_active_dataset())
+from m4 import list_datasets
 print("datasets:", list_datasets())
 PY
 uv run m4 status --all
-uv run m4 agent-env --json
+uv run m4 agent-env --dataset mimic-iv-demo --json
 uv run m4 skills --list
 uv run vitrine status
 ```
@@ -61,7 +60,7 @@ find "${M4_DATA_DIR:-m4_data}/databases" -maxdepth 1 -type f -name '*.duckdb' -p
 find "${M4_DATA_DIR:-m4_data}/datasets" -maxdepth 1 -type f -name '*.json' -print
 ```
 
-Use `set_dataset("name")` before querying, then inspect schema with `get_schema()` and `get_table_info()`.
+Pass `dataset="name"` when querying, then inspect schema with `get_schema(dataset=...)` and `get_table_info(..., dataset=...)`.
 
 ## Skill Installation Repair
 
@@ -81,7 +80,6 @@ Check `${M4_HOME:-${M4_DATA_DIR:-m4_data}}/config.json`:
 | Field | Meaning |
 |-------|---------|
 | `backend` | `duckdb` or `bigquery` |
-| `active_dataset` | Dataset used by API calls |
 | `bigquery_project_id` | Billing/project id for BigQuery |
 
 For local work, `backend: "duckdb"` requires the matching file in the data
@@ -104,6 +102,6 @@ Use the `vitrine-api` skill for display API details.
 ## Recovery Rules
 
 - Prefer `uv run ...` commands to avoid using the wrong environment.
-- Do not guess table names. Call `get_schema()` and `get_table_info()` after `set_dataset()`.
+- Do not guess table names. Call `get_schema(dataset=...)` and `get_table_info(..., dataset=...)`.
 - If a dataset appears in `m4 status --all` but not in `list_datasets()`, check the data directory's `datasets/*.json` files and reload through the M4 API.
 - If skills reference missing functions or outdated tables, compare the installed copy with `src/m4/skills` and reinstall from the canonical source.

--- a/tests/core/test_datasets.py
+++ b/tests/core/test_datasets.py
@@ -216,20 +216,17 @@ class TestDatasetRegistryEdgeCases:
         DatasetRegistry.reset()
         assert DatasetRegistry.get("nonexistent-dataset-xyz") is None
 
-    def test_get_active_no_config_raises(self, monkeypatch):
-        """get_active() raises DatasetError when no dataset is configured."""
+    def test_get_active_raises_removed_state_error(self):
+        """get_active() raises DatasetError because global state was removed."""
         import pytest
 
-        import m4.config as cfg
         from m4.core.exceptions import DatasetError
 
-        monkeypatch.setattr(cfg, "get_active_dataset", lambda: None)
-
-        with pytest.raises(DatasetError, match="No active dataset"):
+        with pytest.raises(DatasetError, match=r"DatasetRegistry\.get_active"):
             DatasetRegistry.get_active()
 
-    def test_get_active_unknown_dataset_raises(self, monkeypatch):
-        """get_active() raises DatasetError when config points to unknown dataset."""
+    def test_get_active_ignores_legacy_config(self, monkeypatch):
+        """get_active() does not route through legacy active dataset config."""
         import pytest
 
         import m4.config as cfg
@@ -237,7 +234,7 @@ class TestDatasetRegistryEdgeCases:
 
         monkeypatch.setattr(cfg, "get_active_dataset", lambda: "no-such-dataset")
 
-        with pytest.raises(DatasetError, match="not found in registry"):
+        with pytest.raises(DatasetError, match=r"DatasetRegistry\.get_active"):
             DatasetRegistry.get_active()
 
     def test_custom_json_oversized_file_skipped(self, tmp_path):

--- a/tests/core/tools/test_management.py
+++ b/tests/core/tools/test_management.py
@@ -80,7 +80,7 @@ class TestListDatasetsTool:
                     # Result is now a dict
                     assert "mimic-iv-demo" in result["datasets"]
                     assert "mimic-iv" in result["datasets"]
-                    assert result["active_dataset"] == "mimic-iv-demo"
+                    assert result["selected_dataset"] is None
 
     def test_invoke_shows_parquet_status(self, mock_availability, dummy_dataset):
         """Test that parquet availability is included."""
@@ -218,135 +218,18 @@ class TestListDatasetsTool:
 
 
 class TestSetDatasetTool:
-    """Test SetDatasetTool functionality."""
+    """Test deprecated SetDatasetTool behavior."""
 
-    def test_invoke_switches_to_valid_dataset(self, mock_availability, dummy_dataset):
-        """Test successful dataset switch."""
-        with patch(
-            "m4.core.tools.management.detect_available_local_datasets",
-            return_value=mock_availability,
-        ):
-            with patch("m4.core.tools.management.set_active_dataset") as mock_set:
-                with patch("m4.core.tools.management.DatasetRegistry.get") as mock_reg:
-                    mock_reg.return_value = DatasetDefinition(
-                        name="mimic-iv-demo", bigquery_dataset_ids=[]
-                    )
-                    with patch(
-                        "m4.core.tools.management.get_active_backend",
-                        return_value="duckdb",
-                    ):
-                        tool = SetDatasetTool()
-                        params = SetDatasetInput(dataset_name="mimic-iv-demo")
-                        result = tool.invoke(dummy_dataset, params)
+    def test_invoke_raises_migration_error(self, dummy_dataset):
+        """set_dataset no longer mutates global state."""
+        tool = SetDatasetTool()
+        params = SetDatasetInput(dataset_name="mimic-iv-demo")
 
-                        mock_set.assert_called_once_with("mimic-iv-demo")
-                        assert result["dataset_name"] == "mimic-iv-demo"
+        with pytest.raises(DatasetError) as exc_info:
+            tool.invoke(dummy_dataset, params)
 
-    def test_invoke_rejects_unknown_dataset(self, mock_availability, dummy_dataset):
-        """Test rejection of unknown dataset raises DatasetError."""
-        with patch(
-            "m4.core.tools.management.detect_available_local_datasets",
-            return_value=mock_availability,
-        ):
-            with patch("m4.core.tools.management.set_active_dataset") as mock_set:
-                tool = SetDatasetTool()
-                params = SetDatasetInput(dataset_name="unknown-dataset")
-
-                with pytest.raises(DatasetError) as exc_info:
-                    tool.invoke(dummy_dataset, params)
-
-                mock_set.assert_not_called()
-                assert "not found" in str(exc_info.value)
-
-    def test_invoke_shows_supported_datasets_on_error(
-        self, mock_availability, dummy_dataset
-    ):
-        """Test that error message lists supported datasets."""
-        with patch(
-            "m4.core.tools.management.detect_available_local_datasets",
-            return_value=mock_availability,
-        ):
-            with patch("m4.core.tools.management.set_active_dataset"):
-                tool = SetDatasetTool()
-                params = SetDatasetInput(dataset_name="nonexistent")
-
-                with pytest.raises(DatasetError) as exc_info:
-                    tool.invoke(dummy_dataset, params)
-
-                assert "mimic-iv-demo" in str(exc_info.value)
-                assert "mimic-iv" in str(exc_info.value)
-
-    def test_invoke_warns_missing_db_for_duckdb(self, mock_availability, dummy_dataset):
-        """Test warning when database file is missing for DuckDB backend."""
-        # Modify availability: parquet present but db missing
-        availability = {
-            "mimic-iv-demo": {
-                "parquet_present": True,
-                "db_present": False,  # Missing!
-            },
-        }
-
-        with patch(
-            "m4.core.tools.management.detect_available_local_datasets",
-            return_value=availability,
-        ):
-            with patch("m4.core.tools.management.set_active_dataset"):
-                with patch("m4.core.tools.management.DatasetRegistry.get") as mock_reg:
-                    mock_reg.return_value = DatasetDefinition(
-                        name="mimic-iv-demo", bigquery_dataset_ids=[]
-                    )
-                    with patch.dict("os.environ", {"M4_BACKEND": "duckdb"}):
-                        tool = SetDatasetTool()
-                        params = SetDatasetInput(dataset_name="mimic-iv-demo")
-                        result = tool.invoke(dummy_dataset, params)
-
-                        assert "Local database not found" in result["warnings"][0]
-
-    def test_invoke_blocks_no_bigquery_config(self, mock_availability, dummy_dataset):
-        """Test that switching to a dataset without BigQuery config is blocked."""
-        with patch(
-            "m4.core.tools.management.detect_available_local_datasets",
-            return_value=mock_availability,
-        ):
-            with patch("m4.core.tools.management.set_active_dataset") as mock_set:
-                with patch("m4.core.tools.management.DatasetRegistry.get") as mock_reg:
-                    mock_reg.return_value = DatasetDefinition(
-                        name="mimic-iv-demo",
-                        bigquery_dataset_ids=[],  # No BigQuery config
-                    )
-                    with patch.dict("os.environ", {"M4_BACKEND": "bigquery"}):
-                        tool = SetDatasetTool()
-                        params = SetDatasetInput(dataset_name="mimic-iv-demo")
-
-                        with pytest.raises(DatasetError) as exc_info:
-                            tool.invoke(dummy_dataset, params)
-
-                        mock_set.assert_not_called()
-                        assert "not available on the BigQuery backend" in str(
-                            exc_info.value
-                        )
-
-    def test_invoke_case_insensitive(self, mock_availability, dummy_dataset):
-        """Test that dataset name lookup is case-insensitive."""
-        with patch(
-            "m4.core.tools.management.detect_available_local_datasets",
-            return_value=mock_availability,
-        ):
-            with patch("m4.core.tools.management.set_active_dataset") as mock_set:
-                with patch("m4.core.tools.management.DatasetRegistry.get") as mock_reg:
-                    mock_reg.return_value = DatasetDefinition(
-                        name="mimic-iv-demo", bigquery_dataset_ids=[]
-                    )
-                    with patch(
-                        "m4.core.tools.management.get_active_backend",
-                        return_value="duckdb",
-                    ):
-                        tool = SetDatasetTool()
-                        params = SetDatasetInput(dataset_name="MIMIC-IV-DEMO")
-                        tool.invoke(dummy_dataset, params)
-
-                        # Should normalize to lowercase
-                        mock_set.assert_called_once_with("mimic-iv-demo")
+        assert "no longer keeps a global active dataset" in str(exc_info.value)
+        assert "Pass dataset explicitly" in str(exc_info.value)
 
     def test_is_compatible_always_true(self):
         """Test that management tools are always compatible."""

--- a/tests/core/tools/test_registry.py
+++ b/tests/core/tools/test_registry.py
@@ -314,7 +314,6 @@ class TestInitTools:
 
         # Management tools
         assert "list_datasets" in tool_names
-        assert "set_dataset" in tool_names
 
         # Tabular tools
         assert "get_database_schema" in tool_names
@@ -326,8 +325,8 @@ class TestInitTools:
         assert "get_note" in tool_names
         assert "list_patient_notes" in tool_names
 
-        # Total: 8 tools (2 management + 3 tabular + 3 notes)
-        assert len(all_tools) == 8
+        # Total: 7 registered tools (1 management + 3 tabular + 3 notes)
+        assert len(all_tools) == 7
 
         # Cleanup
         reset_tools()
@@ -343,9 +342,9 @@ class TestInitTools:
         init_tools()
         init_tools()
 
-        # Should still have exactly 8 tools
+        # Should still have exactly 7 tools
         all_tools = ToolRegistry.list_all()
-        assert len(all_tools) == 8
+        assert len(all_tools) == 7
 
         reset_tools()
 
@@ -354,14 +353,14 @@ class TestInitTools:
         from m4.core.tools import init_tools, reset_tools
 
         init_tools()
-        assert len(ToolRegistry.list_all()) == 8
+        assert len(ToolRegistry.list_all()) == 7
 
         reset_tools()
         assert len(ToolRegistry.list_all()) == 0
 
         # Can reinitialize after reset
         init_tools()
-        assert len(ToolRegistry.list_all()) == 8
+        assert len(ToolRegistry.list_all()) == 7
 
         reset_tools()
 
@@ -375,7 +374,6 @@ class TestInitTools:
             ListDatasetsTool,
             ListPatientNotesTool,
             SearchNotesTool,
-            SetDatasetTool,
         )
 
         tool_classes = [
@@ -383,7 +381,6 @@ class TestInitTools:
             GetTableInfoTool,
             ExecuteQueryTool,
             ListDatasetsTool,
-            SetDatasetTool,
             SearchNotesTool,
             GetNoteTool,
             ListPatientNotesTool,
@@ -415,7 +412,6 @@ class TestInitTools:
 
         # Management tools should always be available
         assert "list_datasets" in demo_names
-        assert "set_dataset" in demo_names
 
         # Tabular tools should be available for demo
         assert "get_database_schema" in demo_names
@@ -433,10 +429,9 @@ class TestInitTools:
 
     def test_management_tools_always_compatible(self):
         """Test that management tools work with any dataset."""
-        from m4.core.tools import ListDatasetsTool, SetDatasetTool
+        from m4.core.tools import ListDatasetsTool
 
         list_tool = ListDatasetsTool()
-        set_tool = SetDatasetTool()
 
         # Create a minimal dataset
         minimal_ds = DatasetDefinition(
@@ -446,4 +441,3 @@ class TestInitTools:
 
         # Management tools should be compatible with any dataset
         assert list_tool.is_compatible(minimal_ds)
-        assert set_tool.is_compatible(minimal_ds)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -78,43 +78,27 @@ class TestDatasetManagement:
         assert len(datasets) > 0
         assert all(isinstance(d, str) for d in datasets)
 
-    @patch("m4.api._set_active_dataset")
-    def test_set_dataset_success(self, mock_set, mock_tabular_dataset):
-        """Test setting a valid dataset."""
-        result = set_dataset("test-tabular")
-        assert "test-tabular" in result
-        mock_set.assert_called_once_with("test-tabular")
-
-    @patch("m4.api._set_active_dataset")
-    def test_set_dataset_invalid_raises_error(self, mock_set):
-        """Test setting invalid dataset raises DatasetError."""
-        mock_set.side_effect = ValueError("Dataset not found")
+    def test_set_dataset_raises_migration_error(self, mock_tabular_dataset):
+        """set_dataset is retained only as migration guidance."""
         with pytest.raises(DatasetError) as exc_info:
-            set_dataset("nonexistent-dataset")
-        assert "Available datasets" in str(exc_info.value)
+            set_dataset("test-tabular")
+        assert "no longer supported" in str(exc_info.value)
+        assert "M4Client(dataset=" in str(exc_info.value)
 
-    @patch("m4.api._get_active_dataset")
-    def test_get_active_dataset(self, mock_get):
-        """Test getting the active dataset name."""
-        mock_get.return_value = "mimic-iv"
-        assert get_active_dataset() == "mimic-iv"
-
-    @patch("m4.api._get_active_dataset")
-    def test_get_active_dataset_none_raises_error(self, mock_get):
-        """Test getting active dataset when none is set."""
-        mock_get.side_effect = DatasetError("No active dataset")
-        with pytest.raises(DatasetError):
+    def test_get_active_dataset_raises_migration_error(self):
+        """get_active_dataset is retained only as migration guidance."""
+        with pytest.raises(DatasetError) as exc_info:
             get_active_dataset()
+        assert "no longer supported" in str(exc_info.value)
+        assert "dataset explicitly" in str(exc_info.value)
 
 
 class TestTabularDataAPI:
     """Test tabular data API functions."""
 
     @patch(TABULAR_BACKEND_PATCH)
-    @patch("m4.api.DatasetRegistry.get_active")
-    def test_get_schema(self, mock_get_active, mock_get_backend, mock_tabular_dataset):
+    def test_get_schema(self, mock_get_backend, mock_tabular_dataset):
         """Test get_schema returns dict with tables."""
-        mock_get_active.return_value = mock_tabular_dataset
         mock_backend = MagicMock()
         mock_backend.get_table_list.return_value = [
             "mimiciv_hosp.patients",
@@ -123,7 +107,7 @@ class TestTabularDataAPI:
         mock_backend.get_backend_info.return_value = "Backend: DuckDB"
         mock_get_backend.return_value = mock_backend
 
-        result = get_schema()
+        result = get_schema(dataset="test-tabular")
 
         # Result is now a dict with 'tables' key
         assert isinstance(result, dict)
@@ -132,28 +116,20 @@ class TestTabularDataAPI:
         mock_backend.get_table_list.assert_called_once()
 
     @patch(TABULAR_BACKEND_PATCH)
-    @patch("m4.api.DatasetRegistry.get_active")
-    def test_get_schema_empty(
-        self, mock_get_active, mock_get_backend, mock_tabular_dataset
-    ):
+    def test_get_schema_empty(self, mock_get_backend, mock_tabular_dataset):
         """Test get_schema with no tables."""
-        mock_get_active.return_value = mock_tabular_dataset
         mock_backend = MagicMock()
         mock_backend.get_table_list.return_value = []
         mock_backend.get_backend_info.return_value = "Backend: DuckDB"
         mock_get_backend.return_value = mock_backend
 
-        result = get_schema()
+        result = get_schema(dataset="test-tabular")
 
         assert result["tables"] == []
 
     @patch(TABULAR_BACKEND_PATCH)
-    @patch("m4.api.DatasetRegistry.get_active")
-    def test_get_table_info(
-        self, mock_get_active, mock_get_backend, mock_tabular_dataset
-    ):
+    def test_get_table_info(self, mock_get_backend, mock_tabular_dataset):
         """Test get_table_info returns dict with schema DataFrame."""
-        mock_get_active.return_value = mock_tabular_dataset
         mock_backend = MagicMock()
         schema_df = pd.DataFrame({"name": ["subject_id"], "type": ["INTEGER"]})
         sample_df = pd.DataFrame({"subject_id": [1], "gender": ["M"]})
@@ -170,7 +146,7 @@ class TestTabularDataAPI:
         mock_backend.get_backend_info.return_value = "Backend: DuckDB"
         mock_get_backend.return_value = mock_backend
 
-        result = get_table_info("patients")
+        result = get_table_info("patients", dataset="test-tabular")
 
         # Result is now a dict
         assert isinstance(result, dict)
@@ -179,12 +155,8 @@ class TestTabularDataAPI:
         assert isinstance(result["sample"], pd.DataFrame)
 
     @patch(TABULAR_BACKEND_PATCH)
-    @patch("m4.api.DatasetRegistry.get_active")
-    def test_execute_query_success(
-        self, mock_get_active, mock_get_backend, mock_tabular_dataset
-    ):
+    def test_execute_query_success(self, mock_get_backend, mock_tabular_dataset):
         """Test execute_query returns DataFrame."""
-        mock_get_active.return_value = mock_tabular_dataset
         mock_backend = MagicMock()
         result_df = pd.DataFrame({"count": [100]})
         mock_result = MagicMock()
@@ -193,70 +165,50 @@ class TestTabularDataAPI:
         mock_backend.execute_query.return_value = mock_result
         mock_get_backend.return_value = mock_backend
 
-        result = execute_query("SELECT COUNT(*) FROM patients")
+        result = execute_query("SELECT COUNT(*) FROM patients", dataset="test-tabular")
 
         assert isinstance(result, pd.DataFrame)
         assert result["count"].iloc[0] == 100
 
     @patch(TABULAR_BACKEND_PATCH)
-    @patch("m4.api.DatasetRegistry.get_active")
     def test_execute_query_unsafe_raises_error(
-        self, mock_get_active, mock_get_backend, mock_tabular_dataset
+        self, mock_get_backend, mock_tabular_dataset
     ):
         """Test execute_query raises SecurityError for unsafe SQL."""
-        mock_get_active.return_value = mock_tabular_dataset
         with pytest.raises(SecurityError):
-            execute_query("DROP TABLE patients")
+            execute_query("DROP TABLE patients", dataset="test-tabular")
 
     @patch(TABULAR_BACKEND_PATCH)
-    @patch("m4.api.DatasetRegistry.get_active")
     def test_execute_query_injection_blocked(
-        self, mock_get_active, mock_get_backend, mock_tabular_dataset
+        self, mock_get_backend, mock_tabular_dataset
     ):
         """Test execute_query raises SecurityError for SQL injection."""
-        mock_get_active.return_value = mock_tabular_dataset
         with pytest.raises(SecurityError):
-            execute_query("SELECT * FROM patients WHERE 1=1")
+            execute_query("SELECT * FROM patients WHERE 1=1", dataset="test-tabular")
 
 
 class TestClinicalNotesAPI:
     """Test clinical notes API functions."""
 
-    @patch("m4.api.DatasetRegistry.get_active")
-    def test_search_notes_requires_notes_modality(
-        self, mock_get_active, mock_tabular_dataset
-    ):
+    def test_search_notes_requires_notes_modality(self, mock_tabular_dataset):
         """Test search_notes fails without NOTES modality."""
-        mock_get_active.return_value = mock_tabular_dataset
         with pytest.raises(ModalityError) as exc_info:
-            search_notes("pneumonia")
-        assert "does not support clinical notes" in str(exc_info.value)
+            search_notes("pneumonia", dataset="test-tabular")
+        assert "not available for dataset" in str(exc_info.value)
 
-    @patch("m4.api.DatasetRegistry.get_active")
-    def test_get_note_requires_notes_modality(
-        self, mock_get_active, mock_tabular_dataset
-    ):
+    def test_get_note_requires_notes_modality(self, mock_tabular_dataset):
         """Test get_note fails without NOTES modality."""
-        mock_get_active.return_value = mock_tabular_dataset
         with pytest.raises(ModalityError):
-            get_note("12345")
+            get_note("12345", dataset="test-tabular")
 
-    @patch("m4.api.DatasetRegistry.get_active")
-    def test_list_patient_notes_requires_notes_modality(
-        self, mock_get_active, mock_tabular_dataset
-    ):
+    def test_list_patient_notes_requires_notes_modality(self, mock_tabular_dataset):
         """Test list_patient_notes fails without NOTES modality."""
-        mock_get_active.return_value = mock_tabular_dataset
         with pytest.raises(ModalityError):
-            list_patient_notes(12345)
+            list_patient_notes(12345, dataset="test-tabular")
 
     @patch(NOTES_BACKEND_PATCH)
-    @patch("m4.api.DatasetRegistry.get_active")
-    def test_search_notes_success(
-        self, mock_get_active, mock_get_backend, mock_notes_dataset
-    ):
+    def test_search_notes_success(self, mock_get_backend, mock_notes_dataset):
         """Test search_notes returns dict with results."""
-        mock_get_active.return_value = mock_notes_dataset
         mock_backend = MagicMock()
         result_df = pd.DataFrame({"note_id": ["123"], "snippet": ["found pneumonia"]})
         mock_result = MagicMock()
@@ -266,7 +218,7 @@ class TestClinicalNotesAPI:
         mock_backend.get_backend_info.return_value = "Backend: DuckDB"
         mock_get_backend.return_value = mock_backend
 
-        result = search_notes("pneumonia", limit=3)
+        result = search_notes("pneumonia", dataset="test-notes", limit=3)
 
         # Result is now a dict with query and results
         assert isinstance(result, dict)
@@ -274,26 +226,18 @@ class TestClinicalNotesAPI:
         assert "results" in result
 
     @patch(NOTES_BACKEND_PATCH)
-    @patch("m4.api.DatasetRegistry.get_active")
-    def test_search_notes_invalid_type(
-        self, mock_get_active, mock_get_backend, mock_notes_dataset
-    ):
+    def test_search_notes_invalid_type(self, mock_get_backend, mock_notes_dataset):
         """Test search_notes raises QueryError for invalid note type."""
-        mock_get_active.return_value = mock_notes_dataset
         mock_backend = MagicMock()
         mock_backend.get_backend_info.return_value = "Backend: DuckDB"
         mock_get_backend.return_value = mock_backend
 
         with pytest.raises(QueryError):
-            search_notes("test", note_type="invalid")
+            search_notes("test", dataset="test-notes", note_type="invalid")
 
     @patch(NOTES_BACKEND_PATCH)
-    @patch("m4.api.DatasetRegistry.get_active")
-    def test_get_note_not_found(
-        self, mock_get_active, mock_get_backend, mock_notes_dataset
-    ):
+    def test_get_note_not_found(self, mock_get_backend, mock_notes_dataset):
         """Test get_note raises QueryError for non-existent note."""
-        mock_get_active.return_value = mock_notes_dataset
         mock_backend = MagicMock()
         mock_result = MagicMock()
         mock_result.success = True
@@ -303,17 +247,13 @@ class TestClinicalNotesAPI:
         mock_get_backend.return_value = mock_backend
 
         with pytest.raises(QueryError) as exc_info:
-            get_note("nonexistent")
+            get_note("nonexistent", dataset="test-notes")
 
         assert "not found" in str(exc_info.value).lower()
 
     @patch(NOTES_BACKEND_PATCH)
-    @patch("m4.api.DatasetRegistry.get_active")
-    def test_list_patient_notes_success(
-        self, mock_get_active, mock_get_backend, mock_notes_dataset
-    ):
+    def test_list_patient_notes_success(self, mock_get_backend, mock_notes_dataset):
         """Test list_patient_notes returns dict with notes metadata."""
-        mock_get_active.return_value = mock_notes_dataset
         mock_backend = MagicMock()
         result_df = pd.DataFrame(
             {"note_id": ["123"], "note_type": ["discharge"], "note_length": [5000]}
@@ -325,7 +265,7 @@ class TestClinicalNotesAPI:
         mock_backend.get_backend_info.return_value = "Backend: DuckDB"
         mock_get_backend.return_value = mock_backend
 
-        result = list_patient_notes(12345)
+        result = list_patient_notes(12345, dataset="test-notes")
 
         # Result is now a dict with subject_id and notes
         assert isinstance(result, dict)

--- a/tests/test_capabilities_download_setup.py
+++ b/tests/test_capabilities_download_setup.py
@@ -430,7 +430,7 @@ def test_setup_agent_service_loads_custom_dataset(tmp_path, monkeypatch):
     )
 
     assert isinstance(result, CommandResult)
-    assert result.data["environment"]["M4_DATASET"] == "custom-ed"
+    assert "M4_DATASET" not in result.data["environment"]
 
 
 @patch("m4.services.setup.get_active_backend", return_value="duckdb")
@@ -462,5 +462,5 @@ def test_doctor_only_requires_active_duckdb_dataset(
 
     assert result.data["summary"]["ok"] is True
     check_names = [check["name"] for check in result.data["checks"]]
-    assert "duckdb:mimic-iv-demo" in check_names
+    assert "duckdb:mimic-iv-demo" not in check_names
     assert "duckdb:mimic-iv" not in check_names

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -318,10 +318,10 @@ def test_use_full_happy_path(mock_detect, mock_set_active):
     }
 
     result = runner.invoke(app, ["use", "mimic-iv"])
-    assert result.exit_code == 0
-    # Updated format without trailing period
-    assert "Active dataset set to 'mimic-iv'" in result.stdout
-    mock_set_active.assert_called_once_with("mimic-iv")
+    assert result.exit_code == 1
+    assert "Active Dataset Removed" in result.stdout
+    assert "explicit dataset" in result.stdout
+    mock_set_active.assert_not_called()
 
 
 @patch("m4.services.use.get_active_backend", return_value="duckdb")
@@ -341,17 +341,13 @@ def test_use_json_success_includes_warning_codes(
 
     result = runner.invoke(app, ["use", "mimic-iv", "--json"])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     payload = json.loads(result.stdout)
-    assert payload["ok"] is True
+    assert payload["ok"] is False
     assert payload["command"] == "use"
-    assert payload["active_dataset"] == "mimic-iv"
-    assert payload["backend"] == "duckdb"
-    assert payload["dataset"]["name"] == "mimic-iv"
-    assert payload["dataset"]["db_present"] is False
-    assert payload["warnings"] == ["local_db_missing"]
+    assert payload["error"]["code"] == "active_dataset_removed"
     assert "Active dataset set" not in result.stdout
-    mock_set_active.assert_called_once_with("mimic-iv")
+    mock_set_active.assert_not_called()
 
 
 @patch("m4.services.use.set_active_dataset")
@@ -363,7 +359,7 @@ def test_use_json_dataset_not_found_emits_error(mock_detect, mock_set_active):
     payload = json.loads(result.stdout)
     assert payload["ok"] is False
     assert payload["command"] == "use"
-    assert payload["error"]["code"] == "dataset_not_found"
+    assert payload["error"]["code"] == "active_dataset_removed"
     assert "Dataset Not Found" not in result.stdout
     mock_set_active.assert_not_called()
 
@@ -387,7 +383,7 @@ def test_use_json_backend_incompatible_emits_error(
 
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
-    assert payload["error"]["code"] == "backend_incompatible"
+    assert payload["error"]["code"] == "active_dataset_removed"
     assert "Backend Incompatible" not in result.stdout
     mock_set_active.assert_not_called()
 
@@ -413,7 +409,7 @@ def test_status_happy_path(mock_detect, mock_active, mock_size):
 
     result = runner.invoke(app, ["status"])
     assert result.exit_code == 0
-    assert "Active dataset:" in result.stdout
+    assert "Dataset:" in result.stdout
     assert "mimic-iv" in result.stdout
     # Updated Rich format: "Parquet size:  X.XX GB"
     assert "Parquet size:" in result.stdout
@@ -538,13 +534,12 @@ def test_status_json_no_active_dataset_returns_empty_dataset_list(
 
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
-    assert payload == {
-        "version": 1,
-        "active_dataset": None,
-        "backend": "duckdb",
-        "bigquery_project_id": None,
-        "datasets": [],
-    }
+    assert payload["version"] == 1
+    assert payload["active_dataset"] is None
+    assert payload["selected_dataset"] is None
+    assert payload["backend"] == "duckdb"
+    assert payload["bigquery_project_id"] is None
+    assert payload["datasets"] == []
 
 
 @patch("m4.services.status.get_bigquery_project_id", return_value=None)
@@ -737,7 +732,7 @@ def test_status_derived_flag(
     mock_db_path.return_value = db_file
     mock_mat.return_value = {"sofa", "sepsis3", "age"}
 
-    result = runner.invoke(app, ["status", "--derived"])
+    result = runner.invoke(app, ["status", "--derived", "--dataset", "mimic-iv"])
     assert result.exit_code == 0
     assert "Derived tables for mimic-iv" in result.stdout
     assert "materialized" in result.stdout
@@ -747,7 +742,7 @@ def test_status_derived_flag(
 @patch("m4.cli.get_active_dataset", return_value="mimic-iv-demo")
 def test_status_derived_flag_unsupported_dataset(mock_active, mock_backend):
     """Test --derived with a dataset that has no derived support."""
-    result = runner.invoke(app, ["status", "--derived"])
+    result = runner.invoke(app, ["status", "--derived", "--dataset", "mimic-iv-demo"])
     assert result.exit_code == 0
     assert "not available" in result.stdout
 
@@ -757,7 +752,7 @@ def test_status_derived_flag_no_active_dataset(mock_active):
     """Test --derived with no active dataset set."""
     result = runner.invoke(app, ["status", "--derived"])
     assert result.exit_code == 0
-    assert "No active dataset" in result.stdout
+    assert "--dataset is required" in result.stdout
 
 
 # ----------------------------------------------------------------
@@ -803,7 +798,7 @@ def test_backend_bigquery_happy_path(
 def test_backend_bigquery_blocks_unsupported_dataset(
     mock_registry, mock_get_dataset, mock_set_backend
 ):
-    """Test that switching to bigquery is blocked when dataset doesn't support BQ."""
+    """Backend switching no longer depends on a selected dataset."""
     # Mock a dataset that doesn't support BigQuery
     mock_get_dataset.return_value = "custom-dataset"
     mock_ds = MagicMock()
@@ -813,8 +808,7 @@ def test_backend_bigquery_blocks_unsupported_dataset(
     result = runner.invoke(app, ["backend", "bigquery"])
 
     assert result.exit_code == 1
-    assert "Dataset Incompatible" in result.stdout
-    assert "not available on BigQuery" in result.stdout
+    assert "Project ID Required" in result.stdout
     mock_set_backend.assert_not_called()
 
 
@@ -868,7 +862,6 @@ def test_backend_json_duckdb_success(
         "ok": True,
         "command": "backend",
         "backend": "duckdb",
-        "active_dataset": "mimic-iv",
         "bigquery_project_id": None,
         "warnings": [],
     }
@@ -891,7 +884,6 @@ def test_backend_json_bigquery_with_project_id_success(
     assert payload["ok"] is True
     assert payload["command"] == "backend"
     assert payload["backend"] == "bigquery"
-    assert payload["active_dataset"] == "mimic-iv"
     assert payload["bigquery_project_id"] == "my-project"
     assert payload["warnings"] == []
     mock_set_backend.assert_called_once_with("bigquery")
@@ -931,7 +923,7 @@ def test_backend_json_bigquery_blocks_incompatible_active_dataset(
 
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
-    assert payload["error"]["code"] == "dataset_incompatible"
+    assert payload["error"]["code"] == "project_id_required"
     assert "Dataset Incompatible" not in result.stdout
     mock_set_backend.assert_not_called()
 

--- a/tests/test_cli_subprocess.py
+++ b/tests/test_cli_subprocess.py
@@ -228,11 +228,11 @@ def test_use_json_subprocess_is_parseable(tmp_path):
 
     result = _run_m4(["use", "mimic-iv-demo", "--json"], tmp_path)
 
-    assert result.returncode == 0
+    assert result.returncode == 1
     payload = _assert_single_json_stdout(result)
-    assert payload["ok"] is True
+    assert payload["ok"] is False
     assert payload["command"] == "use"
-    assert payload["active_dataset"] == "mimic-iv-demo"
+    assert payload["error"]["code"] == "active_dataset_removed"
 
 
 def test_backend_json_subprocess_is_parseable(tmp_path):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -128,6 +128,51 @@ def test_explicit_attribution_recorded_without_environment(tabular_dataset, back
     assert record["actor"] == "actor-1"
 
 
+def test_with_dataset_returns_new_client_with_same_session_context(
+    tabular_dataset, notes_dataset, backend, tmp_path
+):
+    db_path = tmp_path / "source.duckdb"
+    client = M4Client(
+        dataset=tabular_dataset,
+        backend=backend,
+        study_id="study-1",
+        session_id="session-1",
+        actor="agent-1",
+        interface="python_api",
+        project_id="project-1",
+        db_path=db_path,
+        path_disclosure=True,
+    )
+
+    switched = client.with_dataset(notes_dataset)
+
+    assert switched is not client
+    assert client.dataset is tabular_dataset
+    assert client.context.dataset is tabular_dataset
+    assert switched.dataset is notes_dataset
+    assert switched.context.dataset is notes_dataset
+    assert switched.backend is backend
+    assert switched.context.study_id == "study-1"
+    assert switched.context.session_id == "session-1"
+    assert switched.context.actor == "agent-1"
+    assert switched.context.interface == "python_api"
+    assert switched.context.project_id == "project-1"
+    assert switched.context.db_path == db_path
+    assert switched.context.path_disclosure is True
+
+
+def test_switch_dataset_mutates_client_and_context(
+    tabular_dataset, notes_dataset, backend
+):
+    client = M4Client(dataset=tabular_dataset, backend=backend)
+
+    returned = client.switch_dataset(notes_dataset)
+
+    assert returned is client
+    assert client.dataset is notes_dataset
+    assert client.context.dataset is notes_dataset
+
+
 def test_notes_methods_raise_for_tabular_dataset(tabular_dataset, backend):
     client = M4Client(dataset=tabular_dataset, backend=backend)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -253,8 +253,8 @@ class TestBigQueryProjectId:
         set_bigquery_project_id(None)
         assert get_bigquery_project_id() is None
 
-    def test_preserves_other_config(self, isolated_config):
-        """Setting project ID preserves other config values."""
+    def test_preserves_supported_config_and_drops_legacy_dataset(self, isolated_config):
+        """Setting project ID preserves supported values and drops active_dataset."""
         import json
 
         isolated_config.write_text(
@@ -266,7 +266,7 @@ class TestBigQueryProjectId:
         saved = json.loads(isolated_config.read_text())
         assert saved["bigquery_project_id"] == "my-project"
         assert saved["backend"] == "bigquery"
-        assert saved["active_dataset"] == "mimic-iv"
+        assert "active_dataset" not in saved
 
 
 class TestValidBackends:

--- a/tests/test_dynamic_switching.py
+++ b/tests/test_dynamic_switching.py
@@ -1,61 +1,29 @@
-"""Tests for dynamic dataset switching functionality.
-
-This module tests that dataset switching works correctly through the
-config system and is properly reflected in the backends.
-"""
+"""Tests for the removed global dataset switching compatibility shims."""
 
 import pytest
 
-import m4.config as config_mod
 from m4.config import get_active_dataset, set_active_dataset
 from m4.core.datasets import DatasetRegistry
 from m4.core.exceptions import DatasetError
 
 
-def test_dynamic_dataset_switching(tmp_path, monkeypatch):
-    """Test that dataset switching works correctly."""
-    # Setup mock data dir
-    data_dir = tmp_path / "m4_data"
-    data_dir.mkdir()
+def test_global_dataset_accessors_raise_migration_errors():
+    """Global dataset state has been removed in favor of explicit selection."""
+    with pytest.raises(DatasetError, match="Global active dataset state"):
+        get_active_dataset()
 
-    # Patch config module to use our temp data dir
-    monkeypatch.setattr(config_mod, "_PROJECT_DATA_DIR", data_dir)
-    monkeypatch.setattr(config_mod, "_DEFAULT_DATABASES_DIR", data_dir / "databases")
-    monkeypatch.setattr(config_mod, "_DEFAULT_PARQUET_DIR", data_dir / "parquet")
-    monkeypatch.setattr(config_mod, "_RUNTIME_CONFIG_PATH", data_dir / "config.json")
-    monkeypatch.setattr(config_mod, "_CUSTOM_DATASETS_DIR", data_dir / "datasets")
+    with pytest.raises(DatasetError, match="Cannot set active dataset"):
+        set_active_dataset("mimic-iv")
 
-    # Ensure dirs exist
-    (data_dir / "databases").mkdir()
-    (data_dir / "parquet").mkdir()
-    (data_dir / "datasets").mkdir()
 
-    # 1. Start with no active dataset
-    monkeypatch.setenv("M4_BACKEND", "duckdb")
-    monkeypatch.delenv("M4_DB_PATH", raising=False)
-
-    # Ensure config is empty/default
-    if (data_dir / "config.json").exists():
-        (data_dir / "config.json").unlink()
-
-    # With no active dataset configured, DatasetRegistry.get_active() raises DatasetError
-    with pytest.raises(DatasetError):
+def test_dataset_registry_get_active_raises_migration_error():
+    """DatasetRegistry.get_active is retained only for migration guidance."""
+    with pytest.raises(DatasetError, match=r"DatasetRegistry\.get_active"):
         DatasetRegistry.get_active()
 
-    # 2. Set active dataset to something else (simulating 'm4 use')
-    set_active_dataset("mimic-iv")
 
-    # Verify config file was written
-    assert (data_dir / "config.json").exists()
-
-    # Verify DatasetRegistry.get_active() picks it up
-    ds_def = DatasetRegistry.get_active()
-    assert ds_def.name == "mimic-iv"
-
-    # Verify get_active_dataset reflects the change
-    assert get_active_dataset() == "mimic-iv"
-
-    # 3. Verify dataset definition has correct properties
+def test_dataset_registry_explicit_get_still_returns_definitions():
+    """Explicit dataset lookup remains the supported registry API."""
     full_ds = DatasetRegistry.get("mimic-iv")
     assert full_ds is not None
     assert full_ds.requires_authentication is True
@@ -63,8 +31,3 @@ def test_dynamic_dataset_switching(tmp_path, monkeypatch):
     demo_ds = DatasetRegistry.get("mimic-iv-demo")
     assert demo_ds is not None
     assert demo_ds.requires_authentication is False
-
-    # 4. Switch back to demo
-    set_active_dataset("mimic-iv-demo")
-    ds_def = DatasetRegistry.get_active()
-    assert ds_def.name == "mimic-iv-demo"

--- a/tests/test_mcp_dataset_tools.py
+++ b/tests/test_mcp_dataset_tools.py
@@ -35,87 +35,47 @@ class TestMCPDatasetTools:
             },
         }
 
-        # Patch at the location where it's imported (m4.core.tools.management)
         with patch(
             "m4.core.tools.management.detect_available_local_datasets",
             return_value=mock_availability,
         ):
-            with patch(
-                "m4.core.tools.management.get_active_dataset",
-                return_value="mimic-iv-demo",
-            ):
-                with patch(
-                    "m4.config.get_active_dataset",
-                    return_value="mimic-iv-demo",
-                ):
-                    with patch(
-                        "m4.core.tools.management.DatasetRegistry.get"
-                    ) as mock_get:
-                        # Mock ds_def
-                        mock_ds = Mock()
-                        mock_ds.bigquery_dataset_ids = []
-                        mock_ds.modalities = frozenset()
-                        mock_get.return_value = mock_ds
+            with patch("m4.core.tools.management.DatasetRegistry.get") as mock_get:
+                mock_ds = Mock()
+                mock_ds.bigquery_dataset_ids = []
+                mock_ds.modalities = frozenset()
+                mock_get.return_value = mock_ds
 
-                        async with Client(mcp) as client:
-                            result = await client.call_tool("list_datasets", {})
-                            result_text = str(result)
+                async with Client(mcp) as client:
+                    result = await client.call_tool("list_datasets", {})
+                    result_text = str(result)
 
-                        assert "Active dataset: mimic-iv-demo" in result_text
-                        assert "=== MIMIC-IV-DEMO (Active) ===" in result_text
-                        assert "=== MIMIC-IV ===" in result_text
-                        assert "Local Database: ✅" in result_text
-                        assert "Local Database: ❌" in result_text
+                assert "Active dataset" not in result_text
+                assert "=== MIMIC-IV-DEMO ===" in result_text
+                assert "=== MIMIC-IV ===" in result_text
+                assert "Local Database: ✅" in result_text
+                assert "Local Database: ❌" in result_text
 
     @pytest.mark.asyncio
-    async def test_set_dataset_success(self):
-        """Test set_dataset tool with valid dataset."""
-        mock_availability = {
-            "mimic-iv-demo": {"parquet_present": True, "db_present": True}
-        }
+    async def test_set_dataset_returns_migration_error(self):
+        """Test set_dataset tool returns migration guidance."""
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "set_dataset", {"dataset_name": "mimic-iv-demo"}
+            )
+            result_text = str(result)
 
-        with patch(
-            "m4.core.tools.management.detect_available_local_datasets",
-            return_value=mock_availability,
-        ):
-            with patch("m4.core.tools.management.set_active_dataset") as mock_set:
-                with patch(
-                    "m4.config.get_active_dataset", return_value="mimic-iv-demo"
-                ):
-                    with patch("m4.core.tools.management.DatasetRegistry.get"):
-                        async with Client(mcp) as client:
-                            result = await client.call_tool(
-                                "set_dataset", {"dataset_name": "mimic-iv-demo"}
-                            )
-                            result_text = str(result)
-
-                            assert (
-                                "Active dataset switched to 'mimic-iv-demo'"
-                                in result_text
-                            )
-                            mock_set.assert_called_once_with("mimic-iv-demo")
+            assert "**Error:**" in result_text
+            assert "set_dataset is no longer supported" in result_text
+            assert "explicit dataset" in result_text
 
     @pytest.mark.asyncio
-    async def test_set_dataset_invalid(self):
-        """Test set_dataset tool with invalid dataset."""
-        mock_availability = {"mimic-iv-demo": {}}
+    async def test_set_dataset_invalid_returns_migration_error(self):
+        """Invalid names get the same migration guidance because no switch occurs."""
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "set_dataset", {"dataset_name": "invalid-ds"}
+            )
+            result_text = str(result)
 
-        with patch(
-            "m4.core.tools.management.detect_available_local_datasets",
-            return_value=mock_availability,
-        ):
-            with patch("m4.core.tools.management.set_active_dataset") as mock_set:
-                with patch(
-                    "m4.config.get_active_dataset", return_value="mimic-iv-demo"
-                ):
-                    with patch("m4.core.tools.management.DatasetRegistry.get"):
-                        async with Client(mcp) as client:
-                            result = await client.call_tool(
-                                "set_dataset", {"dataset_name": "invalid-ds"}
-                            )
-                            result_text = str(result)
-
-                            assert "**Error:**" in result_text
-                            assert "invalid-ds" in result_text
-                            assert "not found" in result_text
-                            mock_set.assert_not_called()
+            assert "**Error:**" in result_text
+            assert "set_dataset is no longer supported" in result_text

--- a/tests/test_mcp_serialization.py
+++ b/tests/test_mcp_serialization.py
@@ -8,7 +8,6 @@ Tests cover:
 - _serialize_schema_result: Table listing output
 - _serialize_table_info_result: Column info + sample data
 - _serialize_datasets_result: Multi-dataset status display
-- _serialize_set_dataset_result: Switch confirmation with warnings
 - _serialize_search_notes_result: Note search snippets
 - _serialize_get_note_result: Full note text with truncation
 - _serialize_list_patient_notes_result: Patient note metadata
@@ -22,7 +21,6 @@ from m4.mcp_server import (
     _serialize_list_patient_notes_result,
     _serialize_schema_result,
     _serialize_search_notes_result,
-    _serialize_set_dataset_result,
     _serialize_table_info_result,
 )
 
@@ -112,18 +110,18 @@ class TestSerializeDatasetsResult:
 
     def test_no_datasets(self):
         """No datasets returns simple message."""
-        result = _serialize_datasets_result({"active_dataset": None, "datasets": {}})
+        result = _serialize_datasets_result({"selected_dataset": None, "datasets": {}})
         assert "No datasets detected" in result
 
-    def test_single_active_dataset(self):
-        """Single active dataset shows status correctly."""
+    def test_single_selected_dataset(self):
+        """Single selected dataset shows status correctly."""
         result = _serialize_datasets_result(
             {
-                "active_dataset": "mimic-iv-demo",
+                "selected_dataset": "mimic-iv-demo",
                 "backend": "duckdb",
                 "datasets": {
                     "mimic-iv-demo": {
-                        "is_active": True,
+                        "selected": True,
                         "parquet_present": True,
                         "db_present": True,
                         "bigquery_support": False,
@@ -132,19 +130,19 @@ class TestSerializeDatasetsResult:
                 },
             }
         )
-        assert "Active dataset: mimic-iv-demo" in result
-        assert "(Active)" in result
+        assert "Selected dataset: mimic-iv-demo" in result
+        assert "(Selected)" in result
         assert "DuckDB" in result
 
     def test_dataset_with_derived_tables(self):
         """Derived table info is included when present."""
         result = _serialize_datasets_result(
             {
-                "active_dataset": "mimic-iv",
+                "selected_dataset": "mimic-iv",
                 "backend": "duckdb",
                 "datasets": {
                     "mimic-iv": {
-                        "is_active": True,
+                        "selected": True,
                         "parquet_present": True,
                         "db_present": True,
                         "bigquery_support": True,
@@ -164,11 +162,11 @@ class TestSerializeDatasetsResult:
         """Partial derived tables show init hint."""
         result = _serialize_datasets_result(
             {
-                "active_dataset": "mimic-iv",
+                "selected_dataset": "mimic-iv",
                 "backend": "duckdb",
                 "datasets": {
                     "mimic-iv": {
-                        "is_active": True,
+                        "selected": True,
                         "parquet_present": True,
                         "db_present": True,
                         "bigquery_support": True,
@@ -188,11 +186,11 @@ class TestSerializeDatasetsResult:
         """BigQuery backend shows 'cloud (BigQuery)' label."""
         result = _serialize_datasets_result(
             {
-                "active_dataset": "mimic-iv",
+                "selected_dataset": "mimic-iv",
                 "backend": "bigquery",
                 "datasets": {
                     "mimic-iv": {
-                        "is_active": True,
+                        "selected": True,
                         "parquet_present": False,
                         "db_present": False,
                         "bigquery_support": True,
@@ -202,29 +200,6 @@ class TestSerializeDatasetsResult:
             }
         )
         assert "BigQuery" in result
-
-
-class TestSerializeSetDatasetResult:
-    """Test _serialize_set_dataset_result output formatting."""
-
-    def test_successful_switch(self):
-        """Successful switch shows confirmation."""
-        result = _serialize_set_dataset_result(
-            {"dataset_name": "mimic-iv-demo", "warnings": []}
-        )
-        assert "mimic-iv-demo" in result
-        assert "switched" in result.lower()
-
-    def test_switch_with_warnings(self):
-        """Switch with warnings appends warning messages."""
-        result = _serialize_set_dataset_result(
-            {
-                "dataset_name": "mimic-iv",
-                "warnings": ["Local database not found."],
-            }
-        )
-        assert "mimic-iv" in result
-        assert "Local database not found" in result
 
 
 class TestSerializeSearchNotesResult:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -431,7 +431,7 @@ class TestModalityChecking:
 
                         # Verify suggestions are included
                         assert "list_datasets" in result_text
-                        assert "set_dataset" in result_text
+                        assert "dataset='dataset-name'" in result_text
 
                         # Verify backend was NOT called (no execution attempted)
                         mock_backend.assert_not_called()
@@ -489,97 +489,42 @@ class TestModalityChecking:
                         assert "not available" not in result_text.lower()
 
     @pytest.mark.asyncio
-    async def test_set_dataset_returns_supported_tools_snapshot(self):
-        """Test that set_dataset includes supported tools in response."""
+    async def test_set_dataset_returns_migration_error(self):
+        """set_dataset is retained only as migration guidance."""
         from m4.core.backends import reset_backend_cache
 
         reset_backend_cache()
-
-        # Create a dataset with TABULAR modality
-        target_ds = DatasetDefinition(
-            name="test-dataset",
-            modalities={Modality.TABULAR},
-        )
 
         with patch.dict(
             os.environ,
             {"M4_OAUTH2_ENABLED": "false", "M4_BACKEND": "duckdb"},
             clear=True,
         ):
-            with patch(
-                "m4.core.tools.management.detect_available_local_datasets",
-                return_value={
-                    "test-dataset": {"parquet_present": True, "db_present": True}
-                },
-            ):
-                with patch("m4.core.tools.management.set_active_dataset"):
-                    with patch(
-                        "m4.config.get_active_dataset",
-                        return_value="test-dataset",
-                    ):
-                        with patch(
-                            "m4.core.tools.management.DatasetRegistry.get",
-                            return_value=target_ds,
-                        ):
-                            with patch(
-                                "m4.mcp_server.DatasetRegistry.get",
-                                return_value=target_ds,
-                            ):
-                                with patch(
-                                    "m4.core.tools.management.get_active_backend",
-                                    return_value="duckdb",
-                                ):
-                                    async with Client(mcp) as client:
-                                        result = await client.call_tool(
-                                            "set_dataset",
-                                            {"dataset_name": "test-dataset"},
-                                        )
-                                        result_text = str(result)
+            async with Client(mcp) as client:
+                result = await client.call_tool(
+                    "set_dataset",
+                    {"dataset_name": "test-dataset"},
+                )
+                result_text = str(result)
 
-                                        # Verify snapshot is included
-                                        assert "Active dataset" in result_text
-                                        assert "test-dataset" in result_text
-                                        assert "Modalities" in result_text
-                                        assert "Supported tools" in result_text
-
-                                        # Tools should be sorted alphabetically
-                                        assert "execute_query" in result_text
+                assert "set_dataset is no longer supported" in result_text
+                assert "explicit dataset" in result_text
 
     @pytest.mark.asyncio
-    async def test_set_dataset_invalid_returns_error_without_snapshot(self):
-        """Test that set_dataset with invalid dataset returns error without snapshot."""
+    async def test_set_dataset_invalid_returns_same_migration_error(self):
+        """set_dataset does not validate targets because it no longer switches."""
         from m4.core.backends import reset_backend_cache
 
         reset_backend_cache()
 
-        # Create a valid mock dataset for get_active
-        mock_active_ds = DatasetDefinition(
-            name="mimic-iv-demo",
-            modalities={Modality.TABULAR},
-        )
-
         with patch.dict(os.environ, {"M4_OAUTH2_ENABLED": "false"}, clear=True):
-            with patch(
-                "m4.core.tools.management.detect_available_local_datasets",
-                return_value={
-                    "mimic-iv-demo": {"parquet_present": True, "db_present": True}
-                },
-            ):
-                with patch(
-                    "m4.mcp_server.DatasetRegistry.get_active",
-                    return_value=mock_active_ds,
-                ):
-                    with patch(
-                        "m4.mcp_server.DatasetRegistry.get", return_value=None
-                    ):  # Unknown dataset for snapshot lookup
-                        async with Client(mcp) as client:
-                            result = await client.call_tool(
-                                "set_dataset", {"dataset_name": "nonexistent-dataset"}
-                            )
-                            result_text = str(result)
+            async with Client(mcp) as client:
+                result = await client.call_tool(
+                    "set_dataset", {"dataset_name": "nonexistent-dataset"}
+                )
+                result_text = str(result)
 
-                            # Should have error
-                            assert "not found" in result_text.lower()
+                assert "set_dataset is no longer supported" in result_text
 
     @pytest.mark.asyncio
     async def test_tool_incompatibility_with_notes_only(self):
@@ -659,7 +604,7 @@ class TestModalityChecking:
         snapshot = selector.get_supported_tools_snapshot(tabular_ds)
 
         # Verify structure
-        assert "Active dataset" in snapshot
+        assert "Dataset" in snapshot
         assert "tabular-dataset" in snapshot
         assert "Modalities" in snapshot
         assert "Supported tools" in snapshot

--- a/tests/test_services_agent_env_config.py
+++ b/tests/test_services_agent_env_config.py
@@ -12,7 +12,8 @@ def test_agent_env_local_includes_data_dir(monkeypatch, tmp_path):
     )
 
     assert result.command == "agent-env"
-    assert result.data["environment"]["M4_DATASET"] == "mimic-iv-demo"
+    assert "M4_DATASET" not in result.data["environment"]
+    assert result.data["defaults"]["dataset"] == "mimic-iv-demo"
     assert result.data["environment"]["M4_BACKEND"] == "duckdb"
     assert "M4_DATA_DIR" in result.data["environment"]
     assert result.data["raw_paths_hidden"] is True

--- a/tests/test_services_init.py
+++ b/tests/test_services_init.py
@@ -55,7 +55,7 @@ def test_init_service_parquet_already_present_path(
     mock_init.assert_called_once_with(
         dataset_name="mimic-iv-demo", db_target_path=db_path
     )
-    mock_set_active.assert_called_once_with("mimic-iv-demo")
+    mock_set_active.assert_not_called()
 
 
 @patch("m4.services.init.has_derived_support", return_value=False)

--- a/tests/test_services_use_backend.py
+++ b/tests/test_services_use_backend.py
@@ -1,75 +1,22 @@
 from unittest.mock import patch
 
-from m4.core.exceptions import DatasetError
 from m4.services.backend import set_active_backend_service
 from m4.services.results import CommandError, CommandResult
 from m4.services.use import set_active_dataset_service
 
 
-@patch("m4.services.use.get_active_backend", return_value="duckdb")
-@patch("m4.services.use.set_active_dataset")
-@patch("m4.services.use.detect_available_local_datasets")
-def test_use_service_success_includes_dataset_and_warning_codes(
-    mock_detect, mock_set_active, mock_backend
-):
-    mock_detect.return_value = {
-        "mimic-iv": {
-            "parquet_present": True,
-            "db_present": False,
-            "parquet_root": "/tmp/full",
-            "db_path": "/tmp/full.duckdb",
-        }
-    }
-
+def test_use_service_returns_migration_error():
     result = set_active_dataset_service("MIMIC-IV")
 
-    assert isinstance(result, CommandResult)
-    payload = result.to_json_dict()
-    assert payload["active_dataset"] == "mimic-iv"
-    assert payload["backend"] == "duckdb"
-    assert payload["dataset"]["db_present"] is False
-    assert payload["warnings"] == ["local_db_missing"]
-    mock_set_active.assert_called_once_with("mimic-iv")
-
-
-@patch("m4.services.use.set_active_dataset")
-@patch("m4.services.use.detect_available_local_datasets", return_value={})
-def test_use_service_dataset_not_found_does_not_mutate(mock_detect, mock_set_active):
-    result = set_active_dataset_service("missing")
-
     assert isinstance(result, CommandError)
-    assert result.code == "dataset_not_found"
-    mock_set_active.assert_not_called()
-
-
-@patch("m4.services.use.get_active_backend", return_value="bigquery")
-@patch("m4.services.use.set_active_dataset")
-@patch("m4.services.use.detect_available_local_datasets")
-def test_use_service_blocks_bigquery_incompatible_dataset(
-    mock_detect, mock_set_active, mock_backend
-):
-    mock_detect.return_value = {
-        "mimic-iv-demo": {
-            "parquet_present": True,
-            "db_present": True,
-            "parquet_root": "/tmp/demo",
-            "db_path": "/tmp/demo.duckdb",
-        }
-    }
-
-    result = set_active_dataset_service("mimic-iv-demo")
-
-    assert isinstance(result, CommandError)
-    assert result.code == "backend_incompatible"
-    mock_set_active.assert_not_called()
+    assert result.code == "active_dataset_removed"
+    assert "explicit dataset" in result.message
+    assert "M4Client(dataset=...)" in (result.hint or "")
 
 
 @patch("m4.services.backend.get_bigquery_project_id", return_value=None)
-@patch("m4.services.backend.get_active_dataset", return_value="mimic-iv")
 @patch("m4.services.backend.set_active_backend")
-def test_backend_service_duckdb_success(
-    mock_set_backend, mock_get_dataset, mock_get_project
-):
+def test_backend_service_duckdb_success(mock_set_backend, mock_get_project):
     result = set_active_backend_service("duckdb")
 
     assert isinstance(result, CommandResult)
@@ -78,7 +25,6 @@ def test_backend_service_duckdb_success(
         "ok": True,
         "command": "backend",
         "backend": "duckdb",
-        "active_dataset": "mimic-iv",
         "bigquery_project_id": None,
         "warnings": [],
     }
@@ -86,10 +32,9 @@ def test_backend_service_duckdb_success(
 
 
 @patch("m4.services.backend.set_bigquery_project_id")
-@patch("m4.services.backend.get_active_dataset", side_effect=DatasetError("unset"))
 @patch("m4.services.backend.set_active_backend")
 def test_backend_service_bigquery_persists_project_id(
-    mock_set_backend, mock_get_dataset, mock_set_project
+    mock_set_backend, mock_set_project
 ):
     result = set_active_backend_service("BIGQUERY", project_id="my-project")
 
@@ -120,23 +65,10 @@ def test_backend_service_duckdb_rejects_project_id(mock_set_backend, mock_set_pr
     mock_set_project.assert_not_called()
 
 
-@patch("m4.services.backend.set_active_backend")
-@patch("m4.services.backend.get_active_dataset", return_value="mimic-iv-demo")
-def test_backend_service_bigquery_blocks_incompatible_active_dataset(
-    mock_get_dataset, mock_set_backend
-):
-    result = set_active_backend_service("bigquery", project_id="my-project")
-
-    assert isinstance(result, CommandError)
-    assert result.code == "dataset_incompatible"
-    mock_set_backend.assert_not_called()
-
-
 @patch("m4.services.backend.get_bigquery_project_id", return_value=None)
 @patch("m4.services.backend.set_active_backend")
-@patch("m4.services.backend.get_active_dataset", side_effect=DatasetError("unset"))
 def test_backend_service_bigquery_requires_project_id(
-    mock_get_dataset, mock_set_backend, mock_get_project
+    mock_set_backend, mock_get_project
 ):
     result = set_active_backend_service("bigquery")
 


### PR DESCRIPTION
## Summary
- Remove config-backed global active dataset routing and require explicit dataset selection via `M4Client(dataset=...)`, `dataset=...`, or CLI `--dataset`.
- Retain stale global APIs and `m4 use` only as migration-error paths with actionable guidance.
- Update MCP, CLI, setup/status/capabilities, bundled skills, docs, and tests for request-scoped dataset selection.

## Behavioral implications
- `m4 use` and config-backed `active_dataset` no longer route queries.
- Convenience functions remain, but callers must pass `dataset=...`.
- Legacy `active_dataset` config is ignored and dropped when runtime config is saved.

## Verification
- `uv run pytest -q` (`967 passed, 1 skipped, 1 deselected`)
- `uv run ruff check src tests`
- `python -m compileall -q src/m4`
- Commit hooks passed: ruff, ruff-format, derived docs freshness, pytest
