### PR TITLE
Bump package version to 0.5.3

### DIFF
--- a/src/m4/__init__.py
+++ b/src/m4/__init__.py
@@ -15,7 +15,7 @@ Quick Start:
 For MCP server usage, run: m4 serve
 """
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 
 # Expose API functions at package level for easy imports
 from vitrine import show

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -792,11 +792,12 @@ def test_backend_bigquery_happy_path(
     mock_set_backend.assert_called_once_with("bigquery")
 
 
+@patch("m4.services.backend.get_bigquery_project_id", return_value=None)
 @patch("m4.services.backend.set_active_backend")
 @patch("m4.services.backend.get_active_dataset")
 @patch("m4.services.backend.DatasetRegistry.get")
 def test_backend_bigquery_blocks_unsupported_dataset(
-    mock_registry, mock_get_dataset, mock_set_backend
+    mock_registry, mock_get_dataset, mock_set_backend, mock_get_project
 ):
     """Backend switching no longer depends on a selected dataset."""
     # Mock a dataset that doesn't support BigQuery
@@ -914,10 +915,11 @@ def test_backend_json_duckdb_rejects_project_id(mock_set_backend, mock_set_proje
     mock_set_project.assert_not_called()
 
 
+@patch("m4.services.backend.get_bigquery_project_id", return_value=None)
 @patch("m4.services.backend.set_active_backend")
 @patch("m4.services.backend.get_active_dataset", return_value="mimic-iv-demo")
 def test_backend_json_bigquery_blocks_incompatible_active_dataset(
-    mock_get_dataset, mock_set_backend
+    mock_get_dataset, mock_set_backend, mock_get_project
 ):
     result = runner.invoke(app, ["backend", "bigquery", "--json"])
 

--- a/tests/test_cli_subprocess.py
+++ b/tests/test_cli_subprocess.py
@@ -13,9 +13,11 @@ def _run_m4(args: list[str], tmp_path: Path) -> subprocess.CompletedProcess[str]
     env = os.environ.copy()
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
     env["M4_DATA_DIR"] = str(tmp_path / "m4_data")
+    env.pop("M4_HOME", None)
     env.pop("M4_BACKEND", None)
     env.pop("M4_DATASET", None)
     env.pop("M4_PROJECT_ID", None)
+    env.pop("M4_TELEMETRY_DIR", None)
     return subprocess.run(
         [sys.executable, "-m", "m4.cli", *args],
         text=True,

--- a/tests/test_services_init_derived.py
+++ b/tests/test_services_init_derived.py
@@ -4,7 +4,8 @@ from unittest.mock import Mock, patch
 from m4.services.init_derived import init_derived_service
 
 
-def test_init_derived_list_returns_tables():
+@patch("m4.services.init_derived.get_active_backend", return_value="duckdb")
+def test_init_derived_list_returns_tables(mock_backend):
     result = init_derived_service("mimic-iv", list_only=True)
 
     assert result.ok is True


### PR DESCRIPTION
## Summary
- bump the package version from 0.5.2 to 0.5.3 after the latest dataset switching changes
- isolate affected tests from local M4 runtime config and telemetry paths

## Testing
- pre-commit hooks, including pytest: 968 passed, 1 skipped, 1 deselected

## Implications
- patch metadata update only
- no behavioral, benchmark, or migration implications