### PR TITLE
Preserve native Claude routing with an opt-in single-model benchmark mode

### DIFF
--- a/benchmark/ground_truth/gcs.sql
+++ b/benchmark/ground_truth/gcs.sql
@@ -52,7 +52,7 @@ WITH nc AS (
                 THEN CAST(nursingchartvalue AS NUMERIC)
             ELSE NULL
         END) AS gcseyes
-    FROM eicu_crd.nursecharting
+    FROM eicu.nursecharting
     WHERE nursingchartcelltypecat IN ('Scores', 'Other Vital Signs and Infusions')
     GROUP BY patientunitstayid, nursingchartoffset
 )
@@ -103,7 +103,7 @@ SELECT
     COALESCE(g.gcsmotor, 6) AS gcs_motor,
     COALESCE(g.gcsverbal, 5) AS gcs_verbal,
     COALESCE(g.gcseyes, 4) AS gcs_eyes
-FROM eicu_crd.patient p
+FROM eicu.patient p
 LEFT JOIN gcs_first_day g
     ON p.patientunitstayid = g.patientunitstayid
     AND g.rn = 1

--- a/benchmark/ground_truth/oasis.sql
+++ b/benchmark/ground_truth/oasis.sql
@@ -26,7 +26,7 @@ WITH pre_icu_los_data AS (
             WHEN hospitaladmitoffset < (-311.80 * 60) THEN 1
             ELSE NULL
         END AS pre_icu_los_oasis
-    FROM eicu_crd.patient
+    FROM eicu.patient
 )
 
 -- ══════════════════════════════════════════════════════════════════
@@ -43,7 +43,7 @@ WITH pre_icu_los_data AS (
             WHEN MAX(CASE WHEN age = '> 89' THEN 91 ELSE TRY_CAST(age AS INT) END) > 89 THEN 7
             ELSE NULL
         END AS age_oasis
-    FROM eicu_crd.patient
+    FROM eicu.patient
     GROUP BY patientunitstayid
 )
 
@@ -67,7 +67,7 @@ WITH pre_icu_los_data AS (
                 THEN CAST(nursingchartvalue AS NUMERIC)
             ELSE NULL
         END) AS gcs
-    FROM eicu_crd.nursecharting
+    FROM eicu.nursecharting
     WHERE nursingchartcelltypecat IN ('Scores', 'Other Vital Signs and Infusions')
     GROUP BY patientunitstayid, nursingchartoffset
 )
@@ -86,7 +86,7 @@ WITH pre_icu_los_data AS (
     SELECT
         patientunitstayid,
         MIN(TRY_CAST(physicalexamvalue AS NUMERIC)) AS gcs
-    FROM eicu_crd.physicalexam
+    FROM eicu.physicalexam
     WHERE (
         physicalexampath LIKE 'notes/Progress Notes/Physical Exam/Physical Exam/Neurologic/GCS/_'
         OR physicalexampath LIKE 'notes/Progress Notes/Physical Exam/Physical Exam/Neurologic/GCS/__'
@@ -107,7 +107,7 @@ WITH pre_icu_los_data AS (
              AND pg.chartoffset > 0 AND pg.chartoffset <= 1440),
             pe.gcs
         ) AS gcs_min
-    FROM eicu_crd.patient p
+    FROM eicu.patient p
     LEFT JOIN physexam_gcs pe ON p.patientunitstayid = pe.patientunitstayid
 )
 
@@ -179,7 +179,7 @@ WITH pre_icu_los_data AS (
                 THEN CAST(nursingchartvalue AS NUMERIC)
             ELSE NULL
         END AS nibp_mean
-    FROM eicu_crd.nursecharting
+    FROM eicu.nursecharting
     WHERE nursingchartcelltypecat IN ('Vital Signs', 'Scores', 'Other Vital Signs and Infusions')
 )
 
@@ -428,7 +428,7 @@ WITH pre_icu_los_data AS (
             WHEN cellpath LIKE 'flowsheet|Flowsheet Cell Labels|I&O|Output (ml)|Urinary Catheter Output%' THEN 1
             ELSE 0
         END AS is_uo
-    FROM eicu_crd.intakeoutput
+    FROM eicu.intakeoutput
 )
 
 -- Sum urine output in first 24h, with fallback to apacheapsvar.urine
@@ -448,11 +448,11 @@ WITH pre_icu_los_data AS (
     SELECT
         p.patientunitstayid,
         COALESCE(uo.urineoutput, apache_uo.urine) AS uo_comb
-    FROM eicu_crd.patient p
+    FROM eicu.patient p
     LEFT JOIN pivoted_uo_sum uo ON p.patientunitstayid = uo.patientunitstayid
     LEFT JOIN (
         SELECT patientunitstayid, urine
-        FROM eicu_crd.apacheapsvar
+        FROM eicu.apacheapsvar
         WHERE urine > 0 AND urine IS NOT NULL
     ) apache_uo ON p.patientunitstayid = apache_uo.patientunitstayid
 )
@@ -482,8 +482,8 @@ WITH pre_icu_los_data AS (
             WHEN pat.unitadmitsource = 'Emergency Department' THEN 0
             ELSE 1
         END AS adm_elective1
-    FROM eicu_crd.patient pat
-    LEFT JOIN eicu_crd.apachepredvar apache
+    FROM eicu.patient pat
+    LEFT JOIN eicu.apachepredvar apache
         ON pat.patientunitstayid = apache.patientunitstayid
 )
 
@@ -511,14 +511,14 @@ WITH pre_icu_los_data AS (
         COALESCE(predvar.oobintub_flag, 0) AS vent_predvar,
         -- respiratorycare airway
         COALESCE(rc.vent_rc, 0) AS vent_rc
-    FROM eicu_crd.patient p
+    FROM eicu.patient p
     LEFT JOIN (
         SELECT patientunitstayid, 1 AS intubated_flag
-        FROM eicu_crd.apacheapsvar WHERE intubated = 1
+        FROM eicu.apacheapsvar WHERE intubated = 1
     ) apsvar ON p.patientunitstayid = apsvar.patientunitstayid
     LEFT JOIN (
         SELECT patientunitstayid, 1 AS oobintub_flag
-        FROM eicu_crd.apachepredvar WHERE oobintubday1 = 1
+        FROM eicu.apachepredvar WHERE oobintubday1 = 1
     ) predvar ON p.patientunitstayid = predvar.patientunitstayid
     LEFT JOIN (
         SELECT patientunitstayid,
@@ -530,7 +530,7 @@ WITH pre_icu_los_data AS (
                 WHEN COUNT(setapneatv) >= 1 THEN 1
                 ELSE NULL
             END AS vent_rc
-        FROM eicu_crd.respiratorycare
+        FROM eicu.respiratorycare
         WHERE respcarestatusoffset > 0 AND respcarestatusoffset <= 1440
         GROUP BY patientunitstayid
     ) rc ON p.patientunitstayid = rc.patientunitstayid
@@ -577,7 +577,7 @@ SELECT
     COALESCE(uo.urineoutput_oasis, 0) AS urineoutput_score,
     COALESCE(vo.vent_oasis, 0) AS mechvent_score,
     COALESCE(eo.electivesurgery_oasis, 0) AS electivesurgery_score
-FROM eicu_crd.patient p
+FROM eicu.patient p
 LEFT JOIN pre_icu_los_data plos ON p.patientunitstayid = plos.patientunitstayid
 LEFT JOIN age_oasis ao ON p.patientunitstayid = ao.patientunitstayid
 LEFT JOIN gcs_oasis go ON p.patientunitstayid = go.patientunitstayid

--- a/benchmark/matrix.py
+++ b/benchmark/matrix.py
@@ -54,8 +54,10 @@ from lib.db import (
 )
 from run import (
     BENCHMARK_REASONING_EFFORT,
+    CLAUDE_MODEL_ALIASES,
     PROVIDER_DEFAULT_REASONING,
     REASONING_EFFORT_CHOICES,
+    _resolve_model_for_agent,
     _resolve_reasoning_effort,
 )
 
@@ -180,10 +182,16 @@ def _model_plan_for_agent(agent: str) -> AgentModelPlan:
     """Return the default model set for each supported agent CLI."""
     if agent == "claude":
         return AgentModelPlan(
-            primary_models=("opus", "sonnet"),
-            hurts_models=("opus", "sonnet"),
-            contamination_models=("sonnet",),
-            noise_models=("opus",),
+            primary_models=(
+                CLAUDE_MODEL_ALIASES["opus"],
+                CLAUDE_MODEL_ALIASES["sonnet"],
+            ),
+            hurts_models=(
+                CLAUDE_MODEL_ALIASES["opus"],
+                CLAUDE_MODEL_ALIASES["sonnet"],
+            ),
+            contamination_models=(CLAUDE_MODEL_ALIASES["sonnet"],),
+            noise_models=(CLAUDE_MODEL_ALIASES["opus"],),
         )
     if agent == "codex":
         return AgentModelPlan(
@@ -292,6 +300,7 @@ def _run_via_bench(
     skip_preflight: bool = False,
 ) -> dict:
     """Execute one publishable run by invoking bench.sh on the host."""
+    model = _resolve_model_for_agent(agent, model) or model
     bench_script = BENCHMARK_ROOT / "bench.sh"
     container_results_root = _container_results_root(results_root)
     container_name = _docker_container_name(agent, run["task"], run["trial"])
@@ -327,20 +336,6 @@ def _run_via_bench(
         **os.environ,
         "M4BENCH_CONTAINER_NAME": container_name,
     }
-    if agent == "claude":
-        # Keep Claude Code background and subagent calls on the exact primary
-        # model selected for this cell.
-        env.update(
-            {
-                key: model
-                for key in (
-                    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
-                    "ANTHROPIC_DEFAULT_SONNET_MODEL",
-                    "ANTHROPIC_DEFAULT_OPUS_MODEL",
-                    "CLAUDE_CODE_SUBAGENT_MODEL",
-                )
-            }
-        )
     if skip_preflight:
         env["M4BENCH_SKIP_PREFLIGHT"] = "1"
 
@@ -430,7 +425,7 @@ def build_tiers(
 def _operational_spec_models(agent: str, model_plan: AgentModelPlan) -> tuple[str, ...]:
     """Return models for the operational-spec baseline follow-up."""
     if agent == "claude":
-        return ("sonnet",)
+        return (CLAUDE_MODEL_ALIASES["sonnet"],)
     return model_plan.primary_models
 
 

--- a/benchmark/matrix.py
+++ b/benchmark/matrix.py
@@ -327,6 +327,20 @@ def _run_via_bench(
         **os.environ,
         "M4BENCH_CONTAINER_NAME": container_name,
     }
+    if agent == "claude":
+        # Keep Claude Code background and subagent calls on the exact primary
+        # model selected for this cell.
+        env.update(
+            {
+                key: model
+                for key in (
+                    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+                    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+                    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+                    "CLAUDE_CODE_SUBAGENT_MODEL",
+                )
+            }
+        )
     if skip_preflight:
         env["M4BENCH_SKIP_PREFLIGHT"] = "1"
 

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -1310,6 +1310,10 @@ def _agent_process_env(
             "ANTHROPIC_API_KEY",
             "M4BENCH_CLAUDE_AUTH_ROOT",
             "M4BENCH_CLAUDE_AUTH_VOLUME",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL",
+            "CLAUDE_CODE_SUBAGENT_MODEL",
         },
         "codex": {"CODEX_API_KEY", "OPENAI_API_KEY"},
         "gemini": {"GOOGLE_API_KEY", "GEMINI_API_KEY"},
@@ -2676,6 +2680,15 @@ def run_single_task(
                         "validated"
                     ],
                     "claude_memory_validation": claude_memory_validation,
+                    "claude_model_overrides": {
+                        key: os.environ.get(key)
+                        for key in (
+                            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+                            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+                            "ANTHROPIC_DEFAULT_OPUS_MODEL",
+                            "CLAUDE_CODE_SUBAGENT_MODEL",
+                        )
+                    },
                 }
             )
         result_file = workdir / "result.json"

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -276,6 +276,23 @@ AGENT_COMMANDS = {
     },
 }
 
+# Claude Code resolves short aliases only when they are passed through
+# --model. Its model override environment variables require canonical IDs.
+# These IDs match benchmark/Dockerfile's pinned Claude Code version; update
+# both deliberately so benchmark attribution remains stable across upgrades.
+CLAUDE_MODEL_ALIASES = {
+    "opus": "claude-opus-4-7",
+    "sonnet": "claude-sonnet-4-6",
+    "haiku": "claude-haiku-4-5-20251001",
+}
+DEFAULT_CLAUDE_MODEL = CLAUDE_MODEL_ALIASES["sonnet"]
+CLAUDE_MODEL_OVERRIDE_KEYS = (
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "CLAUDE_CODE_SUBAGENT_MODEL",
+)
+
 AGENT_HOME_SEEDS = {
     "claude": [
         ".claude.json",
@@ -321,6 +338,28 @@ AGENT_REASONING_EFFORTS = {
     "claude": {"low", "medium", "high", "xhigh", "max"},
     "codex": {"minimal", "low", "medium", "high", "xhigh"},
 }
+
+
+def _resolve_model_for_agent(agent_name: str, model: str | None) -> str | None:
+    """Return the canonical model ID used for an agent invocation."""
+    if agent_name != "claude":
+        return model
+    if model is None:
+        return DEFAULT_CLAUDE_MODEL
+    return CLAUDE_MODEL_ALIASES.get(model, model)
+
+
+def _claude_model_overrides(model: str | None) -> dict[str, str]:
+    """Pin every Claude Code secondary call to the canonical primary model."""
+    canonical_model = _resolve_model_for_agent("claude", model)
+    if canonical_model is None:  # Defensive; Claude always has a pinned default.
+        return {}
+    return {key: canonical_model for key in CLAUDE_MODEL_OVERRIDE_KEYS}
+
+
+def _claude_model_metadata(model: str | None) -> dict[str, dict[str, str]]:
+    """Return auditable metadata for the effective Claude model overrides."""
+    return {"claude_model_overrides": _claude_model_overrides(model)}
 
 
 def _resolve_reasoning_effort(agent_name: str, reasoning_effort: str | None) -> str:
@@ -464,11 +503,16 @@ def run_filesystem_canary(
     workdir: Path,
     run_home: Path | None,
     *,
+    model: str | None = None,
     isolated: bool,
     enforce: bool,
 ) -> dict:
     """Verify sensitive benchmark paths are unreadable by the agent user."""
-    env = _agent_process_env(agent_name, workdir, run_home) if run_home else None
+    env = (
+        _agent_process_env(agent_name, workdir, run_home, model=model)
+        if run_home
+        else None
+    )
     if isolated and _agent_container_enabled():
         failures_path = workdir / ".m4bench" / "filesystem_canary_failures.txt"
         failures_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1289,7 +1333,10 @@ def _configure_pi_ollama_home(run_home: Path) -> None:
 
 
 def _agent_process_env(
-    agent_name: str, workdir: Path, run_home: Path
+    agent_name: str,
+    workdir: Path,
+    run_home: Path,
+    model: str | None = None,
 ) -> dict[str, str]:
     """Build the isolated environment for an agent subprocess."""
     tmpdir = run_home / "tmp"
@@ -1338,6 +1385,8 @@ def _agent_process_env(
             "TEMP": str(tmpdir),
         }
     )
+    if agent_name == "claude":
+        env.update(_claude_model_overrides(model))
     if _agent_container_enabled():
         env.update(
             {
@@ -1879,6 +1928,7 @@ def run_agent(
             f"Unknown agent: {agent_name}. Available: {list(AGENT_COMMANDS)}"
         )
 
+    model = _resolve_model_for_agent(agent_name, model)
     cmd = list(agent_config["cmd"])
 
     if model:
@@ -1924,7 +1974,7 @@ def run_agent(
 
     env = None
     if run_home:
-        env = _agent_process_env(agent_name, workdir, run_home)
+        env = _agent_process_env(agent_name, workdir, run_home, model=model)
 
     # Run agent as benchagent when isolated (user-level filesystem + network isolation).
     agent_creds = _resolve_agent_creds() if isolated and not agent_container else None
@@ -2251,6 +2301,7 @@ def run_single_task(
     reasoning_effort: str | None = BENCHMARK_REASONING_EFFORT,
 ) -> dict:
     """Run a single benchmark task end-to-end. Returns the full result dict."""
+    model = _resolve_model_for_agent(agent_name, model)
     results_root = (results_root or RESULTS_DIR).resolve()
     ensure_results_manifest(results_root)
 
@@ -2361,6 +2412,7 @@ def run_single_task(
             agent_name,
             workdir,
             run_home,
+            model=model,
             isolated=isolated,
             enforce=isolated
             and (_running_in_container() or _agent_container_enabled()),
@@ -2680,15 +2732,7 @@ def run_single_task(
                         "validated"
                     ],
                     "claude_memory_validation": claude_memory_validation,
-                    "claude_model_overrides": {
-                        key: os.environ.get(key)
-                        for key in (
-                            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
-                            "ANTHROPIC_DEFAULT_SONNET_MODEL",
-                            "ANTHROPIC_DEFAULT_OPUS_MODEL",
-                            "CLAUDE_CODE_SUBAGENT_MODEL",
-                        )
-                    },
+                    **_claude_model_metadata(model),
                 }
             )
         result_file = workdir / "result.json"
@@ -2739,6 +2783,7 @@ def run_leak_canary(
     reasoning_effort: str | None = BENCHMARK_REASONING_EFFORT,
 ) -> dict:
     """Run an adversarial isolation canary with the real agent CLI."""
+    model = _resolve_model_for_agent(agent_name, model)
     results_root = (results_root or RESULTS_DIR).resolve()
     ensure_results_manifest(results_root)
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
@@ -2757,7 +2802,7 @@ def run_leak_canary(
     run_home = None
     publishable, publishable_reason = _publishable_environment(isolated, agent_name)
     try:
-        if isolated:
+        if isolated or agent_name == "claude":
             run_home = ISOLATED_BASE / f"{run_id}_home"
             prepare_run_home(agent_name, run_home)
 
@@ -2788,6 +2833,7 @@ path you attempted in probed_paths using the exact path strings above.
             agent_name,
             workdir,
             run_home,
+            model=model,
             isolated=isolated,
             enforce=isolated
             and (_running_in_container() or _agent_container_enabled()),
@@ -2865,6 +2911,8 @@ path you attempted in probed_paths using the exact path strings above.
                 "pytest_stderr": "",
             },
         }
+        if agent_name == "claude":
+            full_result.update(_claude_model_metadata(model))
         (workdir / "result.json").write_text(json.dumps(full_result, indent=2))
 
         print(f"Leak canary: {'PASS' if passed else 'FAIL'}")
@@ -2877,7 +2925,7 @@ path you attempted in probed_paths using the exact path strings above.
             )
         return full_result
     finally:
-        if isolated and run_home and run_home.exists():
+        if run_home and run_home.exists():
             shutil.rmtree(run_home, ignore_errors=True)
         if final_results_dir:
             copy_results_back(workdir, final_results_dir)
@@ -3216,11 +3264,12 @@ def main():
         )
     except ValueError as e:
         parser.error(str(e))
+    effective_model = _resolve_model_for_agent(args.agent, args.model)
 
     if args.leak_canary:
         run_leak_canary(
             args.agent,
-            args.model,
+            effective_model,
             args.verbose,
             isolated,
             results_root,
@@ -3297,7 +3346,7 @@ def main():
                 task_name,
                 args.condition,
                 args.agent,
-                args.model,
+                effective_model,
                 trial,
                 args.verbose,
                 isolated,
@@ -3318,7 +3367,7 @@ def main():
             run_matrix,
             args.condition,
             args.agent,
-            args.model,
+            effective_model,
             args.verbose,
             isolated,
             args.schema,
@@ -3341,7 +3390,7 @@ def main():
         batch_data = {
             "condition": args.condition,
             "agent": args.agent,
-            "model": args.model,
+            "model": effective_model,
             "reasoning_effort": args.reasoning_effort,
             "resolved_reasoning_effort": resolved_reasoning_effort,
             "schema": args.schema,
@@ -3350,6 +3399,8 @@ def main():
             "results_root": str(results_root),
             "results": results,
         }
+        if args.agent == "claude":
+            batch_data.update(_claude_model_metadata(effective_model))
         with open(batch_path, "w") as f:
             json.dump(batch_data, f, indent=2, default=str)
         print(f"\nBatch results saved to: {batch_path}")

--- a/tests/test_benchmark_harness.py
+++ b/tests/test_benchmark_harness.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -246,7 +247,7 @@ def test_prepare_run_home_claude_login_copies_only_auth_files(monkeypatch, tmp_p
     assert not (claude_home / ".claude" / "projects").exists()
 
 
-def test_claude_env_includes_api_key(monkeypatch, tmp_path):
+def test_direct_claude_run_pins_command_and_env(monkeypatch, tmp_path):
     run = _load_module("benchmark_run_claude_env", "benchmark/run.py")
 
     workdir = tmp_path / "work"
@@ -267,17 +268,32 @@ def test_claude_env_includes_api_key(monkeypatch, tmp_path):
             raise AssertionError("process should not be killed")
 
     def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
         captured["kwargs"] = kwargs
         return FakeProcess()
 
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
     monkeypatch.setattr(run.subprocess, "Popen", fake_popen)
 
-    result = run.run_agent("write output.csv", "claude", workdir, run_home=run_home)
+    result = run.run_agent(
+        "write output.csv",
+        "claude",
+        workdir,
+        model="sonnet",
+        run_home=run_home,
+    )
 
     assert result["returncode"] == 0
-    assert captured["kwargs"]["env"]["ANTHROPIC_API_KEY"] == "sk-ant-test"
-    assert captured["kwargs"]["env"]["HOME"] == str(run_home)
+    env = captured["kwargs"]["env"]
+    assert env["ANTHROPIC_API_KEY"] == "sk-ant-test"
+    assert env["HOME"] == str(run_home)
+    assert captured["cmd"][captured["cmd"].index("--model") + 1] == "claude-sonnet-4-6"
+    assert {env[key] for key in run.CLAUDE_MODEL_OVERRIDE_KEYS} == {"claude-sonnet-4-6"}
+    assert run._claude_model_metadata("sonnet") == {
+        "claude_model_overrides": {
+            key: "claude-sonnet-4-6" for key in run.CLAUDE_MODEL_OVERRIDE_KEYS
+        }
+    }
 
 
 def test_validate_claude_memory_paths_requires_run_home(tmp_path):
@@ -393,6 +409,23 @@ def test_agent_process_env_filters_host_environment(monkeypatch, tmp_path):
     for env in (claude_env, codex_env, gemini_env):
         assert "HTTP_PROXY" not in env
         assert "AWS_SECRET_ACCESS_KEY" not in env
+
+
+def test_agent_process_env_pins_direct_claude_run_to_canonical_model(tmp_path):
+    run = _load_module("benchmark_run_direct_claude_model", "benchmark/run.py")
+
+    env = run._agent_process_env(
+        "claude",
+        tmp_path / "work",
+        tmp_path / "home",
+        model="opus",
+    )
+
+    assert {env[key] for key in run.CLAUDE_MODEL_OVERRIDE_KEYS} == {"claude-opus-4-7"}
+    assert run._claude_model_overrides("opus") == {
+        key: "claude-opus-4-7" for key in run.CLAUDE_MODEL_OVERRIDE_KEYS
+    }
+    assert run._resolve_model_for_agent("claude", None) == "claude-sonnet-4-6"
 
 
 def test_agent_process_env_uses_container_paths(monkeypatch, tmp_path):
@@ -1359,6 +1392,129 @@ def test_leak_canary_report_requires_all_sensitive_paths():
 
     assert not run.validate_leak_canary_report(incomplete)["passed"]
     assert run.validate_leak_canary_report(complete)["passed"]
+
+
+def test_nonisolated_claude_leak_canary_pins_command_env_and_metadata(
+    monkeypatch, tmp_path
+):
+    run = _load_module("benchmark_run_local_claude_canary", "benchmark/run.py")
+    captured = {}
+
+    class FakeProcess:
+        def __init__(self):
+            self.stdout = io.StringIO('{"type":"result","subtype":"success"}\n')
+            self.returncode = 0
+
+        def wait(self, timeout):
+            return 0
+
+        def kill(self):
+            raise AssertionError("process should not be killed")
+
+    def fake_prepare_run_home(_agent_name, run_home):
+        run_home.mkdir(parents=True)
+        return []
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        report = {
+            "leak_found": False,
+            "probed_paths": list(run.LEAK_CANARY_PATHS),
+            "evidence": [
+                f"permission denied for {path}" for path in run.LEAK_CANARY_PATHS
+            ],
+        }
+        (Path(kwargs["cwd"]) / "canary_report.json").write_text(json.dumps(report))
+        return FakeProcess()
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "must-not-leak")
+    monkeypatch.setattr(run, "prepare_run_home", fake_prepare_run_home)
+    monkeypatch.setattr(
+        run,
+        "run_filesystem_canary",
+        lambda *args, **kwargs: {
+            "passed": True,
+            "required": False,
+            "failures": [],
+        },
+    )
+    monkeypatch.setattr(run.subprocess, "Popen", fake_popen)
+
+    result = run.run_leak_canary(
+        "claude",
+        "sonnet",
+        verbose=False,
+        isolated=False,
+        results_root=tmp_path,
+    )
+
+    assert captured["cmd"][captured["cmd"].index("--model") + 1] == (
+        "claude-sonnet-4-6"
+    )
+    assert captured["env"]["ANTHROPIC_API_KEY"] == "sk-ant-test"
+    assert "AWS_SECRET_ACCESS_KEY" not in captured["env"]
+    assert {captured["env"][key] for key in run.CLAUDE_MODEL_OVERRIDE_KEYS} == {
+        "claude-sonnet-4-6"
+    }
+    assert result["model"] == "claude-sonnet-4-6"
+    assert result["claude_model_overrides"] == {
+        key: "claude-sonnet-4-6" for key in run.CLAUDE_MODEL_OVERRIDE_KEYS
+    }
+    stored_result = json.loads(
+        next(tmp_path.glob("leak-canary_*/result.json")).read_text()
+    )
+    assert stored_result["model"] == "claude-sonnet-4-6"
+    assert stored_result["claude_model_overrides"] == result["claude_model_overrides"]
+
+
+def test_batch_metadata_uses_canonical_claude_model(monkeypatch, tmp_path):
+    run = _load_module("benchmark_run_claude_batch_metadata", "benchmark/run.py")
+    child_models = []
+
+    def fake_run_single_task(*args, **kwargs):
+        child_models.append(args[3])
+        return {
+            "task": args[0],
+            "condition": args[1],
+            "model": args[3],
+            "test_results": {"reward": 1.0},
+            "agent_result": {"elapsed_seconds": 0},
+        }
+
+    monkeypatch.setattr(run, "resolve_tasks", lambda _args: ["fake-task"])
+    monkeypatch.setattr(run, "run_single_task", fake_run_single_task)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "benchmark/run.py",
+            "--task",
+            "fake-task",
+            "--condition",
+            "no-skill",
+            "--agent",
+            "claude",
+            "--model",
+            "sonnet",
+            "--seeds",
+            "2",
+            "--no-isolation",
+            "--results-root",
+            str(tmp_path),
+        ],
+    )
+
+    run.main()
+
+    batch_path = next(tmp_path.glob("batch_*.json"))
+    batch = json.loads(batch_path.read_text())
+    assert child_models == ["claude-sonnet-4-6", "claude-sonnet-4-6"]
+    assert batch["model"] == "claude-sonnet-4-6"
+    assert batch["claude_model_overrides"] == {
+        key: "claude-sonnet-4-6" for key in run.CLAUDE_MODEL_OVERRIDE_KEYS
+    }
 
 
 def test_sandbox_hook_extracts_quoted_paths():

--- a/tests/test_benchmark_matrix.py
+++ b/tests/test_benchmark_matrix.py
@@ -78,7 +78,10 @@ def test_provider_comparison_profile_uses_requested_seeds_for_claude(tmp_path):
     tiers = matrix.build_tiers(seeds=5, agent="claude", profile="provider-comparison")
 
     assert sum(len(tier.runs) for tier in tiers) == 190
-    assert {run["model"] for tier in tiers for run in tier.runs} == {"opus", "sonnet"}
+    assert {run["model"] for tier in tiers for run in tier.runs} == {
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+    }
     assert {run["condition"] for run in tiers[0].runs} == {"no-skill", "with-skill"}
     assert {run["trial"] for tier in tiers for run in tier.runs} == {1, 2, 3, 4, 5}
 
@@ -300,6 +303,15 @@ def test_build_tiers_uses_agent_specific_pi_ollama_models():
     assert models == {"qwen3:4b"}
 
 
+def test_operational_spec_uses_canonical_claude_model():
+    matrix = _load_module("benchmark_matrix_operational_model", "benchmark/matrix.py")
+    model_plan = matrix._model_plan_for_agent("claude")
+
+    assert matrix._operational_spec_models("claude", model_plan) == (
+        "claude-sonnet-4-6",
+    )
+
+
 def test_container_results_root_maps_under_benchmark_root():
     matrix = _load_module("benchmark_matrix_container_root", "benchmark/matrix.py")
     results_root = (ROOT / "benchmark" / "results" / "paper-smoke").resolve()
@@ -363,6 +375,36 @@ def test_run_via_bench_builds_publishable_command(monkeypatch):
     assert "--reasoning-effort" in seen["cmd"]
     assert "medium" in seen["cmd"]
     assert seen["env"]["M4BENCH_CONTAINER_NAME"].startswith("m4bench-codex-")
+
+
+def test_run_via_bench_resolves_claude_alias_before_invocation(monkeypatch):
+    matrix = _load_module("benchmark_matrix_claude_model", "benchmark/matrix.py")
+
+    results_root = (ROOT / "benchmark" / "results" / "paper-smoke").resolve()
+    seen = {}
+
+    def fake_subprocess_run(cmd, cwd=None, env=None):
+        seen["cmd"] = cmd
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(matrix.subprocess, "run", fake_subprocess_run)
+    monkeypatch.setattr(
+        matrix,
+        "_find_latest_result",
+        lambda *args, **kwargs: {"model": "claude-sonnet-4-6"},
+    )
+
+    result = matrix._run_via_bench(
+        {"task": "mimic-kdigo-48h", "trial": 1},
+        condition="with-skill",
+        model="sonnet",
+        schema="native",
+        agent="claude",
+        results_root=results_root,
+    )
+
+    assert seen["cmd"][seen["cmd"].index("--model") + 1] == "claude-sonnet-4-6"
+    assert result["model"] == "claude-sonnet-4-6"
 
 
 def test_run_via_bench_can_skip_per_run_preflight(monkeypatch):


### PR DESCRIPTION
Claude benchmark runs now use canonical primary-model IDs while preserving Claude Code's normal secondary-model routing by default. Single-model routing is an explicit controlled comparison, selected with `M4BENCH_CLAUDE_MODEL_ROUTING=single-model`; unset the variable or use `native` for normal routing. The setting applies to direct runs, leak canaries, and matrix runs through `bench.sh`.

Results record the routing mode, configured overrides, and model names observed in assistant trace events separately. Observations cover only the retained trace, not every internal API call; missing evidence remains null. Matrix resume and result selection do not reuse results from a different or unrecorded routing mode.

The eICU GCS/OASIS queries retain the `eicu_crd` schema created by M4. Synthetic regression tests execute both queries against views made by the real initializer. No credentialed datasets or live provider runs are used.

Validation:
- Focused benchmark suite: 102 passed.
- Full public/synthetic suite: 1,014 passed; one credentialed MIMIC-IV test deselected.
- Ruff lint/format and repository hooks passed. All 16 GitHub checks passed for `91ac87d8b6f3b37ed192a3567f0c3851faf2c2e0`, including Windows and clean wheel/sdist installs.
- Standards and spec reviews completed; the routing-mode resume finding was fixed and rechecked.

This PR does not change package APIs, publish a release, or require pinning all models for the main agent evaluation.
